### PR TITLE
Update start page default metadata

### DIFF
--- a/default_metadata/service/base.json
+++ b/default_metadata/service/base.json
@@ -1,15 +1,15 @@
 {
   "_id": "service.base",
   "_type": "service.base",
-  "service_name": "Service name goes here",
+  "service_name": "Service name",
   "configuration": {},
   "pages": [
     {
       "_id": "page.start",
       "_type": "page.start",
-      "heading": "This is your start page heading",
-      "body": "**This is the main content section of your start page**\r\n\r\n[Edit this page](/edit) with content for your own service.\r\n\r\n## Adding more content\r\n\r\nYou can add multiple headings, links and paragraphs - all in this one content section.\r\n\r\nUse [markdown](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown) to format headings, bullet lists and links.",
+      "heading": "Service name goes here",
       "lede": "This is your start page first paragraph. You can only have one paragraph here.",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
       "steps": [],
       "url": "/"
     }

--- a/fixtures/non_finished_service.json
+++ b/fixtures/non_finished_service.json
@@ -2,15 +2,12 @@
   "_id": "service.base",
   "_type": "service.base",
   "service_id": "d243f5c0-e8a2-4b13-982c-7b5f3fa128cf",
-  "service_name": "Main fixture to test Form builder",
+  "service_name": "Service name",
   "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
   "configuration": {
     "service": {
       "_id": "config.service",
-      "_type": "config.service",
-      "homepage_url": "https://www.gov.uk",
-      "service_email_address": "moj-online@digital.justice.gov.uk",
-      "service_url": "page.start"
+      "_type": "config.service"
     },
     "meta": {
       "_id": "config.meta",
@@ -41,9 +38,9 @@
     {
       "_id": "page.start",
       "_type": "page.start",
-      "body": "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
-      "heading": "Complain about a court or tribunal",
-      "lede": "Your complaint will not affect your case.",
+      "heading": "Service name goes here",
+      "lede": "This is your start page first paragraph. You can only have one paragraph here.",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
       "steps": [
         "page.name",
         "page.email-address",

--- a/fixtures/service.json
+++ b/fixtures/service.json
@@ -1,15 +1,12 @@
 {
   "_id": "service.base",
   "_type": "service.base",
-  "service_name": "Complain about a court or tribunal",
+  "service_name": "Service name",
   "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
   "configuration": {
     "service": {
       "_id": "config.service",
-      "_type": "config.service",
-      "homepage_url": "https://www.gov.uk",
-      "service_email_address": "moj-online@digital.justice.gov.uk",
-      "service_url": "page.start"
+      "_type": "config.service"
     },
     "meta": {
       "_id": "config.meta",
@@ -40,9 +37,9 @@
     {
       "_id": "page.start",
       "_type": "page.start",
-      "body": "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
-      "heading": "Complain about a court or tribunal",
-      "lede": "Your complaint will not affect your case.",
+      "heading": "Service name goes here",
+      "lede": "Use this service to:",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
       "steps": [],
       "url": "/"
     }

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -2,15 +2,12 @@
   "_id": "service.base",
   "_type": "service.base",
   "service_id": "d243f5c0-e8a2-4b13-982c-7b5f3fa128cf",
-  "service_name": "Main fixture to test Form builder",
+  "service_name": "Service name",
   "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
   "configuration": {
     "service": {
       "_id": "config.service",
-      "_type": "config.service",
-      "homepage_url": "https://www.gov.uk",
-      "service_email_address": "moj-online@digital.justice.gov.uk",
-      "service_url": "page.start"
+      "_type": "config.service"
     },
     "meta": {
       "_id": "config.meta",
@@ -41,9 +38,9 @@
     {
       "_id": "page.start",
       "_type": "page.start",
-      "body": "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
-      "heading": "Complain about a court or tribunal",
-      "lede": "Your complaint will not affect your case.",
+      "heading": "Service name goes here",
+      "lede": "This is your start page first paragraph. You can only have one paragraph here.",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
       "steps": [
         "page.name",
         "page.email-address",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
This  just updates the content of the default metadata to match the example in the [Design System](https://design-system.service.gov.uk/patterns/start-pages/).

Also update the fixtures to match and remove some of the additional properties from the configuration that is no longer part of the default metadata.