### PR TITLE
Save the data into the session

### DIFF
--- a/app/controllers/metadata_presenter/service_controller.rb
+++ b/app/controllers/metadata_presenter/service_controller.rb
@@ -2,32 +2,29 @@ class MetadataPresenter::ServiceController < MetadataPresenter.parent_controller
   helper MetadataPresenter::ApplicationHelper
 
   def start
-    @service = service
-    @start_page = service.start_page
-    render template: @start_page.template
+    @page = service.start_page
+    render template: @page.template
   end
 
   def answers
     save_user_data # method signature
 
-    # TODO: We need to see what to do with these line
-    # because of bots/hackers/etc
-    current_page = URI(request.referer).path
+    current_page = params[:page_url]
     next_page = service.next_page(from: current_page)
 
     if next_page.present?
-      redirect_to next_page.url
+      redirect_to File.join(request.script_name, next_page.url)
     else
       render template: 'errors/404', status: 404
     end
   end
 
   def render_page
-    load_user_data # method signature
+    @user_data = load_user_data # method signature
 
     # we need verify that the user can't jump pages??
     #
-    @page = service.find_page(request.path)
+    @page = service.find_page(request.env['PATH_INFO'])
 
     if @page
       render template: @page.template

--- a/app/views/metadata_presenter/component/_text.html.erb
+++ b/app/views/metadata_presenter/component/_text.html.erb
@@ -8,5 +8,5 @@
     <p><%= component.hint %></p>
   </div>
 
-  <input class="govuk-input" id="<%= component.id %>" name="<%= component.name %>" type="text" aria-describedby="<%= component.id %>-hint">
+  <input class="govuk-input" id="<%= component.id %>" name="answers[<%= component.name %>]" type="text" aria-describedby="<%= component.id %>-hint" value="<%= @user_data[component.name] %>">
 </div>

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -1,7 +1,7 @@
 <div class="fb-main-grid-wrapper" data-block-id="" data-block-type="start_page" data-block-pagetype="">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= form_tag(reserved_answers_path, method: :post) do  %>
+      <%= form_tag(reserved_answers_path(@page.url), method: :post) do  %>
         <% @page.components.each do |component| %>
           <%= render partial: component, locals: { component: component } %>
         <% end %>

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -1,31 +1,31 @@
 <div class="fb-main-grid-wrapper" data-block-id="" data-block-type="start_page" data-block-pagetype="">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if @start_page.section_heading -%>
-        <p class="govuk-caption-l fb-section_heading" data-block-id="<%= @start_page.id %>" data-block-property="section_heading">
+      <% if @page.section_heading -%>
+        <p class="govuk-caption-l fb-section_heading" data-block-id="<%= @page.id %>" data-block-property="section_heading">
           <%= @page.section_heading.html_safe %>
         </p>
       <%- end %>
 
-      <% if @start_page.heading -%>
-        <h1 class="<%= @start_page.heading_class %>" data-block-id="<%= @start_page.id %>" data-block-property="heading">
-          <%= @start_page.heading.html_safe %>
+      <% if @page.heading -%>
+        <h1 class="<%= @page.heading_class %>" data-block-id="<%= @page.id %>" data-block-property="heading">
+          <%= @page.heading.html_safe %>
         </h1>
       <% end %>
 
-      <% if @start_page.lede %>
-        <p class="govuk-body-l" data-block-id="<%= @start_page.id %>" data-block-property="lede">
-          <%= @start_page.lede.html_safe %>
+      <% if @page.lede %>
+        <p class="govuk-body-l" data-block-id="<%= @page.id %>" data-block-property="lede">
+          <%= @page.lede.html_safe %>
         </p>
       <%- end %>
 
-      <% if @start_page.body %>
-        <p class="govuk-body-l" data-block-id="<%= @start_page.id %>" data-block-property="lede">
-        <%= to_markdown(@start_page.body) %>
+      <% if @page.body %>
+        <p class="govuk-body-l" data-block-id="<%= @page.id %>" data-block-property="lede">
+        <%= to_markdown(@page.body) %>
         </p>
       <%- end %>
 
-      <%= form_tag(reserved_answers_path, method: :post) do  %>
+      <%= form_tag(reserved_answers_path(@page.url), method: :post) do %>
         <button class='govuk-button govuk-button--start govuk-!-margin-top-2'>
         Start
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
@@ -33,7 +33,6 @@
           </svg>
         </button>
       <% end %>
-
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 MetadataPresenter::Engine.routes.draw do
   root to: 'service#start'
 
-  post '/reserved/answers', to: 'service#answers'
+  post '/reserved/:page_url/answers', to: 'service#answers', as: :reserved_answers
   match '*path', to: 'service#render_page', via: :all
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -8,10 +8,16 @@ class ApplicationController < ActionController::Base
   end
 
   def save_user_data
-    session[:user_data] = { something: 'answer' }
+    if params[:answers]
+      session[:user_data] ||= {}
+
+      params[:answers].each do |field, answer|
+        session[:user_data][field] = answer
+      end
+    end
   end
 
   def load_user_data
-    session[:user_data]
+    session[:user_data] || {}
   end
 end

--- a/spec/dummy/config/spring.rb
+++ b/spec/dummy/config/spring.rb
@@ -1,6 +1,0 @@
-Spring.watch(
-  ".ruby-version",
-  ".rbenv-vars",
-  "tmp/restart.txt",
-  "tmp/caching-dev.txt"
-)


### PR DESCRIPTION
## Context

This PR makes the possibility to save in the session possible (for the editor, runner and the dummy app).

## Disclaimer

I had to change the way we process the answers through the form.

Some problems are using the `request.referer`:

*  The editor uses '/services/:service_id/preview' as base URL.

  ```
  The problem redirecting to '/text-first' is that this url doesn't
  exist on the editor (only '/services/:service_id/preview/text-first')
```

  Adding the request.script_name as suggested here:
  https://github.com/rails/rails/issues/7977 makes the redirection
  to work as expected

Also using request.env['PATH_INFO'] (which is 'text-first'
works instead of request.path (which was
'/services/:service_id/preview/text-first')

I tried to add a current page as a hidden field but also has some
drawbacks so I rollback. If we don't add as hidden field everything breaks which
makes this approach more error-prone.

I also remove spring: This is not needed on the dummy app because we don't need t
o dummy app to be quick reloading as we don't often change the app, only
the gem

## Decisions

I am still not 100% happy with this approach but I think it is better than before.
Now the post request expects a page.URL which is the current page.

Example:

You are on the first page and submit the form:

        The app will make a POST /reserved/first-page/answers
        and then redirect to /second-page.

Then when you are on the second page and submit the form:

        The app will make a POST /reserved/second-page/answers
        and then redirect to the next page.