### PR TITLE
Move schemas to presenter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     metadata_presenter (0.1.0)
       govspeak (>= 6.5.10)
       govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
       rails (~> 6.0.3, >= 6.0.3.4)
 
 GEM
@@ -106,7 +107,7 @@ GEM
       nokogumbo (~> 2)
       rinku (~> 2.0)
       sanitize (>= 5.2.1, < 6)
-    govuk_app_config (2.7.1)
+    govuk_app_config (2.8.0)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.4.0)
@@ -115,7 +116,7 @@ GEM
       actionview (>= 5.2)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
-    govuk_publishing_components (23.7.5)
+    govuk_publishing_components (23.7.7)
       govuk_app_config
       kramdown
       plek
@@ -125,6 +126,8 @@ GEM
     htmlentities (4.3.4)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     kgio (2.11.3)
     kramdown (2.3.0)
       rexml

--- a/app/validators/metadata_presenter/validate_schema.rb
+++ b/app/validators/metadata_presenter/validate_schema.rb
@@ -1,0 +1,39 @@
+class SchemaNotFoundError < StandardError
+end
+
+class MetadataPresenter::ValidateSchema
+  class << self
+    def before(controller)
+      return unless controller.request.post?
+
+      schema_name = "request.#{controller.request.params['controller']}"
+      validate(controller.request.params, schema_name)
+    rescue JSON::Schema::ValidationError, JSON::Schema::SchemaError, SchemaNotFoundError => e
+      controller.render(
+        json: ErrorsSerializer.new(message: e.message).attributes,
+        status: :unprocessable_entity
+      )
+    end
+
+    def validate(metadata, schema_name)
+      schema = JSON::Validator.schema_for_uri(schema_name)&.schema || find(schema_name)
+      JSON::Validator.validate!(schema, metadata)
+    end
+
+    def find(schema_name)
+      schema_file = schema_name.gsub('.', '/')
+      schema = JSON.parse(
+        File.read(
+          File.join(
+            Rails.application.config.schemas_directory, "#{schema_file}.json"
+          )
+        )
+      )
+      jschema = JSON::Schema.new(schema, Addressable::URI.parse(schema['_name']))
+      JSON::Validator.add_schema(jschema)
+      JSON::Validator.schema_for_uri(schema_name).schema
+    rescue Errno::ENOENT
+      raise SchemaNotFoundError.new("Schema not found => #{schema_name}")
+    end
+  end
+end

--- a/config/initializers/default_metadata.rb
+++ b/config/initializers/default_metadata.rb
@@ -1,7 +1,4 @@
-Rails.application.config.default_metadata_directory = File.join(
-  File.dirname(__FILE__),
-  '../../default_metadata'
-)
+Rails.application.config.default_metadata_directory = MetadataPresenter::Engine.root.join('default_metadata')
 
 Rails.application.config.default_metadata = {}
 

--- a/config/initializers/schemas.rb
+++ b/config/initializers/schemas.rb
@@ -1,0 +1,13 @@
+Rails.application.config.schemas_directory = MetadataPresenter::Engine.root.join('schemas')
+
+Rails.logger.info('Loading all schemas')
+schemas = Dir.glob("#{Rails.application.config.schemas_directory}/*/**")
+schemas.each do |schema_file|
+  schema = JSON.parse(File.read(schema_file))
+
+  Rails.logger.info(schema['_name'])
+  jschema = JSON::Schema.new(schema, Addressable::URI.parse(schema['_name']))
+  JSON::Validator.add_schema(jschema)
+end
+
+Rails.logger.info("Total loaded schemas => #{JSON::Validator.schemas.count}")

--- a/default_metadata/config/meta.json
+++ b/default_metadata/config/meta.json
@@ -1,0 +1,24 @@
+{
+  "_id": "config.meta",
+  "_type": "config.meta",
+  "items": [
+    {
+      "_id": "config.meta--link",
+      "_type": "link",
+      "href": "/cookies",
+      "text": "Cookies"
+    },
+    {
+      "_id": "config.meta--link--2",
+      "_type": "link",
+      "href": "/privacy",
+      "text": "Privacy"
+    },
+    {
+      "_id": "config.meta--link--3",
+      "_type": "link",
+      "href": "/accessibility",
+      "text": "Accessibility"
+    }
+  ]
+}

--- a/default_metadata/config/service.json
+++ b/default_metadata/config/service.json
@@ -1,0 +1,7 @@
+{
+  "_id": "config.service",
+  "_type": "config.service",
+  "homepage_url": "https://www.gov.uk",
+  "service_email_address": "moj-online@digital.justice.gov.uk",
+  "service_url": "page.start"
+}

--- a/default_metadata/service/base.json
+++ b/default_metadata/service/base.json
@@ -1,0 +1,18 @@
+{
+  "_id": "service.base",
+  "_type": "service.base",
+  "service_name": "Service name goes here",
+  "configuration": {},
+  "pages": [
+    {
+      "_id": "page.start",
+      "_type": "page.start",
+      "heading": "Start page heading",
+      "body": "Start page body text",
+      "lede": "Start page lede text",
+      "steps": [],
+      "url": "/"
+    }
+  ],
+  "locale": "en"
+}

--- a/lib/metadata_presenter.rb
+++ b/lib/metadata_presenter.rb
@@ -1,5 +1,6 @@
 require "metadata_presenter/engine"
 require "govuk_design_system_formbuilder"
+require "json-schema"
 
 module MetadataPresenter
   # Your code goes here...

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '~> 6.0.3', '>= 6.0.3.4'
   spec.add_dependency 'govspeak', '>= 6.5.10'
   spec.add_dependency 'govuk_design_system_formbuilder', '>= 2.1.5'
+  spec.add_dependency 'json-schema', '>= 2.8.1'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rspec-rails'

--- a/schemas/condition/condition.json
+++ b/schemas/condition/condition.json
@@ -1,0 +1,48 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/condition",
+  "_name": "condition",
+  "title": "Condition",
+  "type": "object",
+  "allOf": [
+    {
+      "properties": {
+        "_id": {
+          "title": "Condition ID",
+          "type": "string"
+        },
+        "_type": {
+          "title": "Type",
+          "type": "string",
+          "const": "condition"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "negated": {
+          "title": "Negated",
+          "type": "boolean"
+        }
+      }
+    },
+    {
+      "oneOf": [
+        {
+          "$ref": "definition.condition.expression"
+        },
+        {
+          "$ref": "definition.conditions.all"
+        },
+        {
+          "$ref": "definition.conditions.any"
+        },
+        {
+          "$ref": "definition.conditions.exactly"
+        }
+      ]
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/config/meta.json
+++ b/schemas/config/meta.json
@@ -1,0 +1,27 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/config/meta",
+  "_name": "config.meta",
+  "title": "Form meta links",
+  "description": "List of links to display in GOVUK footer",
+  "usage": "Use the config.meta component to provide a list of links in the footer",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "definition.link_list"
+    }
+  ],
+  "properties": {
+    "_id": {
+      "const": "config.meta"
+    },
+    "_type": {
+      "const": "config.meta"
+    },
+    "title": {
+      "type": "null"
+    }
+  },
+  "category": [
+    "configuration"
+  ]
+}

