### PR TITLE
Add service to json

### DIFF
--- a/app/models/metadata_presenter/metadata.rb
+++ b/app/models/metadata_presenter/metadata.rb
@@ -8,6 +8,10 @@ class MetadataPresenter::Metadata
     @metadata = OpenStruct.new(metadata)
   end
 
+  def to_json
+    self.to_h.to_json
+  end
+
   def id
     metadata._id
   end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.3.2'
+  VERSION = '0.4.0'
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe MetadataPresenter::Service do
+  describe '#to_json' do
+    it 'returns json object' do
+      expect(JSON.parse(service.to_json)).to include(
+        'service_name' => 'Service name'
+      )
+    end
+  end
+
   describe '#pages' do
     it 'returns an array of Page objects' do
       service.pages.each do |page|


### PR DESCRIPTION
This is used to generate the service metadata while publishing in the
editor as env var into the runner app