### PR TITLE
Change check your answer link to a GET verb

### DIFF
--- a/app/views/metadata_presenter/page/summary.html.erb
+++ b/app/views/metadata_presenter/page/summary.html.erb
@@ -38,9 +38,10 @@
                   <%= @user_data[component.name] %>
                 </dd>
                 <dd class="govuk-summary-list__actions">
-                <%= link_to(change_answer_path(url: page.url),
-                       class: 'govuk-link',
-                       method: :post) do %>
+                <%= link_to(
+                      change_answer_path(url: page.url),
+                      class: 'govuk-link'
+                    ) do %>
                        Change<span class="govuk-visually-hidden"> Your answer for <%= component.label %></span>
                   <% end %>
                   </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ MetadataPresenter::Engine.routes.draw do
 
   post '/reserved/:page_url/answers', to: 'answers#create', as: :reserved_answers
   post '/reserved/submissions', to: 'submissions#create', as: :reserved_submissions
-  post '/reserved/change-answer', to: 'change_answer#create', as: :change_answer
+  get '/reserved/change-answer', to: 'change_answer#create', as: :change_answer
   match '*path', to: 'pages#show', via: :all
 end

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -127,9 +127,9 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
     end
   end
 
-  describe 'POST /reserved/change-answer' do
+  describe 'GET /reserved/change-answer' do
     before do
-      post '/reserved/change-answer', params: { url: '/name' }
+      get '/reserved/change-answer', params: { url: '/name' }
     end
 
     it 'sets the session to return to check your answer page' do


### PR DESCRIPTION
[Trello card](https://trello.com/c/Hmf6gF0b/1163-fix-invalidauthenticitytoken-error-in-runner)

## Context

To have a link with a post in the check your answer page,  it raises an error in CI about Autenticity token because is a post request without any token.

Changing to a GET request this problem doesn't exist.