--- a/schemas/config/service.json
+++ b/schemas/config/service.json
@@ -1,0 +1,106 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/config/service",
+  "title": "Service configuration options",
+  "_name": "config.service",
+  "description": "Configuration options for a service",
+  "type": "object",
+  "properties": {
+    "_id": {
+      "const": "config.service"
+    },
+    "_type": {
+      "const": "config.service"
+    },
+    "homepage_url": {
+      "title": "Homepage URL",
+      "description": "The Homepage URL of the service",
+      "type": "string"
+    },
+    "service_email_address": {
+      "title": "Service Email Address",
+      "description": "The email address of the service",
+      "type": "string"
+    },
+    "service_url": {
+      "title": "Service URL",
+      "description": "The URL of the first page of the service",
+      "type": "string"
+    },
+    "phase": {
+      "title": "Form phase",
+      "type": "string",
+      "enum": [
+        "none",
+        "alpha",
+        "beta"
+      ],
+      "default": "alpha"
+    },
+    "phase_text": {
+      "title": "Form phase text",
+      "type": "string",
+      "content": true
+    },
+    "code": {
+      "title": "Form code",
+      "description": "Code used for form (eg. C100)",
+      "type": "string"
+    },
+    "pdf_heading": {
+      "title": "PDF heading",
+      "description": "Used as form’s heading when generating PDF output",
+      "type": "string"
+    },
+    "pdf_sub_heading": {
+      "title": "PDF subheading",
+      "description": "Used as form’s subheading when generating PDF output",
+      "type": "string"
+    },
+    "email_input_name_user": {
+      "title": "CC email address field",
+      "description": "Name of input used as email address to send user a copy of submission details",
+      "type": "string"
+    },
+    "attach_user_submission": {
+      "title": "Attach confirmation of submission to user email",
+      "type": "boolean",
+      "default": false
+    },
+    "email_subject_user": {
+      "title": "CC email subject",
+      "type": "string"
+    },
+    "email_template_user": {
+      "title": "CC email template",
+      "type": "string",
+      "multiline": true
+    },
+    "email_subject_team": {
+      "title": "Form team email subject",
+      "type": "string"
+    },
+    "email_template_team": {
+      "title": "Form team email template",
+      "type": "string",
+      "multiline": true
+    },
+    "session_duration": {
+      "title": "Session duration",
+      "description": "How many minutes a user’s session should last",
+      "type": "number"
+    },
+    "data_retention_duration": {
+      "title": "User data retention duration",
+      "description": "How many days a user’s data should be kept for",
+      "type": "number"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.data"
+    }
+  ],
+  "category": [
+    "configuration"
+  ]
+}

--- a/schemas/definition/block.json
+++ b/schemas/definition/block.json
@@ -1,0 +1,28 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/block",
+  "_name": "definition.block",
+  "title": "Block definition",
+  "properties": {
+    "show": {
+      "title": "Visibility",
+      "category": [
+        "logic"
+      ],
+      "description": "Whether to show or hide the page/component",
+      "oneOf": [
+        {
+          "$ref": "definition.conditional.boolean"
+        }
+      ],
+      "default": true
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.data"
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/component.json
+++ b/schemas/definition/component.json
@@ -1,0 +1,13 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/component",
+  "_name": "definition.component",
+  "title": "Component definition",
+  "allOf": [
+    {
+      "$ref": "definition.block"
+    }
+  ],
+  "category": [
+    "component"
+  ]
+}

--- a/schemas/definition/components.json
+++ b/schemas/definition/components.json
@@ -1,0 +1,15 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/components",
+  "_name": "definition.components",
+  "title": "Components definition",
+  "properties": {
+    "components": {
+      "title": "Components",
+      "description": "The form or content elements used on the page",
+      "type": "array",
+      "items": {
+        "$ref": "definition.component"
+      }
+    }
+  }
+}

