### PR TITLE
Only render pages which are not assets

### DIFF
--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -14,7 +14,6 @@
 
     <%= stylesheet_pack_tag 'govuk' %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <%= javascript_pack_tag 'application' %>
   </head>
 
   <body class="govuk-template__body">
@@ -28,6 +27,7 @@
         <%= yield %>
       </main>
     </div>
+    <%= javascript_pack_tag 'application' %>
     <%= javascript_pack_tag 'govuk' %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ MetadataPresenter::Engine.routes.draw do
 
   post '/', to: 'answers#create'
   match '*path', to: 'answers#create', via: :post
-  match '*path', to: 'pages#show', via: :all
+  match '*path', to: 'pages#show',
+    via: :all,
+    constraints: lambda {|req| req.path !~ /\.(png|jpg|js|css|ico)$/ }
 end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
## Context

We need to fix the runner when the runner is published. Since we will make the runner serve the assets for now, we need to make sure that our global route match don't consider the assets as a "page" object.
