### PR TITLE
Use UUID in page path

### DIFF
--- a/app/controllers/metadata_presenter/pages_controller.rb
+++ b/app/controllers/metadata_presenter/pages_controller.rb
@@ -2,7 +2,7 @@ module MetadataPresenter
   class PagesController < EngineController
     def show
       @user_data = load_user_data # method signature
-      @page ||= service.find_page(request.env['PATH_INFO'])
+      @page ||= service.find_page_by_url(request.env['PATH_INFO'])
 
       if @page
         render template: @page.template

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -6,6 +6,10 @@ module MetadataPresenter
       ValidateAnswers.new(page: self, answers: answers).valid?
     end
 
+    def uuid
+      _uuid
+    end
+
     def ==(other)
       id == other.id if other.respond_to? :id
     end

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -7,12 +7,16 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     pages.first
   end
 
-  def find_page(path)
-    pages.find { |page| page.url == path }
+  def find_page_by_url(url)
+    pages.find { |page| page.url == url }
+  end
+
+  def find_page_by_uuid(uuid)
+    pages.find { |page| page.uuid == uuid }
   end
 
   def next_page(from:)
-    current_page = find_page(from)
+    current_page = find_page_by_url(from)
     pages[pages.index(current_page) + 1] if current_page.present?
   end
 

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -5,7 +5,7 @@
           <%= @page.heading.html_safe %>
       </h1>
 
-      <%= form_for @page, url: reserved_answers_path(@page.url) do |f| %>
+      <%= form_for @page, url: @page.url, method: :post do |f| %>
         <%= f.govuk_error_summary %>
         <% @page.components.each do |component| %>
           <%= render partial: component, locals: { component: component, f: f } %>

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -25,7 +25,7 @@
         </p>
       <%- end %>
 
-      <%= form_tag(reserved_answers_path(@page.url), method: :post) do %>
+      <%= form_tag(@page.url, method: :post) do %>
         <button <%= 'disabled' if editable? %> class='govuk-button govuk-button--start govuk-!-margin-top-2'>
         Start
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">

--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -1,33 +1,13 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "05100c0eaef79ac7502aceca55479b0fec62a889d68981ffdab16ad479e61106",
-      "check_name": "Render",
-      "message": "Render path contains request value",
-      "file": "app/controllers/metadata_presenter/pages_controller.rb",
-      "line": 8,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(template => service.find_page(request.env[\"PATH_INFO\"]).template, {})",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "MetadataPresenter::PagesController",
-        "method": "show"
-      },
-      "user_input": "request.env[\"PATH_INFO\"]",
-      "confidence": "Weak",
-      "note": "Necessary for now in order to find the next page"
-    },
-    {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
       "fingerprint": "8f7ae8aee6aaa43ea7b1220c67d3cbe0a1053bf56a11245026c3ab88eecedeb9",
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/controllers/metadata_presenter/answers_controller.rb",
-      "line": 39,
+      "line": 42,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params[:answers].permit!",
       "render_path": null,
@@ -38,9 +18,29 @@
       },
       "user_input": null,
       "confidence": "Medium",
-      "note": "These are for user answers for forms. Each form has custom answers the keys for which we cannot know in advance"
+      "note": "This is necessary because we do not know what attribute name the service owner is going to use in their forms."
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "a93c4786cc5d333eb509d48dc4da39d03883d947cbc973997236bdd7b74daead",
+      "check_name": "Render",
+      "message": "Render path contains request value",
+      "file": "app/controllers/metadata_presenter/pages_controller.rb",
+      "line": 8,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(template => service.find_page_by_url(request.env[\"PATH_INFO\"]).template, {})",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "MetadataPresenter::PagesController",
+        "method": "show"
+      },
+      "user_input": "request.env[\"PATH_INFO\"]",
+      "confidence": "Weak",
+      "note": "This is because we are not rendering the paths based on the params but rather on the metadata."
     }
   ],
-  "updated": "2020-12-30 11:00:36 +0000",
+  "updated": "2021-01-25 16:32:59 +0000",
   "brakeman_version": "4.10.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 MetadataPresenter::Engine.routes.draw do
   root to: 'service#start'
 
-  post '/reserved/:page_url/answers', to: 'answers#create', as: :reserved_answers
   post '/reserved/submissions', to: 'submissions#create', as: :reserved_submissions
   get '/reserved/change-answer', to: 'change_answer#create', as: :change_answer
+
+  post '/', to: 'answers#create'
+  match '*path', to: 'answers#create', via: :post
   match '*path', to: 'pages#show', via: :all
 end

--- a/default_metadata/page/start.json
+++ b/default_metadata/page/start.json
@@ -1,0 +1,10 @@
+{
+  "_id": "page.start",
+  "_type": "page.start",
+  "heading": "Service name goes here",
+  "lede": "This is your start page first paragraph. You can only have one paragraph here.",
+  "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+  "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally.",
+  "steps": [],
+  "url": "/"
+}

--- a/default_metadata/service/base.json
+++ b/default_metadata/service/base.json
@@ -3,17 +3,6 @@
   "_type": "service.base",
   "service_name": "Service name",
   "configuration": {},
-  "pages": [
-    {
-      "_id": "page.start",
-      "_type": "page.start",
-      "heading": "Service name goes here",
-      "lede": "This is your start page first paragraph. You can only have one paragraph here.",
-      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
-      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally.",
-      "steps": [],
-      "url": "/"
-    }
-  ],
+  "pages": [],
   "locale": "en"
 }

