### PR TITLE
Add check your answers and confirmation schemas and default metadata

### DIFF
--- a/default_metadata/page/confirmation.json
+++ b/default_metadata/page/confirmation.json
@@ -1,0 +1,4 @@
+{
+  "_id": "page.confirmation",
+  "heading": "Required - Confirmation"
+}

--- a/default_metadata/page/summary.json
+++ b/default_metadata/page/summary.json
@@ -1,0 +1,6 @@
+{
+  "_id": "page.summary",
+  "heading": "Check your answers",
+  "send_heading": "Now send your application",
+  "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct."
+}

--- a/schemas/definition/page.content.json
+++ b/schemas/definition/page.content.json
@@ -1,0 +1,23 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/page/content",
+  "_name": "definition.page.content",
+  "title": "Content page definition",
+  "properties": {
+    "components": {
+      "accepts": [
+        "content"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.page"
+    }
+  ],
+  "required": [
+    "heading"
+  ],
+  "category": [
+    "contentPage"
+  ]
+}

--- a/schemas/page/confirmation.json
+++ b/schemas/page/confirmation.json
@@ -1,0 +1,35 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/page/confirmation",
+  "_name": "page.confirmation",
+  "title": "Confirmation",
+  "description": "Confirm to users that they’ve completed their answers",
+  "type": "object",
+  "properties": {
+    "_id": {
+      "const": "page.confirmation"
+    },
+    "_type": {
+      "const": "page.confirmation"
+    },
+    "heading": {
+      "multiline": true
+    },
+    "body": {
+      "multiline": true
+    },
+    "lede": {
+      "multiline": true
+    }
+  },
+  "required": [
+    "_id",
+    "_type",
+    "heading"
+  ],
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "$ref": "definition.page.content"
+    }
+  ]
+}

--- a/schemas/page/summary.json
+++ b/schemas/page/summary.json
@@ -1,0 +1,63 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/page/summary",
+  "_name": "page.summary",
+  "title": "Check answers",
+  "description": "Let users check and change their answers before submitting",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "page.summary"
+    },
+    "section_heading": {
+      "title": "Section heading",
+      "type": "string",
+      "description": "Section to display before the heading"
+    },
+    "heading": {
+      "type": "string",
+      "default": "Check your answers"
+    },
+    "lede": {
+      "title": "Lede",
+      "type": "string",
+      "description": "Content before the body"
+    },
+    "body": {
+      "title": "Body",
+      "type": "string",
+      "description": "Optional content before showing the summary"
+    },
+    "summary_of": {
+      "title": "Summary of",
+      "description": "Page/section that summary summarises"
+    },
+    "send_heading": {
+      "title": "Send heading",
+      "description": "Heading to display before accept and send button",
+      "type": "string",
+      "content": true,
+      "default": "Now send your application"
+    },
+    "send_body": {
+      "title": "Send content",
+      "description": "Content to display before accept and send button - use [markdown](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown) to format text or add hyperlinks",
+      "type": "string",
+      "content": true,
+      "multiline": true,
+      "default": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct."
+    }
+  },
+  "required": [
+    "_id",
+    "_type",
+    "heading",
+    "send_heading",
+    "send_body"
+  ],
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "$ref": "definition.page.form"
+    }
+  ]
+}


### PR DESCRIPTION
This adds the schemas and the default metadata required for the check your answers page and the confirmation page.

https://trello.com/c/Ik5mN0g6/1090-check-your-answers-page-based-on-user-answers
https://trello.com/c/vfyjsnHF/1092-implement-a-basic-confirmation-page

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>