### PR TITLE
Allow optional fields with additional validations

### DIFF
--- a/app/validators/metadata_presenter/validate_answers.rb
+++ b/app/validators/metadata_presenter/validate_answers.rb
@@ -31,7 +31,18 @@ module MetadataPresenter
     def component_validations(component)
       return [] if component.validation.blank?
 
-      component.validation.reject { |_,value| value.blank? }.keys
+      component.validation.reject do |_, value|
+        value.blank? ||
+        (optional_question?(component) && question_not_answered?)
+      end.keys
+    end
+
+    def optional_question?(component)
+      component.validation['required'] == false
+    end
+
+    def question_not_answered?
+      answers.values.any?(&:blank?)
     end
   end
 end

--- a/spec/fixtures/version.json
+++ b/spec/fixtures/version.json
@@ -113,7 +113,9 @@
           "label": "Parent name",
           "name": "parent_name",
           "validation": {
-            "required": false
+            "required": false,
+            "max_length": 10,
+            "min_length": 2
           }
         }
       ],

--- a/spec/validators/validate_answers_spec.rb
+++ b/spec/validators/validate_answers_spec.rb
@@ -14,12 +14,29 @@ RSpec.describe MetadataPresenter::ValidateAnswers do
       end
     end
 
-    context 'when validation are false in metadata' do
+    context 'when validation required = false in metadata' do
       let(:page) { service.find_page('/parent-name') }
-      let(:answers) { { 'parent_name' => '' } }
 
-      it 'returns true' do
-        expect(validate_answers).to be_valid
+      context 'when no answer is provided' do
+        let(:answers) { { 'parent_name' => '' } }
+
+        it 'does not attempt any validations' do
+          expect_any_instance_of(MetadataPresenter::RequiredValidator).not_to receive(:invalid_answer?)
+          expect_any_instance_of(MetadataPresenter::MinLengthValidator).not_to receive(:invalid_answer?)
+          expect_any_instance_of(MetadataPresenter::MaxLengthValidator).not_to receive(:invalid_answer?)
+          expect(validate_answers).to be_valid
+        end
+      end
+
+      context 'when an answer is provided' do
+        let(:answers) { { 'parent_name' => 'Grogu' } }
+
+        it 'should validate the answer' do
+          expect_any_instance_of(MetadataPresenter::RequiredValidator).not_to receive(:invalid_answer?)
+          expect_any_instance_of(MetadataPresenter::MinLengthValidator).to receive(:invalid_answer?)
+          expect_any_instance_of(MetadataPresenter::MaxLengthValidator).to receive(:invalid_answer?)
+          expect(validate_answers).to be_valid
+        end
       end
     end
 
@@ -31,7 +48,7 @@ RSpec.describe MetadataPresenter::ValidateAnswers do
       end
     end
 
-    context 'validates from metadata' do
+    context 'validates form metadata' do
       let(:answers) { {} }
 
       before do


### PR DESCRIPTION
In scenarios where the question is optional and it is answered then additional validations should happen. If the question is not answered then additional validations should not happen.

The tests for this rely on the the `version.json` fixture `parent-name` page component being optional (required: false) but also having validations for minimum and maximum length. Therefore a user should be allowed to progress through the form without answering the question, however should they provide an answer, only then validate.

https://trello.com/c/XEuGMQnV/1156-bug-allow-optional-fields-with-other-validations

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>