### PR TITLE
Set govuk publishing components environment variables

### DIFF
--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -1,3 +1,6 @@
+ENV['GOVUK_APP_DOMAIN'] = ''
+ENV['GOVUK_WEBSITE_ROOT'] = ''
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
GOVUK_APP_DOMAIN and  GOVUK_WEBSITE_ROOT are required by Plek which is a dependency of the govuk_publishing_components gem. This is used by govspeak, which is actually what we require.

Plek is not something we use but the fact they are not set is stopping apps that use the presenter from starting.

Temporarily set them until we find an alternative.