--- a/fixtures/service.json
+++ b/fixtures/service.json
@@ -35,6 +35,7 @@
   },
   "pages": [
     {
+      "_uuid": "9626b2e9-5ef0-4070-8331-ac55151b22c4",
       "_id": "page.start",
       "_type": "page.start",
       "heading": "Service name goes here",

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -36,6 +36,7 @@
   },
   "pages": [
     {
+      "_uuid": "fa391697-ae82-4416-adc3-3433e54ce535",
       "_id": "page.start",
       "_type": "page.start",
       "heading": "Service name goes here",
@@ -52,6 +53,7 @@
       "url": "/"
     },
     {
+      "_uuid": "847c4a0c-1c5f-4391-8847-42c8d82f1d0b",
       "_id": "page.name",
       "_type": "page.singlequestion",
       "components": [
@@ -71,6 +73,7 @@
       "url": "/name"
     },
     {
+      "_uuid": "ccf49acb-ad33-4fd3-8a7e-f0594b86cc96",
       "_id": "page.email-address",
       "_type": "page.singlequestion",
       "heading": "Email address",
@@ -102,6 +105,7 @@
       "url": "/email-address"
     },
     {
+      "_uuid": "7b748584-100e-4d81-a54a-5049190136cc",
       "_id": "page.parent_name",
       "_type": "page.singlequestion",
       "components": [
@@ -121,6 +125,7 @@
       "url": "/parent-name"
     },
     {
+      "_uuid": "e819d0c2-7062-4997-89cf-44d26d098404",
       "_id": "page._check-answers",
       "_type": "page.checkanswers",
       "body": "Optional content",
@@ -132,6 +137,7 @@
       "url": "/check-answers"
     },
     {
+      "_uuid": "b238a22f-c180-48d0-a7d9-8aad2036f1f2",
       "_id": "page._confirmation",
       "_type": "page.confirmation",
       "body": "You'll receive a confirmation email",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/schemas/definition/page.json
+++ b/schemas/definition/page.json
@@ -4,6 +4,10 @@
   "id_seed": "url",
   "title": "Page definition",
   "properties": {
+    "_uuid": {
+      "title": "Unique identifier of the page",
+      "description": "Used internally in the editor and the runner."
+    },
     "url": {
       "title": "URL",
       "description": "The page’s relative url - it must not contain any spaces",
@@ -95,6 +99,7 @@
     }
   ],
   "required": [
+    "_uuid",
     "url"
   ],
   "category": [

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe MetadataPresenter::Page do
     end
   end
 
+  describe '#uuid' do
+    it 'returns _uuid attribute' do
+      expect(
+        described_class.new(_uuid: 'kylo-ren').uuid
+      ).to eq('kylo-ren')
+    end
+  end
+
   describe '#to_partial_path' do
     subject(:page) { described_class.new(_type: 'page.singlequestion') }
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MetadataPresenter::Service do
   describe '#find_page' do
     it 'finds the correct page' do
       path = service_metadata['pages'][1]['url']
-      page = service.find_page(path)
+      page = service.find_page_by_url(path)
       expect(page.id).to eq(service_metadata['pages'][1]['_id'])
     end
   end
@@ -51,7 +51,7 @@ RSpec.describe MetadataPresenter::Service do
   describe '#previous_page' do
     context 'when previous page exists' do
       it 'returns the previous page' do
-        current_page = service.find_page(service_metadata['pages'][1]['url'])
+        current_page = service.find_page_by_url(service_metadata['pages'][1]['url'])
         previous_page = service.previous_page(current_page: current_page)
         expect(previous_page.id).to eq(service_metadata['pages'][0]['_id'])
       end
@@ -59,7 +59,7 @@ RSpec.describe MetadataPresenter::Service do
 
     context 'when previous page does not exists' do
       it 'returns nil' do
-        current_page = service.find_page(service_metadata['pages'][0]['url'])
+        current_page = service.find_page_by_url(service_metadata['pages'][0]['url'])
         previous_page = service.previous_page(current_page: current_page)
         expect(previous_page).to be(nil)
       end

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -49,10 +49,10 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
     end
   end
 
-  describe 'POST /reserved/%2Fname/answers' do
+  describe 'POST to page URL' do
     context 'when valid' do
       before do
-        post '/reserved/%2Fname/answers',
+        post '/name',
           params: { answers: { full_name: 'Mithrandir' } }
       end
 
@@ -63,7 +63,7 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
 
     context 'when invalid' do
       before do
-        post '/reserved/%2Fname/answers',
+        post '/name',
           params: { answers: { } }
       end
 
@@ -86,11 +86,21 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
 
       before do
         expect(Rails.configuration).to receive(:service_metadata).and_return(service_metadata)
-        post '/reserved/%2Fparent-name/answers',
+        post '/parent-name',
           params: { answers: { parent_name: 'Test' } }
       end
 
       it 'returns not found' do
+        expect(response.status).to be(404)
+      end
+    end
+
+    context 'when URL does not exist' do
+      before do
+        post '/non-existent-url'
+      end
+
+      it 'should return a 404' do
         expect(response.status).to be(404)
       end
     end

--- a/spec/validators/base_validator_spec.rb
+++ b/spec/validators/base_validator_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe MetadataPresenter::BaseValidator do
   subject(:validator) do
     described_class.new(page: page, answers: answers, component: component)
   end
-  let(:page) { service.find_page('/name') }
+  let(:page) { service.find_page_by_url('/name') }
   let(:answers) { {} }
   let(:component) { page.components.first }
 

--- a/spec/validators/max_length_validator_spec.rb
+++ b/spec/validators/max_length_validator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MetadataPresenter::MaxLengthValidator do
       let(:answers) { {'full_name' => 'Gandalf the Grey' } }
 
       context 'when there is no custom error message' do
-        let(:page) { service.find_page('/name') }
+        let(:page) { service.find_page_by_url('/name') }
 
         it 'returns invalid' do
           expect(validator).to_not be_valid
@@ -27,7 +27,7 @@ RSpec.describe MetadataPresenter::MaxLengthValidator do
       end
 
       context 'when there is a custom error message' do
-        let(:page) { service.find_page('/email-address') }
+        let(:page) { service.find_page_by_url('/email-address') }
         let(:answers) do
           { 'email_address' => 'gandalf.mithrandir@middleearth.gov.uk' }
         end
@@ -42,7 +42,7 @@ RSpec.describe MetadataPresenter::MaxLengthValidator do
 
     context 'when maximum length is valid' do
       let(:answers) { {'full_name' => 'Gandalf' } }
-      let(:page) { service.find_page('/name') }
+      let(:page) { service.find_page_by_url('/name') }
 
       it 'returns no errors' do
         expect(page.errors.full_messages).to eq([])

--- a/spec/validators/min_length_validator_spec.rb
+++ b/spec/validators/min_length_validator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MetadataPresenter::MinLengthValidator do
       let(:answers) { {'full_name' => 'T' } }
 
       context 'when there is no custom error message' do
-        let(:page) { service.find_page('/name') }
+        let(:page) { service.find_page_by_url('/name') }
 
         it 'returns invalid' do
           expect(validator).to_not be_valid
@@ -27,7 +27,7 @@ RSpec.describe MetadataPresenter::MinLengthValidator do
       end
 
       context 'when there is a custom error message' do
-        let(:page) { service.find_page('/email-address') }
+        let(:page) { service.find_page_by_url('/email-address') }
         let(:answers) do
           { 'email_address' => 'g' }
         end
@@ -42,7 +42,7 @@ RSpec.describe MetadataPresenter::MinLengthValidator do
 
     context 'when minimum length is valid' do
       let(:answers) { {'full_name' => 'Gandalf' } }
-      let(:page) { service.find_page('/name') }
+      let(:page) { service.find_page_by_url('/name') }
 
       it 'returns no errors' do
         expect(page.errors.full_messages).to eq([])

--- a/spec/validators/required_validator_spec.rb
+++ b/spec/validators/required_validator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MetadataPresenter::RequiredValidator do
 
     context 'when there is required validations on the metadata' do
       context 'when there is no custom error message' do
-        let(:page) { service.find_page('/name') }
+        let(:page) { service.find_page_by_url('/name') }
         let(:answers) { { } }
 
         it 'be invalid' do
@@ -27,7 +27,7 @@ RSpec.describe MetadataPresenter::RequiredValidator do
 
       context 'when there is custom error message' do
         context 'when there is "any"' do
-          let(:page) { service.find_page('/email-address') }
+          let(:page) { service.find_page_by_url('/email-address') }
           let(:answers) { { 'email_address' => '' } }
 
           it 'be invalid' do
@@ -44,7 +44,7 @@ RSpec.describe MetadataPresenter::RequiredValidator do
 
       context 'when required is valid' do
         let(:answers) { {'full_name' => 'Gandalf' } }
-        let(:page) { service.find_page('/name') }
+        let(:page) { service.find_page_by_url('/name') }
 
         it 'returns no errors' do
           expect(page.errors.full_messages).to eq([])

--- a/spec/validators/validate_answers_spec.rb
+++ b/spec/validators/validate_answers_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MetadataPresenter::ValidateAnswers do
   end
 
   describe '#valid?' do
-    let(:page) { service.find_page('/name') }
+    let(:page) { service.find_page_by_url('/name') }
 
     context 'when is valid' do
       let(:answers) { { 'full_name' => 'Gandalf' } }
@@ -15,7 +15,7 @@ RSpec.describe MetadataPresenter::ValidateAnswers do
     end
 
     context 'when validation required = false in metadata' do
-      let(:page) { service.find_page('/parent-name') }
+      let(:page) { service.find_page_by_url('/parent-name') }
 
       context 'when no answer is provided' do
         let(:answers) { { 'parent_name' => '' } }


### PR DESCRIPTION
## Context

We address two major issues in the presenter:

1. Let's use the page uuid for base finder and not the url 
2. Let's generate answer routes for each url of the pages of the form

## Page uuid

We are generating a page uuid on the editor and use to find the pages in the editor.

## Generate answer routes

Before we had to add the page URL to the params on the runner so it would POST to /reserved-answers/%2f/ (%2f mean the '/'). We don't need to do that anymore because we are generating the POST to each URL of the pages metadata.

Example:

if we have a page with a url '/name' there will be a POST '/name' for that page on the presenter
Also return 404 if requested page URL does not exist in the metadata.


Release version 0.3.0

https://trello.com/c/wbZcslTs/1224-use-generated-page-id-instead-of-name