### PR TITLE
Allow metadata to be passed into the engine

### DIFF
--- a/app/controllers/metadata_presenter/service_controller.rb
+++ b/app/controllers/metadata_presenter/service_controller.rb
@@ -1,6 +1,11 @@
 class MetadataPresenter::ServiceController < ApplicationController
   def start
-    @service = MetadataPresenter::Service.new
+    @service = MetadataPresenter::Service.new(service_metadata)
     @start_page = @service.pages.first
+  end
+
+  def service_metadata
+    return JSON.parse(params[:service_metadata]) if params[:service_metadata]
+    Rails.configuration.service_metadata
   end
 end

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -1,38 +1,8 @@
 class MetadataPresenter::Service
   attr_reader :raw_metadata
 
-  def initialize
-    @raw_metadata = {
-      "service_id": "634aa3d5-a3b3-4d0f-9078-bb754542a1d3",
-      "service_name" => "Service Name",
-      "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
-      "created_at": "2020-10-09T11:51:46",
-      "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
-      "configuration": {
-        "_id": "service",
-        "_type": "config.service"
-      },
-      "pages" => [
-        { "_id" => "page.start",
-          "_type" => "page.start",
-          "body" => "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
-          "heading" => "Complain about a court or tribunal",
-          "lede" => "Your complaint will not affect your case.",
-          "steps" => [
-            "page-2",
-            "page.do-you-have-a-case-number"
-          ],
-          "url" => "/"
-        },
-        {
-          "_id" => "page-2",
-          "_type" => "page",
-          "body" => "This is page two",
-          "url" => "/page-2"
-        }
-      ],
-      "locale" => "en"
-    }
+  def initialize(raw_metadata)
+    @raw_metadata = raw_metadata
   end
 
   def service_id

--- a/config/initializers/service_metadata.rb
+++ b/config/initializers/service_metadata.rb
@@ -1,0 +1,10 @@
+class ServiceMetadataNotFoundError < StandardError
+end
+
+if File.exist?(Rails.root.join('spec', 'fixtures', 'service.json'))
+  Rails.configuration.service_metadata = JSON.parse(
+    File.read(Rails.root.join('spec', 'fixtures', 'service.json'))
+  )
+else
+  raise ServiceMetadataNotFoundError.new('No service metadata found')
+end


### PR DESCRIPTION
In preview mode the service metadata will not be available on startup therefore we need the ability to pass into the service object. This will be the case in the editor.

In the runner the service metadata should be there at startup so we can read it in and keep it in memory. The location
'/spec/fixtures/service.json` is a temporary one until we decide how the publisher will pass the metadata into the runner's container.

The fixture lives in the fb-runner repo.

https://trello.com/c/QOHT8XOs/1076-create-barebones-fb-runner

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>