### PR TITLE
Component/textarea

### DIFF
--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -18,6 +18,14 @@ module MetadataPresenter
     end
     alias answer a
 
+    ## Display user answers on the view formatted.
+    ##
+    def formatted_answer(component_key)
+      user_answer = answer(component_key)
+
+      simple_format(user_answer) if user_answer.present?
+    end
+
     # Renders markdown given a text.
     #
     # @example

--- a/app/views/metadata_presenter/component/_textarea.html.erb
+++ b/app/views/metadata_presenter/component/_textarea.html.erb
@@ -1,0 +1,11 @@
+<%=
+  f.govuk_text_area component.id.to_sym,
+    label: { text: component.label },
+    hint: { text: component.hint },
+    name: "answers[#{component.name}]",
+    value: answer(component.name),
+    max_chars: component.maxchars,
+    max_words: component.maxwords,
+    threshold: component.threshold,
+    rows: component.rows
+%>

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -35,7 +35,7 @@
                 </dt>
 
                 <dd class="govuk-summary-list__value">
-                  <%=a component.name %>
+                  <%= formatted_answer(component.name) %>
                 </dd>
                 <dd class="govuk-summary-list__actions">
                 <%= link_to(

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -25,7 +25,7 @@
         </p>
       <%- end %>
 
-      <%= form_tag(@page.url, method: :post) do %>
+      <%= form_tag(root_path, method: :post) do %>
         <button <%= 'disabled' if editable? %> class='govuk-button govuk-button--start govuk-!-margin-top-2'>
         Start
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">

--- a/default_metadata/component/text.json
+++ b/default_metadata/component/text.json
@@ -4,5 +4,8 @@
   "errors": {},
   "hint": "Component hint",
   "label": "Component label",
-  "name": "component-name"
+  "name": "component-name",
+  "validation": {
+    "required": true
+  }
 }

--- a/default_metadata/component/textarea.json
+++ b/default_metadata/component/textarea.json
@@ -1,0 +1,12 @@
+{
+  "_id": "component.textarea",
+  "_type": "textarea",
+  "errors": {},
+  "hint": "Component hint",
+  "label": "Component label",
+  "name": "component-name",
+  "rows": 5,
+  "validation": {
+    "required": true
+  }
+}

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -125,6 +125,25 @@
       "url": "/parent-name"
     },
     {
+      "_uuid": "7b748584-100e-4d81-a54a-5049190136cc",
+      "_id": "page.family_hobbies",
+      "_type": "page.singlequestion",
+      "components": [
+        {
+          "_id": "page.family-hobbies--text.auto_name__3",
+          "_type": "textarea",
+          "label": "Your family hobbies",
+          "name": "family_hobbies",
+          "rows": 5,
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "heading": "Family Hobbies",
+      "url": "/family-hobbies"
+    },
+    {
       "_uuid": "e819d0c2-7062-4997-89cf-44d26d098404",
       "_id": "page._check-answers",
       "_type": "page.checkanswers",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end

--- a/schemas/textarea/textarea.json
+++ b/schemas/textarea/textarea.json
@@ -1,0 +1,55 @@
+{
+  "_id": "component.textarea",
+  "_name": "textarea",
+  "title": "Textarea",
+  "description": "Let users enter text that can be longer than a single line",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "textarea"
+    },
+    "maxwords": {
+      "type": "number",
+      "title": "Maximum words",
+      "description": "Set a word limit",
+      "category": [
+        "userinput"
+      ]
+    },
+    "maxchars": {
+      "type": "number",
+      "title": "Maximum characters",
+      "description": "Set a character limit",
+      "category": [
+        "userinput"
+      ]
+    },
+    "threshold": {
+      "type": "number",
+      "title": "Threshold percentage",
+      "description": "Display the message about maximum length or words after a user has entered a certain amount",
+      "category": [
+        "userinput"
+      ]
+    },
+    "rows": {
+      "type": "number",
+      "title": "Number of rows in the textarea",
+      "description": "Set the number of rows",
+      "category": [
+        "userinput"
+      ]
+    }
+  },
+  "allOf": [
+   {
+      "$ref": "definition.field"
+    },
+    {
+      "$ref": "validations#/definitions/string_bundle"
+    },
+    {
+      "$ref": "definition.width_class.input"
+    }
+  ]
+}

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
   describe '#a' do
+    before do
+      helper.instance_variable_set(:@user_data, user_data)
+    end
+
     context 'when there is an answer' do
-      before do
-        helper.instance_variable_set(
-          :@user_data,
-          { 'ewoks-communication' =>'ewokie talkies' }
-        )
+      let(:user_data) do
+        { 'ewoks-communication' => 'ewokie talkies' }
       end
 
       it 'returns answer for a question' do
@@ -16,8 +17,36 @@ RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
     end
 
     context 'when there is no answer' do
+      let(:user_data) { {} }
+
       it 'returns answer for a question' do
         expect(helper.a('ewoks-communication')).to be_nil
+      end
+    end
+  end
+
+  describe '#formatted_answer' do
+    before do
+      helper.instance_variable_set(:@user_data, user_data)
+    end
+
+    context 'when answer has a format' do
+      let(:user_data) do
+        { 'what-do-gungans-put-things-in' => "Gungans put things in: \n Jar Jars" }
+      end
+
+      it 'returns answer for a question with simple format' do
+        expect(helper.formatted_answer('what-do-gungans-put-things-in')).to eq(
+          "<p>Gungans put things in: \n<br /> Jar Jars</p>"
+        )
+      end
+    end
+
+    context 'when there is no answer' do
+      let(:user_data) { {} }
+
+      it 'returns answer for a question' do
+        expect(helper.formatted_answer('ewoks-communication')).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Context

This PR adds the textarea component to the metadata presenter gem.

The textarea supports:

1. Max words
2. Max chars
3. Threshold
4. Rows

The first three belongs to the character count feature:  https://design-system.service.gov.uk/components/character-count/

Another detail is that we should be making sure the validation is required by default in all components.