### PR TITLE
Component/number

### DIFF
--- a/app/validators/metadata_presenter/base_validator.rb
+++ b/app/validators/metadata_presenter/base_validator.rb
@@ -62,6 +62,12 @@ module MetadataPresenter
       message % error_message_hash if message.present?
     end
 
+    # @return [String] user answer for the specific component
+    #
+    def user_answer
+      answers[component.name]
+    end
+
     # The default error message will be look using the schema key.
     # Assuming the schema key is 'grogu' then the default message
     # will look for 'error.grogu.value'.

--- a/app/validators/metadata_presenter/max_length_validator.rb
+++ b/app/validators/metadata_presenter/max_length_validator.rb
@@ -1,7 +1,7 @@
 module MetadataPresenter
   class MaxLengthValidator < BaseValidator
     def invalid_answer?
-      answers[component.name].to_s.size > component.validation[schema_key]
+      user_answer.to_s.size > component.validation[schema_key]
     end
   end
 end

--- a/app/validators/metadata_presenter/min_length_validator.rb
+++ b/app/validators/metadata_presenter/min_length_validator.rb
@@ -1,7 +1,7 @@
 module MetadataPresenter
   class MinLengthValidator < BaseValidator
     def invalid_answer?
-      answers[component.name].to_s.size < component.validation[schema_key]
+      user_answer.to_s.size < component.validation[schema_key]
     end
   end
 end

--- a/app/validators/metadata_presenter/number_validator.rb
+++ b/app/validators/metadata_presenter/number_validator.rb
@@ -1,0 +1,7 @@
+module MetadataPresenter
+  class NumberValidator < BaseValidator
+    def invalid_answer?
+      Float(user_answer, exception: false).blank?
+    end
+  end
+end

--- a/app/validators/metadata_presenter/required_validator.rb
+++ b/app/validators/metadata_presenter/required_validator.rb
@@ -1,7 +1,7 @@
 module MetadataPresenter
   class RequiredValidator < BaseValidator
     def invalid_answer?
-      answers[component.name].blank?
+      user_answer.blank?
     end
   end
 end

--- a/app/views/metadata_presenter/component/_number.html.erb
+++ b/app/views/metadata_presenter/component/_number.html.erb
@@ -1,0 +1,8 @@
+<%=
+  f.govuk_text_field component.id.to_sym,
+    label: { text: component.label },
+    hint: { text: component.hint },
+    name: "answers[#{component.name}]",
+    value: answer(component.name),
+    width: component.width_class_input.to_i
+%>

--- a/default_metadata/component/number.json
+++ b/default_metadata/component/number.json
@@ -1,0 +1,12 @@
+{
+  "_id": "component.number",
+  "_type": "number",
+  "errors": {},
+  "hint": "Component hint",
+  "label": "Component label",
+  "name": "component-name",
+  "width_class_input": "10",
+  "validation": {
+    "number": true
+  }
+}

--- a/default_metadata/string/error.number.json
+++ b/default_metadata/string/error.number.json
@@ -1,0 +1,6 @@
+{
+  "_id": "error.number",
+  "_type": "string.error",
+  "description": "Input (number) is not a number",
+  "value": "Enter a number for %{control}"
+}

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -125,6 +125,28 @@
       "url": "/parent-name"
     },
     {
+      "_id": "page.your_age",
+      "url": "your-age",
+      "_type":"page.singlequestion",
+      "_uuid":"59d1326c-32e6-45e9-b57a-bcc8e2fb6b2c",
+      "heading":"Your age",
+      "components": [
+        {
+          "_id": "your_age_number_1",
+          "hint": "Component hint",
+          "name": "your_age_number_1",
+          "_type": "number",
+          "label": "Your age",
+          "errors": {},
+          "validation": {
+            "required": true,
+            "number": true
+          },
+          "width_class_input": "10"
+        }
+      ]
+    },
+    {
       "_uuid": "7b748584-100e-4d81-a54a-5049190136cc",
       "_id": "page.family_hobbies",
       "_type": "page.singlequestion",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.7.1'
+  VERSION = '0.8.0'
 end

--- a/schemas/component/number.json
+++ b/schemas/component/number.json
@@ -1,0 +1,29 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/number",
+  "_name": "component.number",
+  "title": "Number",
+  "description": "Let users enter a number",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "number"
+    },
+    "name": {
+      "inputType": "number"
+    },
+    "width_class_input": {
+      "default": "10"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.field"
+    },
+    {
+      "$ref": "validations#/definitions/number_bundle"
+    },
+    {
+      "$ref": "definition.width_class.input"
+    }
+  ]
+}

--- a/spec/validators/number_validator_spec.rb
+++ b/spec/validators/number_validator_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe MetadataPresenter::NumberValidator do
+  subject(:validator) do
+    described_class.new(page: page, answers: answers, component: component)
+  end
+  let(:component) { page.components.first }
+
+  describe '#validate' do
+    before do
+      validator.valid?
+    end
+
+    context 'when is not a number' do
+      %w(centuries . $ # % , 1.a 2.b).each do |invalid_answer|
+        let(:answers) { { 'your_age_number_1' => invalid_answer } }
+        let(:page) { service.find_page_by_url('/your-age') }
+
+        it "returns invalid for '#{invalid_answer}'" do
+          expect(validator).to_not be_valid
+        end
+      end
+    end
+
+    context 'when is a number' do
+      %w(1 1.1 100).each do |valid_answer|
+        let(:answers) { { 'your_age_number_1' => valid_answer } }
+        let(:page) { service.find_page_by_url('/your-age') }
+
+        it "returns valid for '#{valid_answer}'" do
+          expect(validator).to be_valid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/LcEoCP68/1235-add-number-component-to-a-single-question-page)

## Context

This PR adds the number component to the gem.

The number component is very similar to the text component with the only gotcha that only accepts number (obviously 😅 ).

## Next steps

- [ ] Runner PR - fix specs because of the version.json fixture change
- [ ] Editor PR - bump the gem so the create single question -> number component to work 

🎸 