### PR TITLE
Feature/change your answer

### DIFF
--- a/app/controllers/metadata_presenter/application_controller.rb
+++ b/app/controllers/metadata_presenter/application_controller.rb
@@ -1,5 +1,0 @@
-module MetadataPresenter
-  class ApplicationController < ActionController::Base
-    protect_from_forgery with: :exception
-  end
-end

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -1,0 +1,8 @@
+module MetadataPresenter
+  class EngineController < MetadataPresenter.parent_controller.constantize
+    protect_from_forgery with: :exception
+
+    helper MetadataPresenter::ApplicationHelper
+    default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+  end
+end

--- a/app/controllers/metadata_presenter/service_controller.rb
+++ b/app/controllers/metadata_presenter/service_controller.rb
@@ -31,6 +31,11 @@ class MetadataPresenter::ServiceController < MetadataPresenter.parent_controller
     end
   end
 
+  def change_answer
+    session[:return_to_check_you_answer] = true
+    redirect_to params[:url]
+  end
+
   def confirmation
     @page = service.confirmation_page
 
@@ -52,7 +57,12 @@ class MetadataPresenter::ServiceController < MetadataPresenter.parent_controller
 
   def redirect_to_next_page
     save_user_data # method signature
-    next_page = service.next_page(from: params[:page_url])
+    next_page = if session[:return_to_check_you_answer].present?
+                  session[:return_to_check_you_answer] = nil
+                  service.pages.find { |page| page.type == 'page.summary' }
+                else
+                  service.next_page(from: params[:page_url])
+                end
 
     if next_page.present?
       redirect_to File.join(request.script_name, next_page.url)

--- a/app/controllers/metadata_presenter/service_controller.rb
+++ b/app/controllers/metadata_presenter/service_controller.rb
@@ -1,82 +1,85 @@
-class MetadataPresenter::ServiceController < MetadataPresenter.parent_controller.constantize
-  helper MetadataPresenter::ApplicationHelper
-  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
-
-  def start
-    @page = service.start_page
-    render template: @page.template
-  end
-
-  def answers
-    @page = MetadataPresenter::Page.new(service.find_page(params[:page_url]).metadata)
-
-    if @page.validate_answers(answers_params)
-      redirect_to_next_page
-    else
-      render_validation_error
-    end
-  end
-
-  def render_page
-    @user_data = load_user_data # method signature
-
-    # we need verify that the user can't jump pages??
-    #
-    @page = service.find_page(request.env['PATH_INFO'])
-
-    if @page
+module MetadataPresenter
+  class ServiceController < EngineController
+    def start
+      @page = service.start_page
       render template: @page.template
-    else
-      render template: 'errors/404', status: 404
     end
-  end
 
-  def change_answer
-    session[:return_to_check_you_answer] = true
-    redirect_to params[:url]
-  end
+    def answers
+      @page = MetadataPresenter::Page.new(service.find_page(params[:page_url]).metadata)
 
-  def confirmation
-    @page = service.confirmation_page
-
-    if @page
-      redirect_to @page.url
-    else
-      render template: 'errors/404', status: 404
+      if @page.validate_answers(answers_params)
+        redirect_to_next_page
+      else
+        render_validation_error
+      end
     end
-  end
 
-  def back_link
-    return if @page.blank?
+    def render_page
+      @user_data = load_user_data # method signature
 
-    @back_link ||= service.previous_page(current_page: @page)&.url
-  end
-  helper_method :back_link
+      # we need verify that the user can't jump pages??
+      #
+      @page = service.find_page(request.env['PATH_INFO'])
 
-  private
-
-  def redirect_to_next_page
-    save_user_data # method signature
-    next_page = if session[:return_to_check_you_answer].present?
-                  session[:return_to_check_you_answer] = nil
-                  service.pages.find { |page| page.type == 'page.summary' }
-                else
-                  service.next_page(from: params[:page_url])
-                end
-
-    if next_page.present?
-      redirect_to File.join(request.script_name, next_page.url)
-    else
-      render template: 'errors/404', status: 404
+      if @page
+        render template: @page.template
+      else
+        render template: 'errors/404', status: 404
+      end
     end
