### PR TITLE
Check Answers

### DIFF
--- a/app/models/metadata_presenter/next_page.rb
+++ b/app/models/metadata_presenter/next_page.rb
@@ -9,7 +9,7 @@ module MetadataPresenter
     def find(session:, current_page_url:)
       if session[:return_to_check_you_answer].present?
         session[:return_to_check_you_answer] = nil
-        service.pages.find { |page| page.type == 'page.summary' }
+        service.pages.find { |page| page.type == 'page.checkanswers' }
       else
         service.next_page(from: current_page_url)
       end

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -25,7 +25,7 @@
     <% end %>
 
     <%= form_for @page, url: reserved_submissions_path do |f| %>
-      <div data-block-id="page.summary.answers" data-block-type="answers">
+      <div data-block-id="page.checkanswers.answers" data-block-type="answers">
         <dl class="fb-block fb-block-answers govuk-summary-list">
           <% @service.pages.each do |page| %>
             <% Array(page.components).each do |component| %>

--- a/default_metadata/page/checkanswers.json
+++ b/default_metadata/page/checkanswers.json
@@ -1,0 +1,8 @@
+{
+  "_id": "page.checkanswers",
+  "_type": "page.checkanswers",
+  "heading": "Check your answers",
+  "send_heading": "Now send your application",
+  "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+  "components": []
+}

--- a/default_metadata/page/summary.json
+++ b/default_metadata/page/summary.json
@@ -1,7 +1,0 @@
-{
-  "_id": "page.summary",
-  "_type": "page.summary",
-  "heading": "Check your answers",
-  "send_heading": "Now send your application",
-  "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct."
-}

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -122,7 +122,7 @@
     },
     {
       "_id": "page._check-answers",
-      "_type": "page.summary",
+      "_type": "page.checkanswers",
       "body": "Optional content",
       "heading": "Review your answer",
       "lede": "First paragraph",

--- a/schemas/page/checkanswers.json
+++ b/schemas/page/checkanswers.json
@@ -1,12 +1,12 @@
 {
-  "$id": "http://gov.uk/schema/v1.0.0/page/summary",
-  "_name": "page.summary",
+  "$id": "http://gov.uk/schema/v1.0.0/page/checkanswers",
+  "_name": "page.checkanswers",
   "title": "Check answers",
   "description": "Let users check and change their answers before submitting",
   "type": "object",
   "properties": {
     "_type": {
-      "const": "page.summary"
+      "const": "page.checkanswers"
     },
     "section_heading": {
       "title": "Section heading",


### PR DESCRIPTION
We have decided to change the Check Your Answers page schema from 'summary' to 'checkanswers'.
This aligns better with the GOVUK design systems: https://design-system.service.gov.uk/patterns/check-answers/

I have also added an empty array value for the components key in the default metadata as it is possible to add components into the check your answers page.

This change will help set the foundation for the story: https://trello.com/c/zp9OuUox/1196-backend-check-your-answers-page

This PR will need to be merged to allow the runner to work.