### PR TITLE
Make sure find page by url can be with or without slashes

### DIFF
--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -8,7 +8,7 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
   end
 
   def find_page_by_url(url)
-    pages.find { |page| page.url == url }
+    pages.find { |page| strip_slash(page.url) == strip_slash(url) }
   end
 
   def find_page_by_uuid(uuid)
@@ -28,5 +28,13 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     @confirmation_page ||= pages.find do |page|
       page.type == 'page.confirmation'
     end
+  end
+
+  private
+
+  def strip_slash(url)
+    return url if url == '/'
+
+    url.gsub(/^\//, '')
   end
 end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -9,11 +9,34 @@ RSpec.describe MetadataPresenter::Service do
     end
   end
 
-  describe '#find_page' do
-    it 'finds the correct page' do
-      path = service_metadata['pages'][1]['url']
-      page = service.find_page_by_url(path)
-      expect(page.id).to eq(service_metadata['pages'][1]['_id'])
+  describe '#find_page_by_url' do
+    context 'when passing without slash in the beginning' do
+      let(:path) { 'name' }
+
+      it 'finds the correct page' do
+        page = service.find_page_by_url(path)
+        expect(page.id).to eq(service_metadata['pages'][1]['_id'])
+      end
+    end
+
+    context 'when passing with slash in the beginning' do
+      let(:path) { '/name' }
+
+      it 'finds the correct page' do
+        page = service.find_page_by_url(path)
+        expect(page.id).to eq(service_metadata['pages'][1]['_id'])
+      end
+    end
+
+    context 'when page does not exist' do
+      let(:path) do
+        "/darth-vader-nooooooooo"
+      end
+
+      it 'finds the correct page' do
+        page = service.find_page_by_url(path)
+        expect(page).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
## Context

This is a temporary solution while we do the definition of how we should
store the URLs in the metadata.

Right now when we publish forms to test environment the forms can't
be rendered because the metadata contains the URL without the slash
(e.g name) and when the request path info line on the pages controller
is called the URL to find is '/name' returning nil and not
rendering the page we expected to be rendered.

Do with or without slashes, for now, solves the issue.
