### PR TITLE
Use govuk_error_summary component

### DIFF
--- a/app/controllers/metadata_presenter/service_controller.rb
+++ b/app/controllers/metadata_presenter/service_controller.rb
@@ -1,5 +1,6 @@
 class MetadataPresenter::ServiceController < MetadataPresenter.parent_controller.constantize
   helper MetadataPresenter::ApplicationHelper
+  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   def start
     @page = service.start_page

--- a/app/models/metadata_presenter/metadata.rb
+++ b/app/models/metadata_presenter/metadata.rb
@@ -2,10 +2,11 @@ class MetadataPresenter::Metadata
   include ActiveModel::Conversion
   extend ActiveModel::Naming
 
-  attr_reader :metadata
+  attr_reader :metadata, :errors
 
   def initialize(metadata)
     @metadata = OpenStruct.new(metadata)
+    @errors = ActiveModel::Errors.new(self)
   end
 
   def id

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -5,7 +5,8 @@
           <%= @page.heading.html_safe %>
       </h1>
 
-      <%= form_for @page.id, url: reserved_answers_path(@page.url), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= form_for @page, url: reserved_answers_path(@page.url) do |f| %>
+        <%= f.govuk_error_summary %>
         <% @page.components.each do |component| %>
           <%= render partial: component, locals: { component: component, f: f } %>
         <% end %>


### PR DESCRIPTION
This should allow for the rendering of the errors summary list with links back to the individual element that triggered the error.

https://trello.com/c/Crwo6jqv/1124-validation-for-the-text-field-component