### PR TITLE
Use govuk design system formbuilder gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     metadata_presenter (0.1.0)
-      govspeak
+      govspeak (>= 6.5.10)
+      govuk_design_system_formbuilder (>= 2.1.5)
       rails (~> 6.0.3, >= 6.0.3.4)
 
 GEM
@@ -105,12 +106,16 @@ GEM
       nokogumbo (~> 2)
       rinku (~> 2.0)
       sanitize (>= 5.2.1, < 6)
-    govuk_app_config (2.7.0)
+    govuk_app_config (2.7.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.8)
-    govuk_publishing_components (23.6.0)
+    govuk_design_system_formbuilder (2.1.5)
+      actionview (>= 5.2)
+      activemodel (>= 5.2)
+      activesupport (>= 5.2)
+    govuk_publishing_components (23.7.5)
       govuk_app_config
       kramdown
       plek
@@ -144,7 +149,7 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    nokogumbo (2.0.2)
+    nokogumbo (2.0.4)
       nokogiri (~> 1.8, >= 1.8.4)
     plek (4.0.0)
     public_suffix (4.0.6)

--- a/app/models/metadata_presenter/metadata.rb
+++ b/app/models/metadata_presenter/metadata.rb
@@ -1,5 +1,6 @@
 class MetadataPresenter::Metadata
   include ActiveModel::Conversion
+  extend ActiveModel::Naming
 
   attr_reader :metadata
 

--- a/app/views/metadata_presenter/component/_text.html.erb
+++ b/app/views/metadata_presenter/component/_text.html.erb
@@ -1,12 +1,7 @@
-<div class="fb-block fb-block-text govuk-form-group" data-block-id="<%= component.id %>" data-block-type="text">
-  <h1 class="govuk-label-wrapper">
-    <label class="govuk-label govuk-label--xl" data-block-id="<%= component.id %>" data-block-property="label" for="<%= component.id %>">
-      <%= component.label %>
-    </label>
-    </h1>
-  <div id="<%= component.id %>-hint" class="govuk-hint" data-block-id="<%= component.id %>" data-block-property="hint">
-    <p><%= component.hint %></p>
-  </div>
-
-  <input class="govuk-input" id="<%= component.id %>" name="answers[<%= component.name %>]" type="text" aria-describedby="<%= component.id %>-hint" value="<%= @user_data[component.name] %>">
-</div>
+<%=
+  f.govuk_text_field component.id,
+    label: { text: component.label },
+    hint: { text: component.hint },
+    name: "answers[#{component.name}]",
+    value: @user_data[component.name]
+%>

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -1,14 +1,16 @@
 <div class="fb-main-grid-wrapper" data-block-id="" data-block-type="start_page" data-block-pagetype="">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= form_tag(reserved_answers_path(@page.url), method: :post) do  %>
+      <h1 class="<%= @page.heading_class %>" data-block-id="<%= @page.id %>" data-block-property="heading">
+          <%= @page.heading.html_safe %>
+      </h1>
+
+      <%= form_for @page.id, url: reserved_answers_path(@page.url), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
         <% @page.components.each do |component| %>
-          <%= render partial: component, locals: { component: component } %>
+          <%= render partial: component, locals: { component: component, f: f } %>
         <% end %>
 
-        <button data-prevent-double-click="true" class="fb-block fb-block-actions govuk-button" data-module="govuk-button" data-block-id="actions" data-block-type="actions">
-          Continue
-        </button>
+        <%= f.govuk_submit %>
       <% end %>
     </div>
   </div>

--- a/lib/metadata_presenter.rb
+++ b/lib/metadata_presenter.rb
@@ -1,4 +1,5 @@
 require "metadata_presenter/engine"
+require "govuk_design_system_formbuilder"
 
 module MetadataPresenter
   # Your code goes here...

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   spec.add_dependency 'rails', '~> 6.0.3', '>= 6.0.3.4'
-  spec.add_dependency 'govspeak'
+  spec.add_dependency 'govspeak', '>= 6.5.10'
+  spec.add_dependency 'govuk_design_system_formbuilder', '>= 2.1.5'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rspec-rails'

--- a/spec/fixtures/service.json
+++ b/spec/fixtures/service.json
@@ -38,6 +38,7 @@
     {
       "_id": "page.email-address",
       "_type": "page.singlequestion",
+      "heading": "Email address",
       "components": [
         {
           "_id": "page.email-address--email.auto_name__2",


### PR DESCRIPTION
## Update govspeak to latest version

For some reason the presenter was a waaaaaaaay old version which had a vulnerability in kramdown. Use the lattest version. This will also be picked up by the fb-runner and will silence the notification there as well.

## Use govuk design system formbuilder gem

The old runner makes use of `govuk-frontend` built in macros to dynamically generate html pages on the fly. An example template file:

```
{%- macro text(data) %}
{% set params = setError(data) %}
{% set params = setLabel(params) %}
{% set params = setInputWidthClass(params) %}
{% if params.spellcheck %}
{% set attributes = setObjectProperty(params.attributes, 'spellcheck', params.spellcheck) %}
{% set params = setObjectProperty(params, 'attributes', attributes) %}
{% endif %}
{{ callMacro('govukInput', params) }}
{% endmacro -%}
```

This template, which is for a text field, is basically creating the necessary params which is then passed into the `govukInput` macro. That macro comes bundled with `govuk-frontend` npm package. It does a lot:

https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/input/template.njk

Nearly all the template files in fb-components makes calls to the  myriad of `govuk-frontend` helper macros.

This presents another quandary for us as nunjucks cannot be used directly inside rails.

DfE currently have a helpful gem which outputs govuk design system friendly components. This will help us at component level for sure. It does not support every single component that we require but it is open source so we could contribute to it or even fork it and extend it when we require it. For now it has the necessary components to not be blocking.

We will have to hand craft the page templates unfortunately.