### PR TITLE
Check your answer/confirmation page

### DIFF
--- a/app/controllers/metadata_presenter/service_controller.rb
+++ b/app/controllers/metadata_presenter/service_controller.rb
@@ -31,6 +31,16 @@ class MetadataPresenter::ServiceController < MetadataPresenter.parent_controller
     end
   end
 
+  def confirmation
+    @page = service.confirmation_page
+
+    if @page
+      redirect_to @page.url
+    else
+      render template: 'errors/404', status: 404
+    end
+  end
+
   def back_link
     return if @page.blank?
 

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -23,4 +23,10 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
   def all_components
     pages.map(&:components).compact.flatten
   end
+
+  def confirmation_page
+    @confirmation_page ||= pages.find do |page|
+      page.type == 'page.confirmation'
+    end
+  end
 end

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -19,4 +19,8 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
   def previous_page(current_page:)
     pages[pages.index(current_page) - 1] unless current_page == start_page
   end
+
+  def all_components
+    pages.map(&:components).compact.flatten
+  end
 end

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-panel govuk-panel--confirmation" data-block-id="<%= @page.id %>" data-block-property="heading" data-block-property-class="govuk-panel__body:lede">
+  <h1 class="govuk-panel__title">
+    <%= @page.heading %>
+  </h1>
+
+  <% if @page.lede %>
+    <div class="govuk-panel__body">
+      <p><%= @page.lede %></p>
+    </div>
+  <% end %>
+</div>
+
+<% if @page.body %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="fb-body govuk-prose-scope" data-block-id="<%= @page.id %>" data-block-property="body">
+        <%= @page.body %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/metadata_presenter/page/summary.html.erb
+++ b/app/views/metadata_presenter/page/summary.html.erb
@@ -1,0 +1,63 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @page.section_heading.present? %>
+      <p class="govuk-caption-l fb-section-heading" data-block-id="<%= @page.id %>" data-block-property="section_heading">
+        <%= @page.section_heading %>
+      </p>
+    <% end %>
+
+    <% if @page.heading.present? %>
+      <h1 class="govuk-heading-xl" data-block-id="<%= @page.id %>" data-block-property="heading">
+        <%= @page.heading %>
+      </h1>
+    <% end %>
+
+    <% if @page.lede.present? %>
+      <p class="govuk-body-l" data-block-id="<%= @page.id %>" data-block-property="lede">
+        <%= @page.lede %>
+      </p>
+    <% end %>
+
+    <% if @page.body.present? %>
+      <div class="fb-body govuk-prose-scope" data-block-id="<%= @page.id %>" data-block-property="body">
+        <p><%= @page.body %></p>
+      </div>
+    <% end %>
+
+    <%= form_for @page, url: reserved_confirmation_path do |f| %>
+      <div data-block-id="page.summary.answers" data-block-type="answers">
+        <dl class="fb-block fb-block-answers govuk-summary-list">
+          <% @service.all_components.each do |component| %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                <%= component.label %>
+              </dt>
+
+              <dd class="govuk-summary-list__value">
+                <%= @user_data[component.name] %>
+              </dd>
+            </div>
+          <% end %>
+        </dl>
+      </div>
+
+      <% if @page.send_heading.present? %>
+        <h2 class="fb-send-heading govuk-heading-m" data-block-id="<%= @page.id %>" data-block-property="send_heading">
+          <%= @page.send_heading %>
+        </h2>
+      <% end %>
+
+      <% if @page.send_body.present? %>
+        <div class="fb-send-body" data-block-id="<%= @page.id %>" data-block-property="send_body">
+          <p>
+            <%= @page.send_body %>
+          </p>
+        </div>
+      <% end %>
+
+      <button data-prevent-double-click="true" class="fb-block fb-block-actions govuk-button" data-module="govuk-button" data-block-id="actions" data-block-type="actions">
+        Accept and send application
+      </button>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ MetadataPresenter::Engine.routes.draw do
   root to: 'service#start'
 
   post '/reserved/:page_url/answers', to: 'service#answers', as: :reserved_answers
+  post '/reserved/confirmation', to: 'service#confirmation', as: :reserved_confirmation
   match '*path', to: 'service#render_page', via: :all
 end

--- a/spec/fixtures/non_finished_service.json
+++ b/spec/fixtures/non_finished_service.json
@@ -47,9 +47,7 @@
       "steps": [
         "page.name",
         "page.email-address",
-        "page.parent_name",
-        "page.check-answers",
-        "page._confirmation"
+        "page.parent_name"
       ],
       "url": "/"
     },
