### PR TITLE
Add back links to pages

### DIFF
--- a/app/controllers/metadata_presenter/service_controller.rb
+++ b/app/controllers/metadata_presenter/service_controller.rb
@@ -28,6 +28,7 @@ class MetadataPresenter::ServiceController < MetadataPresenter.parent_controller
     @page = service.find_page(request.env['PATH_INFO'])
 
     if @page
+      @back_link = service.previous_page(current_page: @page)&.url
       render template: @page.template
     else
       render template: 'errors/404', status: 404

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -15,4 +15,8 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     current_page = find_page(from)
     pages[pages.index(current_page) + 1] if current_page.present?
   end
+
+  def previous_page(current_page:)
+    pages[pages.index(current_page) - 1] unless current_page == start_page
+  end
 end

--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -21,6 +21,10 @@
     <%= render template: 'metadata_presenter/header/show' %>
     <div class="govuk-width-container govuk-body-m">
       <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+      <% if @back_link %>
+        <a class="govuk-back-link" href="<%= @back_link %>">Back</a
+      <% end %>
+
         <%= yield %>
       </main>
     </div>

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -29,5 +29,9 @@ RSpec.describe MetadataPresenter::ServiceController, type: :controller do
       start_page_heading = JSON.parse(service_metadata)['pages'][0]['heading']
       expect(response.body).to include(start_page_heading)
     end
+
+    it 'has no back link' do
+      expect(response.body).not_to include('govuk-back-link')
+    end
   end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -56,4 +56,22 @@ RSpec.describe MetadataPresenter::Service do
       end
     end
   end
+
+  describe '#previous_page' do
+    context 'when previous page exists' do
+      it 'returns the previous page' do
+        current_page = service.find_page(service_metadata['pages'][1]['url'])
+        previous_page = service.previous_page(current_page: current_page)
+        expect(previous_page.id).to eq(service_metadata['pages'][0]['_id'])
+      end
+    end
+
+    context 'when previous page does not exists' do
+      it 'returns nil' do
+        current_page = service.find_page(service_metadata['pages'][0]['url'])
+        previous_page = service.previous_page(current_page: current_page)
+        expect(previous_page).to be(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds the govuk design system back links to all pages except the start page.

In the future the confirmation page will probably be the only other page that doesn't need a back link.

The logic for previous page is super simple at this point, based entirely upon the order of the page objects in the service's pages array.

In the future we will have to cater for conditional logic for pages therefore finding the previous page will get a lot more complicated.

No acceptance tests were changed in the making of this PR. This is because they make use of the dummy app. Currently the assets which the govuk frontend expects reside in the containing apps; ie. fb-runner and fb-editor.

As a result of this in order for the navigation specs to pass with these changes we need to delegate the layout to the presenter engine, as happens in the fb-runner. In doing that all the asset tags then need to be installed in the dummy app. This would result in a massive amount of duplication that we would have to keep up to date.

We are currently considering where these acceptance should live going forward.

https://trello.com/c/KSu2E2bP/1089-back-links