-  end
 
-  def render_validation_error
-    @user_data = answers_params
-    render template: @page.template, status: :unprocessable_entity
-  end
+    def change_answer
+      session[:return_to_check_you_answer] = true
+      redirect_to_page params[:url]
+    end
 
-  def answers_params
-    params[:answers] ? params[:answers].permit! : {}
+    def confirmation
+      @page = service.confirmation_page
+
+      if @page
+        redirect_to_page @page.url
+      else
+        render template: 'errors/404', status: 404
+      end
+    end
+
+    def back_link
+      return if @page.blank?
+
+      @back_link ||= service.previous_page(current_page: @page)&.url
+    end
+    helper_method :back_link
+
+    private
+
+    def redirect_to_next_page
+      save_user_data # method signature
+      next_page = NextPage.new(service).find(
+        session: session,
+        current_page_url: params[:page_url]
+      )
+
+      if next_page.present?
+        redirect_to_page next_page.url
+      else
+        render template: 'errors/404', status: 404
+      end
+    end
+
+    def render_validation_error
+      @user_data = answers_params
+      render template: @page.template, status: :unprocessable_entity
+    end
+
+    def answers_params
+      params[:answers] ? params[:answers].permit! : {}
+    end
+
+    private
+
+    def redirect_to_page(url)
+      redirect_to File.join(request.script_name, url)
+    end
   end
 end

--- a/app/models/metadata_presenter/next_page.rb
+++ b/app/models/metadata_presenter/next_page.rb
@@ -1,0 +1,18 @@
+module MetadataPresenter
+  class NextPage
+    attr_reader :service
+
+    def initialize(service)
+      @service = service
+    end
+
+    def find(session:, current_page_url:)
+      if session[:return_to_check_you_answer].present?
+        session[:return_to_check_you_answer] = nil
+        service.pages.find { |page| page.type == 'page.summary' }
+      else
+        service.next_page(from: current_page_url)
+      end
+    end
+  end
+end

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -20,10 +20,6 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     pages[pages.index(current_page) - 1] unless current_page == start_page
   end
 
-  def all_components
-    pages.map(&:components).compact.flatten
-  end
-
   def confirmation_page
     @confirmation_page ||= pages.find do |page|
       page.type == 'page.confirmation'

--- a/app/views/metadata_presenter/page/summary.html.erb
+++ b/app/views/metadata_presenter/page/summary.html.erb
@@ -27,16 +27,26 @@
     <%= form_for @page, url: reserved_confirmation_path do |f| %>
       <div data-block-id="page.summary.answers" data-block-type="answers">
         <dl class="fb-block fb-block-answers govuk-summary-list">
-          <% @service.all_components.each do |component| %>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                <%= component.label %>
-              </dt>
+          <% @service.pages.each do |page| %>
+            <% Array(page.components).each do |component| %>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  <%= component.label %>
+                </dt>
 
-              <dd class="govuk-summary-list__value">
-                <%= @user_data[component.name] %>
-              </dd>
-            </div>
+                <dd class="govuk-summary-list__value">
+                  <%= @user_data[component.name] %>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                <%= link_to(change_answer_path(url: page.url),
+                       class: 'govuk-link',
+                       method: :post) do %>
+                       Change<span class="govuk-visually-hidden"> Your answer for <%= component.label %></span>
+                  <% end %>
+                  </a>
+                </dd>
+              </div>
+            <% end %>
           <% end %>
         </dl>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ MetadataPresenter::Engine.routes.draw do
 
   post '/reserved/:page_url/answers', to: 'service#answers', as: :reserved_answers
   post '/reserved/confirmation', to: 'service#confirmation', as: :reserved_confirmation
+  post '/reserved/change-answer', to: 'service#change_answer', as: :change_answer
   match '*path', to: 'service#render_page', via: :all
 end

--- a/lib/metadata_presenter.rb
+++ b/lib/metadata_presenter.rb
@@ -1,8 +1,4 @@
-require "metadata_presenter/engine"
-require "govuk_design_system_formbuilder"
-require "json-schema"
+require 'metadata_presenter/engine'
+require 'govuk_design_system_formbuilder'
+require 'json-schema'
 require 'kramdown'