--- a/schemas/definition/condition.base.json
+++ b/schemas/definition/condition.base.json
@@ -1,0 +1,25 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/base",
+  "_name": "definition.condition.base",
+  "title": "Base condition properties",
+  "properties": {
+    "identifier": {
+      "title": "Identifier",
+      "type": "string"
+    },
+    "identifier_type": {
+      "title": "Identifier type",
+      "type": "string",
+      "enum": [
+        "input",
+        "feature"
+      ]
+    }
+  },
+  "required": [
+    "identifier"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.boolean.json
+++ b/schemas/definition/condition.boolean.json
@@ -1,0 +1,25 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/boolean",
+  "_name": "definition.condition.boolean",
+  "title": "Boolean condition properties",
+  "allOf": [
+    {
+      "$ref": "definition.condition.base"
+    }
+  ],
+  "properties": {
+    "operator": {
+      "title": "Operator",
+      "type": "string",
+      "enum": [
+        "isTrue"
+      ]
+    }
+  },
+  "required": [
+    "operator"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.defined.json
+++ b/schemas/definition/condition.defined.json
@@ -1,0 +1,25 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/defined",
+  "_name": "definition.condition.defined",
+  "title": "Defined condition properties",
+  "allOf": [
+    {
+      "$ref": "definition.condition.base"
+    }
+  ],
+  "properties": {
+    "operator": {
+      "title": "Operator",
+      "type": "string",
+      "enum": [
+        "defined"
+      ]
+    }
+  },
+  "required": [
+    "operator"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.expression.json
+++ b/schemas/definition/condition.expression.json
@@ -1,0 +1,22 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/expression",
+  "_name": "definition.condition.expression",
+  "title": "Single expression condition properties",
+  "oneOf": [
+    {
+      "$ref": "definition.condition.defined"
+    },
+    {
+      "$ref": "definition.condition.text"
+    },
+    {
+      "$ref": "definition.condition.number"
+    },
+    {
+      "$ref": "definition.condition.boolean"
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.number.json
+++ b/schemas/definition/condition.number.json
@@ -1,0 +1,49 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/number",
+  "_name": "definition.condition.number",
+  "title": "Number condition properties",
+  "allOf": [
+    {
+      "$ref": "definition.condition.base"
+    }
+  ],
+  "properties": {
+    "operator": {
+      "title": "Operator",
+      "type": "string",
+      "enum": [
+        "equals",
+        "greater_than",
+        "greater_than_or_equal_to",
+        "less_than",
+        "less_than_or_equal_to",
+        "multiple_of"
+      ]
+    },
+    "value": {
+      "title": "Value"
+    }
+  },
+  "if": {
+    "required": [
+      "value_type"
+    ]
+  },
+  "then": {
+    "$ref": "definition.condition.value_type"
+  },
+  "else": {
+    "properties": {
+      "value": {
+        "type": "number"
+      }
+    }
+  },
+  "required": [
+    "operator",
+    "value"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.text.json
+++ b/schemas/definition/condition.text.json
@@ -1,0 +1,48 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/text",
+  "_name": "definition.condition.text",
+  "title": "Text condition properties",
+  "allOf": [
+    {
+      "$ref": "definition.condition.base"
+    }
+  ],
+  "properties": {
+    "operator": {
+      "title": "Operator",
+      "type": "string",
+      "enum": [
+        "is",
+        "starts_with",
+        "ends_with",
+        "includes",
+        "match"
+      ]
+    },
+    "value": {
+      "title": "Value"
+    }
+  },
+  "if": {
+    "required": [
+      "value_type"
+    ]
+  },
+  "then": {
+    "$ref": "definition.condition.value_type"
+  },
+  "else": {
+    "properties": {
+      "value": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "operator",
+    "value"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.value_type.json
+++ b/schemas/definition/condition.value_type.json
@@ -1,0 +1,24 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/value_type",
+  "_name": "definition.condition.value_type",
+  "title": "Condition value type properties",
+  "properties": {
+    "value": {
+      "type": "string"
+    },
+    "value_type": {
+      "type": "string",
+      "enum": [
+        "value",
+        "input",
+        "feature"
+      ]
+    }
+  },
+  "required": [
+    "value_type"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/conditional.boolean.json
+++ b/schemas/definition/conditional.boolean.json
@@ -1,0 +1,20 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/conditional/boolean",
+  "_name": "definition.conditional.boolean",
+  "title": "Boolean or condition",
+  "type": [
+    "boolean",
+    "object"
+  ],
+  "oneOf": [
+    {
+      "type": "boolean"
+    },
+    {
+      "$ref": "condition"
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/conditions.all.json
+++ b/schemas/definition/conditions.all.json
@@ -1,0 +1,20 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/conditions/all",
+  "_name": "definition.conditions.all",
+  "title": "All conditions met properties",
+  "properties": {
+    "all": {
+      "title": "All conditions met",
+      "type": "array",
+      "items": {
+        "$ref": "condition"
+      }
+    }
+  },
+  "required": [
+    "all"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/conditions.any.json
+++ b/schemas/definition/conditions.any.json
@@ -1,0 +1,26 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/conditions/any",
+  "_name": "definition.conditions.any",
+  "title": "At least conditions met properties",
+  "properties": {
+    "any": {
+      "title": "At least X conditions met",
+      "type": "array",
+      "items": {
+        "$ref": "condition"
+      }
+    },
+    "conditions_met": {
+      "title": "Number of conditions to meet",
+      "type": "number",
+      "minimum": 1,
+      "default": 1
+    }
+  },
+  "required": [
+    "any"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/conditions.exactly.json
+++ b/schemas/definition/conditions.exactly.json
@@ -1,0 +1,26 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/conditions/exactly",
+  "_name": "definition.conditions.exactly",
+  "title": "Exactly conditions met properties",
+  "properties": {
+    "exactly": {
+      "title": "Exactly X conditions met",
+      "type": "array",
+      "items": {
+        "$ref": "condition"
+      }
+    },
+    "conditions_met": {
+      "title": "Number of conditions to meet",
+      "type": "number",
+      "minimum": 1,
+      "default": 1
+    }
+  },
+  "required": [
+    "exactly"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/control.json
+++ b/schemas/definition/control.json
@@ -1,0 +1,75 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/control",
+  "_name": "definition.control",
+  "title": "Control definition",
+  "allOf": [
+    {
+      "$ref": "definition.component"
+    },
+    {
+      "$ref": "definition.html_attributes"
+    },
+    {
+      "$ref": "definition.namespace"
+    },
+    {
+      "$ref": "validations#/definitions/required_bundle"
+    }
+  ],
+  "properties": {
+    "redact": {
+      "title": "Redaction pattern",
+      "description": "Pattern specifying that user input should be redacted and how",
+      "type": "string",
+      "category": [
+        "userinput"
+      ]
+    },
+    "optionalText": {
+      "title": "Optional text",
+      "description": "Additional text to display if control is optional",
+      "type": "string",
+      "category": [
+        "content"
+      ],
+      "acceptsEmptyString": true,
+      "default": "(optional)"
+    },
+    "autocomplete": {
+      "title": "Autocomplete",
+      "description": "Instructions how to suggest (or not) values",
+      "type": "string",
+      "category": [
+        "userinput"
+      ]
+    },
+    "spellcheck": {
+      "title": "Spellcheck",
+      "description": "Whether the element may be checked for spelling errors",
+      "type": "string",
+      "enum": [
+        "true",
+        "false"
+      ],
+      "category": [
+        "userinput"
+      ]
+    },
+    "disabled": {
+      "title": "Disabled",
+      "description": "Whether the control should be disabled",
+      "oneOf": [
+        {
+          "$ref": "definition.conditional.boolean"
+        }
+      ],
+      "default": false,
+      "category": [
+        "logic"
+      ]
+    }
+  },
+  "category": [
+    "control"
+  ]
+}

--- a/schemas/definition/data.json
+++ b/schemas/definition/data.json
@@ -1,0 +1,28 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/data",
+  "_name": "definition.data",
+  "title": "Data definition",
+  "properties": {
+    "_id": {
+      "title": "Data ID",
+      "type": "string"
+    },
+    "_type": {
+      "title": "Data type",
+      "type": "string"
+    },
+    "_isa": {
+      "title": "Based on",
+      "description": "Id of page/component to inherit property values from",
+      "type": "string",
+      "blockReference": true
+    }
+  },
+  "required": [
+    "_id",
+    "_type"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/field.json
+++ b/schemas/definition/field.json
@@ -1,0 +1,26 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/field",
+  "_name": "definition.field",
+  "title": "Field definition",
+  "allOf": [
+    {
+      "$ref": "definition.label"
+    },
+    {
+      "$ref": "definition.control"
+    },
+    {
+      "$ref": "definition.repeatable"
+    },
+    {
+      "$ref": "definition.name"
+    }
+  ],
+  "required": [
+    "name",
+    "label"
+  ],
+  "category": [
+    "field"
+  ]
+}

--- a/schemas/definition/html_attributes.json
+++ b/schemas/definition/html_attributes.json
@@ -1,0 +1,37 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/html_attributes",
+  "_name": "definition.html_attributes",
+  "title": "HTML attributes definition",
+  "description": "Additional HTML values to set on instances",
+  "type": "object",
+  "properties": {
+    "id": {
+      "title": "HTML id",
+      "description": "Additional HTML id to apply to instance - only use as a last resort, to target a specific element on the page",
+      "type": "string",
+      "category": [
+        "html_attributes"
+      ]
+    },
+    "classes": {
+      "title": "Classes",
+      "description": "Additional HTML classes to apply to instance - to add more than one, separate with a space",
+      "type": "string",
+      "content": true,
+      "category": [
+        "html_attributes"
+      ]
+    },
+    "attributes": {
+      "title": "Attributes",
+      "description": "Additional HTML attributes to apply to instance - Enter the attributes as JSON",
+      "type": "object",
+      "category": [
+        "html_attributes"
+      ]
+    }
+  },
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/label.json
+++ b/schemas/definition/label.json
@@ -1,0 +1,30 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/label",
+  "_name": "definition.label",
+  "title": "Label definition",
+  "type": "object",
+  "properties": {
+    "label": {
+      "title": "Label",
+      "description": "Question or instruction to user - appears above the component. If component is repeatable, the label appears next to the input, with the number added automatically (for example, child 1)",
+      "type": "string",
+      "content": true
+    },
+    "hint": {
+      "title": "Hint text",
+      "description": "Text to help users answer a question - appears in grey under the label (like this text)",
+      "type": "string",
+      "multiline": true,
+      "content": true
+    },
+    "label_summary": {
+      "title": "Label (Summary version)",
+      "description": "The text used on the 'check your answers' page. Ideally a shorter version of the label text",
+      "type": "string",
+      "content": true
+    }
+  },
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/link_list.json
+++ b/schemas/definition/link_list.json
@@ -1,0 +1,30 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/link_list",
+  "_name": "definition.link_list",
+  "title": "Link list definition",
+  "type": "object",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "description": "Title/heading to display",
+      "type": "string",
+      "content": true
+    },
+    "items": {
+      "title": "Items",
+      "description": "Items that make up list",
+      "type": "array",
+      "items": {
+        "$ref": "link"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.block"
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/name.json
+++ b/schemas/definition/name.json
@@ -1,0 +1,18 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/name",
+  "_name": "definition.name",
+  "idSeed": "name",
+  "title": "Name definition",
+  "properties": {
+    "name": {
+      "title": "Input name",
+      "description": "Used by system to identify user's answer - also used as the component's HTML name property.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9-_]+$",
+      "processInput": true,
+      "category": [
+        "userinput"
+      ]
+    }
+  }
+}

--- a/schemas/definition/namespace.json
+++ b/schemas/definition/namespace.json
@@ -1,0 +1,28 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/namespace",
+  "_name": "definition.namespace",
+  "title": "Namespace definition",
+  "type": "object",
+  "properties": {
+    "namespace": {
+      "title": "Namespace",
+      "description": "Namespace under which to store user inputs - combines with input names of child components",
+      "type": "string",
+      "category": [
+        "userinput"
+      ]
+    },
+    "namespace_protect": {
+      "title": "Namespace protection",
+      "description": "Whether to prevent the component’s namespace being overridden or appended",
+      "type": "boolean",
+      "default": false,
+      "category": [
+        "userinput"
+      ]
+    }
+  },
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/next_page.json
+++ b/schemas/definition/next_page.json
@@ -1,0 +1,40 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/nextpage",
+  "_name": "definition.nextpage",
+  "title": "Next page",
+  "description": "What page (or pages) to go to next, and under what conditions. Only use if what you’re trying to achieve is impossible or extremely difficult using page steps",
+  "oneOf": [
+    {
+      "type": "string"
+    },
+    {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "string"
+              },
+              "condition": {
+                "$ref": "definition.conditional.boolean"
+              }
+            },
+            "required": [
+              "page",
+              "condition"
+            ]
+          },
+          {
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "category": [
+    "logic",
+    "definition"
+  ]
+}

--- a/schemas/definition/page.form.json
+++ b/schemas/definition/page.form.json
@@ -1,0 +1,96 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/page/form",
+  "_name": "definition.page.form",
+  "title": "Form page definition",
+  "properties": {
+    "extra_components": {
+      "title": "Additional components",
+      "description": "Components following continue button",
+      "type": "array",
+      "items": {
+        "$ref": "definition.component"
+      },
+      "accepts": [
+        "content"
+      ],
+      "category": [
+        "additional"
+      ]
+    },
+    "section_heading": {
+      "title": "Section heading",
+      "description": "Name of section",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "section_heading_summary": {
+      "title": "Section heading (Summary version)",
+      "description": "A condensed version of the section heading, for use on the 'check your answers' page",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "heading_summary": {
+      "title": "Heading (Summary version)",
+      "description": "A condensed version of the page heading, for use on the 'check your answers' page",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "steps_heading": {
+      "title": "Steps heading",
+      "description": "Name of section to use on step pages (if any)",
+      "type": "string",
+      "category": [
+        "content"
+      ]
+    },
+    "steps": {
+      "title": "Steps",
+      "description": "The ‘child’ pages that follow from this ‘parent’ page",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "enable_steps": {
+      "title": "Enable steps",
+      "description": "Allow current page to have steps",
+      "type": "boolean"
+    },
+    "show_steps": {
+      "title": "Steps visibility",
+      "category": [
+        "logic"
+      ],
+      "description": "Whether to show or hide the page’s steps",
+      "oneOf": [
+        {
+          "$ref": "definition.conditional.boolean"
+        }
+      ],
+      "default": true
+    },
+    "nextPage": {
+      "$ref": "definition.next_page"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.page"
+    },
+    {
+      "$ref": "definition.repeatable"
+    }
+  ],
+  "category": [
+    "form_page"
+  ]
+}

--- a/schemas/definition/page.json
+++ b/schemas/definition/page.json
@@ -1,0 +1,109 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/page",
+  "_name": "definition.page",
+  "id_seed": "url",
+  "title": "Page definition",
+  "properties": {
+    "url": {
+      "title": "URL",
+      "description": "The page’s relative url - it must not contain any spaces",
+      "type": "string",
+      "pattern": "^[\\w\\-_\\/]+$"
+    },
+    "heading": {
+      "title": "Heading",
+      "description": "The page’s top-level heading (H1) - appears at the top of the page",
+      "type": "string",
+      "content": true
+    },
+    "title": {
+      "title": "Title",
+      "description": "The text to use as the page’s title in the document title element - uses heading value by default",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "lede": {
+      "title": "First paragraph",
+      "description": "Introductory paragraph after the heading (it‘s also known as the ‘lede’) - use [markdown](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown) to format text or add hyperlinks",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "body": {
+      "title": "Content",
+      "description": "Free-form content after the heading and first paragraph - use [markdown](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown) to format text or add hyperlinks",
+      "type": "string",
+      "content": true,
+      "multiline": true,
+      "category": [
+        "content"
+      ]
+    },
+    "cookie_message": {
+      "title": "Cookie message",
+      "description": "Set dynamically - exists here to enable formatting of value",
+      "type": "string",
+      "content": true,
+      "default": "[% cookie.message %]",
+      "category": [
+        "dynamic"
+      ]
+    },
+    "action_type": {
+      "title": "Primary action",
+      "description": "Text for primary action button",
+      "type": "string",
+      "enum": [
+        "continue",
+        "save_continue",
+        "save",
+        "confirm",
+        "send.email",
+        "send.sms",
+        "custom-1",
+        "custom-2",
+        "custom-3",
+        "custom-4",
+        "custom-5"
+      ],
+      "default": "continue",
+      "category": [
+        "additional"
+      ]
+    },
+    "back_link": {
+      "title": "Back link text",
+      "type": "string",
+      "default": "[% link.back %]",
+      "content": true,
+      "category": [
+        "additional"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.block"
+    },
+    {
+      "$ref": "definition.components"
+    }
+  ],
+  "required": [
+    "url"
+  ],
+  "category": [
+    "definition",
+    "page"
+  ],
+  "transforms": {
+    "namespace": {
+      "propagation": "components[?(@.$control || @.$grouping)]"
+    }
+  }
+}

--- a/schemas/definition/page.singlequestion.json
+++ b/schemas/definition/page.singlequestion.json
@@ -1,0 +1,31 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/page/singlequestion",
+  "_name": "page.singlequestion",
+  "title": "Single question",
+  "description": "Ask users one question on a page (you can make the question repeatable for additional answers)",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "page.singlequestion"
+    },
+    "components": {
+      "maxItems": 1,
+      "accepts": [
+        "control"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.page.form"
+    }
+  ],
+  "required": [
+    "components"
+  ],
+  "surplus_properties": [
+    "heading",
+    "lede",
+    "body"
+  ]
+}

--- a/schemas/definition/repeatable.json
+++ b/schemas/definition/repeatable.json
@@ -1,0 +1,72 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/repeatable",
+  "_name": "definition.repeatable",
+  "title": "Repeatable definition",
+  "type": "object",
+  "properties": {
+    "repeatable": {
+      "title": "Repeatable",
+      "description": "Whether the page or component lets users ‘add another’ answer",
+      "type": "boolean"
+    },
+    "repeatable_minimum": {
+      "title": "Minimum number of repeatable items",
+      "description": "For example, if users must give at least 3 answers, set this to 3 - the page will show 3 inputs when it loads",
+      "type": "number",
+      "minimum": 0,
+      "default": 1,
+      "category": [
+        "repeatable"
+      ]
+    },
+    "repeatable_maximum": {
+      "title": "Maximum number of repeatable items",
+      "description": "For example, if users can give up to 5 answers, set this to 5",
+      "type": "number",
+      "minimum": 0,
+      "category": [
+        "repeatable"
+      ]
+    },
+    "repeatable_heading": {
+      "title": "Repeatable section heading",
+      "description": "Heading for repeatable items - appears once before the components",
+      "type": "string",
+      "category": [
+        "repeatable"
+      ]
+    },
+    "repeatable_lede": {
+      "title": "Repeatable section first paragraph",
+      "description": "Introductory paragraph - follows the heading",
+      "type": "string",
+      "category": [
+        "repeatable"
+      ]
+    },
+    "repeatable_add": {
+      "title": "Text to add another answer",
+      "description": "Specify the link text for users to add another answer - defaults to ‘Add another’",
+      "type": "string",
+      "category": [
+        "repeatable"
+      ]
+    },
+    "repeatable_delete": {
+      "title": "Text to remove an answer",
+      "description": "Specify the link text for users to delete an answer - defaults to ‘Remove’",
+      "type": "string",
+      "category": [
+        "repeatable"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.namespace"
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/width_class.input.json
+++ b/schemas/definition/width_class.input.json
@@ -1,0 +1,48 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/width_class/input",
+  "_name": "definition.width_class.input",
+  "title": "Input width class definition",
+  "properties": {
+    "width_class_input": {
+      "title": "Input width",
+      "description": "How wide the input should be visually",
+      "type": "string",
+      "enum_map": {
+        "2": "2 characters",
+        "3": "3 characters",
+        "4": "4 characters",
+        "5": "5 characters",
+        "10": "10 characters",
+        "20": "20 characters",
+        "30": "30 characters",
+        "one-quarter": "One quarter",
+        "one-third": "One third",
+        "one-half": "One half",
+        "two-thirds": "Two thirds",
+        "three-quarters": "Three quarters",
+        "full": "Full width"
+      },
+      "enum": [
+        "2",
+        "3",
+        "4",
+        "5",
+        "10",
+        "20",
+        "30",
+        "one-quarter",
+        "one-third",
+        "one-half",
+        "two-thirds",
+        "three-quarters",
+        "full"
+      ],
+      "category": [
+        "html_attributes"
+      ]
+    }
+  },
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/width_class.json
+++ b/schemas/definition/width_class.json
@@ -1,0 +1,34 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/width_class",
+  "_name": "definition.width_class",
+  "title": "Width class definition",
+  "properties": {
+    "width_class": {
+      "title": "Width",
+      "description": "How wide the component should be visually",
+      "type": "string",
+      "enum_map": {
+        "one-quarter": "One quarter",
+        "one-third": "One third",
+        "one-half": "One half",
+        "two-thirds": "Two thirds",
+        "three-quarters": "Three quarters",
+        "full": "Full width"
+      },
+      "enum": [
+        "one-quarter",
+        "one-third",
+        "one-half",
+        "two-thirds",
+        "three-quarters",
+        "full"
+      ],
+      "category": [
+        "html_attributes"
+      ]
+    }
+  },
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/errors/errors.json
+++ b/schemas/errors/errors.json
@@ -1,0 +1,142 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/errors",
+  "_name": "errors",
+  "title": "Error strings",
+  "type": "object",
+  "definitions": {
+    "error_strings": {
+      "type": "object",
+      "properties": {
+        "inline": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        }
+      }
+    },
+    "required": {
+      "title": "Error strings for required",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "min_length": {
+      "title": "Error strings for minimum length",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "max_length": {
+      "title": "Error strings for maximum length",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "pattern": {
+      "title": "Error strings for pattern",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "multiple_of": {
+      "title": "Error strings for multiple of",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "maximum": {
+      "title": "Error strings for maximum",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "exclusive_maximum": {
+      "title": "Error strings for exclusive maximum",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "minimum": {
+      "title": "Error strings for minimum",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "exclusive_minimum": {
+      "title": "Error strings for exclusive minimum",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "required_errors": {
+      "properties": {
+        "errors": {
+          "properties": {
+            "required": {
+              "$ref": "#/definitions/required"
+            }
+          }
+        }
+      }
+    },
+    "string_errors": {
+      "properties": {
+        "errors": {
+          "properties": {
+            "min_length": {
+              "$ref": "#/definitions/min_length"
+            },
+            "max_length": {
+              "$ref": "#/definitions/max_length"
+            },
+            "pattern": {
+              "$ref": "#/definitions/pattern"
+            }
+          }
+        }
+      }
+    },
+    "number_errors": {
+      "properties": {
+        "errors": {
+          "properties": {
+            "multiple_of": {
+              "$ref": "#/definitions/multiple_of"
+            },
+            "maximum": {
+              "$ref": "#/definitions/maximum"
+            },
+            "exclusive_maximum": {
+              "$ref": "#/definitions/exclusive_maximum"
+            },
+            "minimum": {
+              "$ref": "#/definitions/minimum"
+            },
+            "exclusive_minimum": {
+              "$ref": "#/definitions/exclusive_minimum"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/link/link.json
+++ b/schemas/link/link.json
@@ -1,0 +1,46 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/link",
+  "_name": "link",
+  "title": "Link",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "link"
+    },
+    "text": {
+      "title": "Link text",
+      "description": "Link text to display",
+      "type": "string",
+      "content": true
+    },
+    "href": {
+      "title": "Link url",
+      "description": "Page Id or absolute url",
+      "type": "string",
+      "content": true,
+      "url": true
+    },
+    "active": {
+      "title": "Active",
+      "description": "Whether link is active",
+      "type": "boolean"
+    },
+    "attributes": {
+      "title": "Link attributes",
+      "description": "Attributes to pass to link",
+      "type": "object"
+    }
+  },
+  "required": [
+    "text",
+    "href"
+  ],
+  "allOf": [
+    {
+      "$ref": "definition.block"
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/page/start.json
+++ b/schemas/page/start.json
@@ -1,0 +1,34 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/page/start",
+  "_name": "page.start",
+  "title": "Start page",
+  "description": "Let users start using a service",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "page.start"
+    },
+    "enable_steps": {
+      "const": true
+    },
+    "components": {
+      "accepts": [
+        "content"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.page.form"
+    }
+  ],
+  "ui_category": {
+    "main": [
+      "lede",
+      "body"
+    ]
+  },
+  "required": [
+    "steps"
+  ]
+}

--- a/schemas/request/services.json
+++ b/schemas/request/services.json
@@ -1,0 +1,48 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/request/services",
+  "_name": "request.services",
+  "title": "Create new service",
+  "description": "Request schema for creating a new service",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "_id": {
+          "const": "service.base"
+        },
+        "_type": {
+          "const": "service.base"
+        },
+        "service_name": {
+          "type": "string"
+        },
+        "created_by": {
+          "type": "string"
+        },
+        "configuration": {
+          "$ref": "configuration"
+        },
+        "locale": {
+          "$ref": "service.locale"
+        },
+        "pages": {
+          "type": "array",
+          "items": {
+            "$ref": "definition.page"
+          }
+        }
+      },
+      "required": [
+        "_id",
+        "_type",
+        "service_name",
+        "created_by",
+        "configuration",
+        "pages"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": ["metadata"]
+}

--- a/schemas/request/versions.json
+++ b/schemas/request/versions.json
@@ -1,0 +1,13 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/request/versions",
+  "_name": "request.versions",
+  "title": "Create new service version",
+  "description": "Request schema for creating a new version of a service",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "$ref": "service.base"
+    }
+  },
+  "required": ["metadata"]
+}

--- a/schemas/service/base.json
+++ b/schemas/service/base.json
@@ -1,0 +1,53 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/service/base",
+  "_name": "service.base",
+  "title": "Base service schema",
+  "description": "Base schema for a service",
+  "type": "object",
+  "properties": {
+    "_id": {
+      "const": "service.base"
+    },
+    "_type": {
+      "const": "service.base"
+    },
+    "service_id": {
+      "type": "string"
+    },
+    "service_name": {
+      "type": "string"
+    },
+    "version_id": {
+      "type": "string"
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "created_by": {
+      "type": "string"
+    },
+    "locale": {
+      "$ref": "service.locale"
+    },
+    "configuration": {
+      "$ref": "configuration"
+    },
+    "pages": {
+      "type": "array",
+      "items": {
+        "$ref": "definition.page"
+      }
+    }
+  },
+  "required": [
+    "_id",
+    "_type",
+    "service_id",
+    "service_name",
+    "created_by",
+    "locale",
+    "configuration",
+    "pages"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/service/configuration.json
+++ b/schemas/service/configuration.json
@@ -1,0 +1,22 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/configuration",
+  "_name": "configuration",
+  "title": "Service configuration",
+  "description": "Service configuration",
+  "type": "object",
+  "properties": {
+    "service": {
+      "$ref": "config.service"
+    },
+    "meta": {
+      "$ref": "config.meta"
+    }
+  },
+  "required": [
+    "service",
+    "meta"
+  ],
+  "category": [
+    "configuration"
+  ]
+}

--- a/schemas/service/locale.json
+++ b/schemas/service/locale.json
@@ -1,0 +1,12 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/service/locale",
+  "_name": "service.locale",
+  "title": "Service version locale",
+  "description": "The locale of a version of a service",
+  "type": "string",
+  "default": "en",
+  "enum": [
+    "en",
+    "cy"
+  ]
+}

--- a/schemas/text/text.json
+++ b/schemas/text/text.json
@@ -1,0 +1,23 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/text",
+  "_name": "text",
+  "title": "Text",
+  "description": "Let users enter text that’s no longer than a single line",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "text"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.field"
+    },
+    {
+      "$ref": "validations#/definitions/string_bundle"
+    },
+    {
+      "$ref": "definition.width_class.input"
+    }
+  ]
+}

--- a/schemas/validations/validations.json
+++ b/schemas/validations/validations.json
@@ -1,0 +1,455 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/validations",
+  "_name": "validations",
+  "title": "Validations",
+  "type": "object",
+  "definitions": {
+    "error_strings": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "title": "Error message",
+          "description": "Error message users see if their answer fails validation - write {control} to show the question in the message",
+          "type": "string",
+          "role": "error_string"
+        },
+        "inline": {
+          "title": "Input error",
+          "description": "Specific error message users see next to the input if their answer fails validation - only set if your input message absolutely must be different to that shown in the summary",
+          "type": "string",
+          "role": "error_string"
+        },
+        "summary": {
+          "title": "Summary error",
+          "description": "Specific error message users see at the top of a page if their answer fails validation - only set if your summary message absolutely must be different to that shown for the input",
+          "type": "string",
+          "role": "error_string"
+        }
+      }
+    },
+    "required": {
+      "title": "Required",
+      "description": "Whether the user must answer a question",
+      "oneOf": [
+        {
+          "$ref": "definition.conditional.boolean"
+        }
+      ],
+      "default": true
+    },
+    "errors_required": {
+      "title": "Error messages for ‘Required’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "errors_accept": {
+      "title": "Error messages for ‘Accept’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "errors_max_size": {
+      "title": "Error messages for ‘Max Size’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "min_length": {
+      "title": "Minimum length",
+      "description": "The minimum characters users must enter",
+      "type": "number",
+      "minimum": 0
+    },
+    "errors_min_length": {
+      "title": "Error messages for ‘Minimum length’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "max_length": {
+      "title": "Maximum length",
+      "description": "The maximum characters users can enter",
+      "type": "number",
+      "minimum": 0
+    },
+    "errors_max_length": {
+      "title": "Error messages for ‘Maximum length’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "pattern": {
+      "title": "Pattern to match string against",
+      "description": "A regular expression for validating users’ answers",
+      "type": "string"
+    },
+    "errors_pattern": {
+      "title": "Error messages for pattern",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "format": {
+      "title": "Format to match string against",
+      "description": "Format used for validating users’ answers",
+      "type": "string"
+    },
+    "errors_format": {
+      "title": "Error messages for format",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "multiple_of": {
+      "title": "Multiple of",
+      "description": "Whether users must enter a multiple of another number",
+      "type": "number",
+      "minimum": 0
+    },
+    "errors_multiple_of": {
+      "title": "Error messages for ‘Multiple of’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "maximum": {
+      "title": "Maximum value",
+      "description": "The largest number that users can enter",
+      "type": "number",
+      "minimum": 0
+    },
+    "errors_maximum": {
+      "title": "Error messages for ‘Maximum value’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "exclusive_maximum": {
+      "title": "Is maximum value exclusive?",
+      "description": "Excludes the maximum value from the range users can enter",
+      "type": "boolean"
+    },
+    "errors_exclusive_maximum": {
+      "title": "Error messages for ‘Maximum value is exclusive",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "minimum": {
+      "title": "Minimum value",
+      "description": "The smallest number that users can enter",
+      "type": "number",
+      "minimum": 0
+    },
+    "errors_minimum": {
+      "title": "Error messages for for ‘Minimum value’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "exclusive_minimum": {
+      "title": "Is minimum value exclusive?",
+      "description": "Excludes the minimum value from the range users can enter",
+      "type": "boolean"
+    },
+    "errors_exclusive_minimum": {
+      "title": "Error messages for ‘Minimum value is exclusive",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "date_before": {
+      "title": "Before date",
+      "description": "Date which user input must be before - eg. 2000-10-24",
+      "type": "string",
+      "format": "date"
+    },
+    "errors_date_before": {
+      "title": "Error messages for ‘Before date’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "date_after": {
+      "title": "After date",
+      "description": "Date which user input must be after - eg. 2000-10-24",
+      "type": "string",
+      "format": "date"
+    },
+    "errors_date_after": {
+      "title": "Error messages for ‘After date’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "date_within_next": {
+      "title": "Within next",
+      "description": "Date which user input must be before - eg. 1y, 4Mm, 2w, 100d",
+      "type": "object",
+      "properties": {
+        "amount": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "enum": [
+            "years",
+            "months",
+            "weeks",
+            "days"
+          ]
+        }
+      },
+      "required": [
+        "amount",
+        "unit"
+      ]
+    },
+    "errors_date_within_next": {
+      "title": "Error messages for ‘Within next’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "date_within_last": {
+      "title": "Within last",
+      "description": "Date which user input must be before - eg. 1y, 4Mm, 2w, 100d",
+      "type": "object",
+      "properties": {
+        "amount": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "enum": [
+            "years",
+            "months",
+            "weeks",
+            "days"
+          ]
+        }
+      },
+      "required": [
+        "amount",
+        "unit"
+      ]
+    },
+    "errors_date_within_last": {
+      "title": "Error messages for ‘Within last’",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "required_bundle": {
+      "properties": {
+        "validation": {
+          "title": "Validation",
+          "description": "Values for default validation",
+          "role": "validation",
+          "properties": {
+            "required": {
+              "$ref": "#/definitions/required"
+            }
+          }
+        },
+        "errors": {
+          "title": "Errors",
+          "description": "Strings to override for default error messages",
+          "role": "error_strings",
+          "properties": {
+            "required": {
+              "$ref": "#/definitions/errors_required"
+            }
+          }
+        }
+      }
+    },
+    "upload_bundle": {
+      "properties": {
+        "validation": {
+          "title": "Validation",
+          "description": "Values for default validation",
+          "role": "validation",
+          "properties": {
+            "accept": {
+              "title": "Accepted types",
+              "description": "Which file types to accept",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "max_size": {
+              "title": "Maximum size",
+              "description": "Maximum file size as human readable string or bytes",
+              "type": "string"
+            }
+          }
+        },
+        "errors": {
+          "title": "Errors",
+          "description": "Strings to override for default error messages",
+          "role": "error_strings",
+          "properties": {
+            "accept": {
+              "$ref": "#/definitions/errors_accept"
+            },
+            "maxSize": {
+              "$ref": "#/definitions/errors_max_size"
+            }
+          }
+        }
+      }
+    },
+    "string_bundle": {
+      "properties": {
+        "validation": {
+          "properties": {
+            "min_length": {
+              "$ref": "#/definitions/min_length"
+            },
+            "max_length": {
+              "$ref": "#/definitions/max_length"
+            },
+            "pattern": {
+              "$ref": "#/definitions/pattern"
+            },
+            "format": {
+              "$ref": "#/definitions/format"
+            }
+          }
+        },
+        "errors": {
+          "properties": {
+            "min_length": {
+              "$ref": "#/definitions/errors_min_length"
+            },
+            "max_length": {
+              "$ref": "#/definitions/errors_max_length"
+            },
+            "pattern": {
+              "$ref": "#/definitions/errors_pattern"
+            },
+            "format": {
+              "$ref": "#/definitions/errors_format"
+            }
+          }
+        }
+      }
+    },
+    "number_bundle": {
+      "properties": {
+        "validation": {
+          "properties": {
+            "multiple_of": {
+              "$ref": "#/definitions/multiple_of"
+            },
+            "maximum": {
+              "$ref": "#/definitions/maximum"
+            },
+            "exclusive_maximum": {
+              "$ref": "#/definitions/exclusive_maximum"
+            },
+            "minimum": {
+              "$ref": "#/definitions/minimum"
+            },
+            "exclusive_minimum": {
+              "$ref": "#/definitions/exclusive_minimum"
+            }
+          }
+        },
+        "errors": {
+          "properties": {
+            "multiple_of": {
+              "$ref": "#/definitions/errors_multiple_of"
+            },
+            "maximum": {
+              "$ref": "#/definitions/errors_maximum"
+            },
+            "exclusive_maximum": {
+              "$ref": "#/definitions/errors_exclusive_maximum"
+            },
+            "minimum": {
+              "$ref": "#/definitions/errors_minimum"
+            },
+            "exclusive_minimum": {
+              "$ref": "#/definitions/errors_exclusive_minimum"
+            }
+          }
+        }
+      }
+    },
+    "date_bundle": {
+      "properties": {
+        "validation": {
+          "properties": {
+            "date_before": {
+              "$ref": "#/definitions/date_before"
+            },
+            "date_after": {
+              "$ref": "#/definitions/date_after"
+            },
+            "date_within_next": {
+              "$ref": "#/definitions/date_within_next"
+            },
+            "date_within_last": {
+              "$ref": "#/definitions/date_within_last"
+            }
+          }
+        },
+        "errors": {
+          "properties": {
+            "date_before": {
+              "$ref": "#/definitions/errors_date_before"
+            },
+            "date_after": {
+              "$ref": "#/definitions/errors_date_after"
+            },
+            "date_within_next": {
+              "$ref": "#/definitions/errors_date_within_next"
+            },
+            "date_within_last": {
+              "$ref": "#/definitions/errors_date_within_last"
+            }
+          }
+        }
+      }
+    }
+  },
+  "category": [
+    "definition"
+  ]
+}

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'Navigation' do
     JSON.parse(
       File.read(
         MetadataPresenter::Engine.root.join(
-          'spec', 'fixtures', 'service.json'
+          'spec', 'fixtures', 'version.json'
         )
       )
     )

--- a/spec/fixtures/service.json
+++ b/spec/fixtures/service.json
@@ -1,12 +1,40 @@
 {
-  "service_id": "d243f5c0-e8a2-4b13-982c-7b5f3fa128cf",
+  "_id": "service.base",
+  "_type": "service.base",
   "service_name": "Complain about a court or tribunal",
-  "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
-  "created_at": "2020-10-09T11:51:46",
   "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
   "configuration": {
-    "_id": "service",
-    "_type": "config.service"
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service",
+      "homepage_url": "https://www.gov.uk",
+      "service_email_address": "moj-online@digital.justice.gov.uk",
+      "service_url": "page.start"
+    },
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "_type": "link",
+          "href": "/cookies",
+          "text": "Cookies"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "_type": "link",
+          "href": "/privacy",
+          "text": "Privacy"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "_type": "link",
+          "href": "/accessibility",
+          "text": "Accessibility"
+        }
+      ]
+    }
   },
   "pages": [
     {
@@ -15,48 +43,8 @@
       "body": "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
       "heading": "Complain about a court or tribunal",
       "lede": "Your complaint will not affect your case.",
-      "steps": [
-        "page.name",
-        "page.email-address"
-      ],
+      "steps": [],
       "url": "/"
-    },
-    {
-      "_id": "page.name",
-      "_type": "page.singlequestion",
-      "components": [
-        {
-          "_id": "page.name--text.auto_name__1",
-          "_type": "text",
-          "label": "Full name",
-          "name": "full_name"
-        }
-      ],
-      "heading": "Your name",
-      "url": "/name"
-    },
-    {
-      "_id": "page.email-address",
-      "_type": "page.singlequestion",
-      "heading": "Email address",
-      "components": [
-        {
-          "_id": "page.email-address--email.auto_name__2",
-          "_type": "text",
-          "errors": {
-            "format": {},
-            "required": {
-              "any": "Enter an email address"
-            }
-          },
-          "label": "Your email address",
-          "name": "email_address",
-          "validation": {
-            "required": true
-          }
-        }
-      ],
-      "url": "/email-address"
     }
   ],
   "locale": "en"

--- a/spec/fixtures/version.json
+++ b/spec/fixtures/version.json
@@ -1,0 +1,92 @@
+{
+  "_id": "service.base",
+  "_type": "service.base",
+  "service_id": "d243f5c0-e8a2-4b13-982c-7b5f3fa128cf",
+  "service_name": "Complain about a court or tribunal",
+  "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+  "configuration": {
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service",
+      "homepage_url": "https://www.gov.uk",
+      "service_email_address": "moj-online@digital.justice.gov.uk",
+      "service_url": "page.start"
+    },
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "_type": "link",
+          "href": "/cookies",
+          "text": "Cookies"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "_type": "link",
+          "href": "/privacy",
+          "text": "Privacy"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "_type": "link",
+          "href": "/accessibility",
+          "text": "Accessibility"
+        }
+      ]
+    }
+  },
+  "pages": [
+    {
+      "_id": "page.start",
+      "_type": "page.start",
+      "body": "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
+      "heading": "Complain about a court or tribunal",
+      "lede": "Your complaint will not affect your case.",
+      "steps": [
+        "page.name",
+        "page.email-address"
+      ],
+      "url": "/"
+    },
+    {
+      "_id": "page.name",
+      "_type": "page.singlequestion",
+      "components": [
+        {
+          "_id": "page.name--text.auto_name__1",
+          "_type": "text",
+          "label": "Full name",
+          "name": "full_name"
+        }
+      ],
+      "heading": "Your name",
+      "url": "/name"
+    },
+    {
+      "_id": "page.email-address",
+      "_type": "page.singlequestion",
+      "heading": "Email address",
+      "components": [
+        {
+          "_id": "page.email-address--email.auto_name__2",
+          "_type": "text",
+          "errors": {
+            "format": {},
+            "required": {
+              "any": "Enter an email address"
+            }
+          },
+          "label": "Your email address",
+          "name": "email_address",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "url": "/email-address"
+    }
+  ],
+  "locale": "en"
+}

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MetadataPresenter::Service do
   let(:service_metadata) do
     JSON.parse(
       File.read(
-        MetadataPresenter::Engine.root.join('spec', 'fixtures', 'service.json')
+        MetadataPresenter::Engine.root.join('spec', 'fixtures', 'version.json')
       )
     )
   end


### PR DESCRIPTION
## Add schemas to MetadataPresenter

The MetadataPresenter is fast becoming the most obvious place for holding things like the schemas and the default metadata that will be used by the fb-editor in the future. Having a single place for both of these allows us to make use of a single point for fixtures or perhaps a future generator.

This means that we will no longer have to juggle several different versions of metadata between the three apps that will be relying on them. The presenter is the single source of truth.

The one downside of this approach is that when the MetadataPresenter is added to the metadata-api, where schema validation occurs on the incoming requests, the latter will also have a copy of the views that it will never make use of.

## Validate schemas via the presenter

The MetadataPresenter will now also take care of schema validation. Any Form Builder app which installs the MetadataPresenter will now be able to validate any metadata it creates or receives in a consistent fashion.

## Added schemas for the start page and the single question page

Added schemas for the start page as well as the single question page.

Schema validation should now occur for page types as well.

## Add the service configuration schemas

The configuration for a given service takes the form of a service object, a meta object and an array of module objects (like save and return). The last of those we will not be moving in this PR.

Configuration is now an object that expects to have a service property and a meta property. The latter is the configuration for the service footer.

## Use Version fixture instead of Service fixture

The service fixture is the minimum metadata required for a creating a new service with the metadata-api. the version fixture is a fuller example of an actual form's metadata.