### PR TITLE
Default metadata for required fields

### DIFF
--- a/config/initializers/default_metadata.rb
+++ b/config/initializers/default_metadata.rb
@@ -1,0 +1,18 @@
+Rails.application.config.default_metadata_directory = File.join(
+  File.dirname(__FILE__),
+  '../../default_metadata'
+)
+
+Rails.application.config.default_metadata = {}
+
+Rails.logger.info('Loading default metadata')
+default_metadata = Dir.glob("#{Rails.application.config.default_metadata_directory}/*/**")
+default_metadata.each do |metadata_file|
+  metadata = JSON.parse(File.read(metadata_file))
+  Rails.logger.info(metadata['_id'])
+  Rails.application.config.default_metadata[metadata['_id']] = metadata
+end
+
+Rails.logger.info(
+  "Total loaded default metadata => #{Rails.application.config.default_metadata.count}"
+)

--- a/default_metadata/string/error.required.json
+++ b/default_metadata/string/error.required.json
@@ -1,0 +1,7 @@
+{
+  "_id": "error.required",
+  "_type": "string.error",
+  "description": "Input is required",
+  "value:en": "Enter an answer for {control}",
+  "value:cy": "Rhowch ateb i {control}"
+}

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -20,4 +20,8 @@ class ApplicationController < ActionController::Base
   def load_user_data
     session[:user_data] || {}
   end
+
+  def default_metadata
+    Rails.application.config.default_metadata
+  end
 end


### PR DESCRIPTION
This adds the default metadata for a required field.

We are also caching the default metadata on startup.