@@ -119,25 +117,6 @@
       ],
       "heading": "Parent name",
       "url": "/parent-name"
-    },
-    {
-      "_id": "page._check-answers",
-      "_type": "page.summary",
-      "body": "Optional content",
-      "heading": "Review your answer",
-      "lede": "First paragraph",
-      "section_heading": "This section is optional",
-      "send_body": "By submitting this answer you confirm all your answers",
-      "send_heading": "Send your answer",
-      "url": "/check-answers"
-    },
-    {
-      "_id": "page._confirmation",
-      "_type": "page.confirmation",
-      "body": "You'll receive a confirmation email",
-      "heading": "Complaint sent",
-      "lede": "Optional lede",
-      "url": "/confirmation"
     }
   ],
   "locale": "en"

--- a/spec/fixtures/version.json
+++ b/spec/fixtures/version.json
@@ -47,7 +47,8 @@
       "steps": [
         "page.name",
         "page.email-address",
-        "page.parent_name"
+        "page.parent_name",
+        "page.check-answers"
       ],
       "url": "/"
     },
@@ -117,6 +118,17 @@
       ],
       "heading": "Parent name",
       "url": "/parent-name"
+    },
+    {
+      "_id": "page._check-answers",
+      "_type": "page.summary",
+      "body": "Optional content",
+      "heading": "Review your answer",
+      "lede": "First paragraph",
+      "section_heading": "This section is optional",
+      "send_body": "By submitting this answer you confirm all your answers",
+      "send_heading": "Send your answer",
+      "url": "/check-answers"
     }
   ],
   "locale": "en"

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -77,4 +77,10 @@ RSpec.describe MetadataPresenter::Service do
       )
     end
   end
+
+  describe '#confirmation_page' do
+    it 'returns the confirmation page for the service' do
+      expect(service.confirmation_page.type).to eq('page.confirmation')
+    end
+  end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -65,4 +65,16 @@ RSpec.describe MetadataPresenter::Service do
       end
     end
   end
+
+  describe '#all_components' do
+    let(:expected_components) do
+      ['full_name', 'email_address', 'parent_name']
+    end
+
+    it 'returns all components for the service' do
+      expect(service.all_components.map(&:name)).to include(
+        *expected_components
+      )
+    end
+  end
 end

--- a/spec/requests/service_spec.rb
+++ b/spec/requests/service_spec.rb
@@ -78,13 +78,63 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
     end
 
     context 'when next page does not exist' do
+      let(:service_metadata) do
+        JSON.parse(
+          File.read(
+            MetadataPresenter::Engine.root.join(
+              'spec',
+              'fixtures',
+              'non_finished_service.json'
+            )
+          )
+        )
+      end
+
       before do
+        expect(Rails.configuration).to receive(:service_metadata).and_return(service_metadata)
         post '/reserved/%2Fparent-name/answers',
           params: { answers: { parent_name: 'Test' } }
       end
 
       it 'returns not found' do
         expect(response.status).to be(404)
+      end
+    end
+  end
+
+  describe 'POST /confirmation' do
+    context 'when there is a confirmation in the metadata' do
+      before do
+        post '/reserved/confirmation'
+      end
+
+      it 'redirect to the confirmation' do
+        expect(response).to redirect_to('/confirmation')
+      end
+    end
+
+    context 'when there is no confirmation in the metadata' do
+      let(:service_metadata) do
+        JSON.parse(
+          File.read(
+            MetadataPresenter::Engine.root.join(
+              'spec',
+              'fixtures',
+              'non_finished_service.json'
+            )
+          )
+        )
+      end
+
+      before do
+        expect(Rails.configuration).to receive(:service_metadata).and_return(service_metadata)
+        post '/reserved/confirmation'
+      end
+
+      it 'returns not found' do
+        expect(response.body).to include(
+          "The page you were looking for doesn't exist."
+        )
       end
     end
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/Ik5mN0g6/1090-check-your-answers-page-based-on-user-answers)
[Trello card](https://trello.com/c/vfyjsnHF/1092-implement-a-basic-confirmation-page)

## Context

This PR adds the check your answer and confirmation page.

## Caveats

1. The check your answer doesn't have the "Change your answer" link because it is a separate card.
2. The confirmation page is a basic one without extra component.
