### PR TITLE
Docs/create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ spec/dummy/.sass-cache
 .DS_Store
 
 coverage/
+doc/
+.yardoc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.25)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -221,6 +222,7 @@ DEPENDENCIES
   simplecov-console
   site_prism
   sqlite3
+  yard
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ An example of implementation:
    end
  end
 ```
+
+## Generate documentation
+
+Run `rake doc` and open the doc/index.html

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # MetadataPresenter
-Short description and motivation.
 
-## Usage
-How to use my plugin.
+Rails engine responsible for rendering the MoJ Form Builder metadata into
+GOV.UK design system components.
 
 ## Installation
-Add this line to your application's Gemfile:
 
 ```ruby
 gem 'metadata_presenter'
 ```
 
 And then execute:
+
 ```bash
 $ bundle
 ```
@@ -21,8 +20,45 @@ Or install it yourself as:
 $ gem install metadata_presenter
 ```
 
-## Contributing
-Contribution directions go here.
+## Setup & Mount
 
-## License
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+To mount the application:
+
+```ruby
+  mount MetadataPresenter::Engine => '/'
+```
+
+Or if you are using for another route (like the MoJ Editor as preview feature):
+
+```ruby
+  mount MetadataPresenter::Engine => '/preview', as: :preview
+```
+
+The MetadataPresenter controllers inherits from your main
+`::ApplicationController` as default but you can overwrite if you need:
+
+```ruby
+  MetadataPresenter.parent_controller = '::MyAwesomeController'
+```
+
+The application that you mount requires to save and load user data from some
+store (session or a backend API or direct to a database). In order to do
+that you need to write the following methods in your controller:
+
+1. save_user_data
+2. load_user_data
+
+The user answers can be accessed via `params[:answers]`.
+
+An example of implementation:
+```ruby
+ class MyAwesomeController
+   def save_user_data
+     session[:user_data] = params[:answers]
+   end
+
+   def load_user_data
+     session[:user_data]
+   end
+ end
+```

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,11 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
+require 'yard'
+YARD::Rake::YardocTask.new(:doc) do |yardoc|
+  yardoc.files = ['app/**/*.rb', 'lib/**/*.rb']
+end
+
 task default: :rspec
 
 APP_RAKEFILE = File.expand_path("spec/dummy/Rakefile", __dir__)

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kramdown', '>= 2.3.0'
   spec.add_dependency 'govuk_design_system_formbuilder', '>= 2.1.5'
   spec.add_dependency 'json-schema', '>= 2.8.1'
+
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rspec-rails'
@@ -28,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'site_prism'
   spec.add_development_dependency 'simplecov-console'
+  spec.add_development_dependency 'yard'
 end

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -1,17 +1,15 @@
 $:.push File.expand_path('lib', __dir__)
 
-# Maintain your gem's version:
 require 'metadata_presenter/version'
 
-# Describe your gem and declare its dependencies:
 Gem::Specification.new do |spec|
   spec.name        = 'metadata_presenter'
   spec.version     = MetadataPresenter::VERSION
-  spec.authors     = ["Tomas D'Stefano"]
-  spec.email       = ["tomas_stefano@successoft.com"]
-  spec.homepage    = 'http://www.example.com'
-  spec.summary     = 'Summary of MetadataPresenter.'
-  spec.description = 'Description of Fb::Metadata::Presenter.'
+  spec.authors     = ["MoJ Online"]
+  spec.email       = ["moj-online@digital.justice.gov.uk"]
+  spec.homepage    = 'https://moj-online.service.justice.gov.uk'
+  spec.summary     = 'Service Metadata Presenter'
+  spec.description = 'Service Metadata Presenter for the Form Builder product'
   spec.license     = 'MIT'
 
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']


### PR DESCRIPTION
## Context

This PR adds documentation to the project:

1. Readme
2. Yard as documentation generator for the gem.

I documented the base validator as example but since the whole gem has the public interface we should document more.
I also added the instructions in the Readme for generating the docs and to use the gem.