### PR TITLE
Add answer helper method

### DIFF
--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -1,5 +1,23 @@
 module MetadataPresenter
   module ApplicationHelper
+    ## Display user answers on the view
+    ## When the user doesn't answered yet the component will be blank
+    # or with data otherwise, so doing the if in every output is not
+    # pratical.
+    #
+    # The below example search for 'first_name' in the user data instance
+    # variable as long your load_user_data in the controller sets the variable.
+    #
+    # @example
+    #   <%= a('first_name') %>
+    #
+    def a(component_key)
+      if @user_data.present?
+        @user_data[component_key]
+      end
+    end
+    alias answer a
+
     def to_markdown(text)
       (Kramdown::Document.new(text).to_html).html_safe
     end

--- a/app/views/metadata_presenter/component/_text.html.erb
+++ b/app/views/metadata_presenter/component/_text.html.erb
@@ -3,5 +3,5 @@
     label: { text: component.label },
     hint: { text: component.hint },
     name: "answers[#{component.name}]",
-    value: @user_data ? @user_data[component.name] : nil
+    value: answer(component.name)
 %>

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -35,7 +35,7 @@
                 </dt>
 
                 <dd class="govuk-summary-list__value">
-                  <%= @user_data[component.name] %>
+                  <%=a component.name %>
                 </dd>
                 <dd class="govuk-summary-list__actions">
                 <%= link_to(

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
In order to show the user answer and also to render on the editor (which doesn't have the user answer when editing the page) we need this helper method to avoid many if's in the view.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>

Story: https://trello.com/c/zp9OuUox/1196-backend-check-your-answers-page