-
-module MetadataPresenter
-  # Your code goes here...
-end

--- a/spec/models/next_page_spec.rb
+++ b/spec/models/next_page_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe MetadataPresenter::NextPage do
+  subject(:next_page) { described_class.new(service) }
+
+  describe '#find' do
+    subject(:result) do
+      next_page.find(
+        session: session,
+        current_page_url: current_page_url
+      )
+    end
+
+    context 'when user should return to check your answer' do
+      let(:session) { { return_to_check_you_answer: true } }
+      let(:current_page_url) { '' }
+
+      it 'returns check your answer page' do
+        expect(result).to eq(
+          MetadataPresenter::Page.new(_id: 'page._check-answers')
+        )
+      end
+
+      it 'set the session as nil' do
+        result
+        expect(session).to eq({ return_to_check_you_answer: nil })
+      end
+    end
+
+    context 'when there is a next page' do
+      let(:session) { { return_to_check_you_answer: nil } }
+      let(:current_page_url) { '/name' }
+
+      it 'returns next page in sequence' do
+        expect(result).to eq(
+          MetadataPresenter::Page.new(_id: 'page.email-address')
+        )
+      end
+    end
+
+    context 'when there is no next page' do
+      let(:service_metadata) do
+        metadata_fixture(:non_finished_service)
+      end
+      let(:session) { {} }
+      let(:current_page_url) { '/parent-name' }
+
+      it 'returns nil' do
+        expect(result).to be(nil)
+      end
+    end
+  end
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -66,18 +66,6 @@ RSpec.describe MetadataPresenter::Service do
     end
   end
 
-  describe '#all_components' do
-    let(:expected_components) do
-      ['full_name', 'email_address', 'parent_name']
-    end
-
-    it 'returns all components for the service' do
-      expect(service.all_components.map(&:name)).to include(
-        *expected_components
-      )
-    end
-  end
-
   describe '#confirmation_page' do
     it 'returns the confirmation page for the service' do
       expect(service.confirmation_page.type).to eq('page.confirmation')

--- a/spec/requests/service_spec.rb
+++ b/spec/requests/service_spec.rb
@@ -138,4 +138,18 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
       end
     end
   end
+
+  describe 'POST /reserved/change-answer' do
+    before do
+      post '/reserved/change-answer', params: { url: '/name' }
+    end
+
+    it 'sets the session to return to check your answer page' do
+      expect(session[:return_to_check_you_answer]).to be_truthy
+    end
+
+    it 'redirect to the url' do
+      expect(response).to redirect_to('/name')
+    end
+  end
 end

--- a/spec/support/helpers/test_helper.rb
+++ b/spec/support/helpers/test_helper.rb
@@ -4,9 +4,22 @@ module TestHelper
   end
 
   def service_metadata
+    metadata_fixture(:version)
     JSON.parse(
       File.read(
         MetadataPresenter::Engine.root.join('spec', 'fixtures', 'version.json')
+      )
+    )
+  end
+
+  def metadata_fixture(fixture_name)
+    JSON.parse(
+      File.read(
+        MetadataPresenter::Engine.root.join(
+          'spec',
+          'fixtures',
+          "#{fixture_name}.json"
+        )
       )
     )
   end


### PR DESCRIPTION
## Context

This PR adds the possibility to change your answer from the check your answers page.

## Considerations on terminology

 We called "check your answer" but the metadata is defined as "page.summary". 

About terminology what should we use?
1. Check your answer
2. Page summary
3. Just summary
4. MetaSummary 3000

## Considerations on check your answers page

In order to know the page URL that the user should change we had to change the summary view to loop through each page and each component from each page. This can change when we start to add conditional logic.

## Common Considerations

Just renamed ApplicationController to EngineController to avoid any clashes with naming. 
Create a redirect_to_page because we found bugs on the editor due to the fact that `redirect_to '/some-url'` could clash with editor routes. The `redirect_to_page` uses the `script_name` to avoid those clashes.


