### PR TITLE
Remove inline and summary errors

### DIFF
--- a/schemas/errors/errors.json
+++ b/schemas/errors/errors.json
@@ -7,10 +7,7 @@
     "error_strings": {
       "type": "object",
       "properties": {
-        "inline": {
-          "type": "string"
-        },
-        "summary": {
+        "any": {
           "type": "string"
         }
       }

--- a/schemas/validations/validations.json
+++ b/schemas/validations/validations.json
@@ -12,18 +12,6 @@
           "description": "Error message users see if their answer fails validation - write {control} to show the question in the message",
           "type": "string",
           "role": "error_string"
-        },
-        "inline": {
-          "title": "Input error",
-          "description": "Specific error message users see next to the input if their answer fails validation - only set if your input message absolutely must be different to that shown in the summary",
-          "type": "string",
-          "role": "error_string"
-        },
-        "summary": {
-          "title": "Summary error",
-          "description": "Specific error message users see at the top of a page if their answer fails validation - only set if your summary message absolutely must be different to that shown for the input",
-          "type": "string",
-          "role": "error_string"
         }
       }
     },


### PR DESCRIPTION
The team have decided to use the `any` error message for now.
We will not require the `inline` or the `summary` errors.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>