### PR TITLE
Move helper method to controller

### DIFF
--- a/app/controllers/metadata_presenter/service_controller.rb
+++ b/app/controllers/metadata_presenter/service_controller.rb
@@ -1,4 +1,5 @@
 class MetadataPresenter::ServiceController < MetadataPresenter.parent_controller.constantize
+  helper MetadataPresenter::ApplicationHelper
 
   def start
     @service = MetadataPresenter::Service.new(service_metadata)

--- a/lib/metadata_presenter/engine.rb
+++ b/lib/metadata_presenter/engine.rb
@@ -5,11 +5,5 @@ module MetadataPresenter
     isolate_namespace MetadataPresenter
 
     MetadataPresenter.parent_controller = '::ApplicationController'
-
-    initializer 'local_helper.action_controller' do
-      ActiveSupport.on_load :action_controller do
-        helper MetadataPresenter::ApplicationHelper
-      end
-    end
   end
 end


### PR DESCRIPTION
## Context

The editor in the test environment was not booting:

```
/usr/local/bundle/bundler/gems/fb-metadata-presenter-9b8c0380ad68/lib/metadata_presenter/engine.rb:11:in `block (2 levels) in <class:Engine>': undefined method `helper' for ActionController::API:Class (NoMethodError)
```

This PR fixes the issue. The reason is that `helper` method is not available in the initializer. Since the `helper` is available in the controller, moving to controller makes everything works as expected.