### PR TITLE
Component/radio

### DIFF
--- a/default_metadata/component/radios.json
+++ b/default_metadata/component/radios.json
@@ -1,0 +1,10 @@
+{
+  "_id": "component.radios",
+  "_type": "radios",
+  "errors": {},
+  "hint": "Component hint",
+  "label": "Component label",
+  "items": [],
+  "name": "component-name",
+  "legend": "Required legend"
+}

--- a/default_metadata/definition/radio.json
+++ b/default_metadata/definition/radio.json
@@ -1,0 +1,6 @@
+{
+  "_id": "definition.radio",
+  "_type": "radio",
+  "label": "Required label",
+  "value": "radio-value"
+}

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -166,6 +166,37 @@
       "url": "/family-hobbies"
     },
     {
+      "_uuid": "4251b25e-08de-4dcb-8f2f-dd9848dcdca6",
+      "_id": "page.radio-buttons",
+      "_type": "page.singlequestion",
+      "components": [
+        {
+          "_id": "radio-buttons_radios_1",
+          "_type": "radios",
+          "errors": {},
+          "hint": "Component hint",
+          "label": "Component label",
+          "items": [
+            {
+              "_id": "radio-buttons_radio_1",
+              "_type": "radio",
+              "label": "Yes",
+              "value": "radio_value_1"
+            },
+            {
+              "_id": "radio-buttons_radio_2",
+              "_type": "radio",
+              "label": "No",
+              "value": "radio_value_2"
+            }
+          ],
+          "name": "radio-buttons_radios_1"
+        }
+      ],
+      "heading": "Parent name",
+      "url": "/radio-buttons"
+    },
+    {
       "_uuid": "e819d0c2-7062-4997-89cf-44d26d098404",
       "_id": "page._check-answers",
       "_type": "page.checkanswers",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end

--- a/schemas/component/radios.json
+++ b/schemas/component/radios.json
@@ -1,0 +1,37 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/radios",
+  "_name": "component.radios",
+  "title": "Radios",
+  "description": "Let users select one option from a list",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "radios"
+    },
+    "items": {
+      "title": "Options",
+      "description": "Items that users can select",
+      "type": "array",
+      "items": {
+        "$ref": "definition.radio"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.fieldset"
+    },
+    {
+      "$ref": "definition.name"
+    }
+  ],
+  "transforms": {
+    "namespace": {
+      "propagation": "items[*].conditional_component"
+    }
+  },
+  "required": [
+    "name",
+    "items"
+  ]
+}

--- a/schemas/definition/conditionalcomponent.json
+++ b/schemas/definition/conditionalcomponent.json
@@ -1,0 +1,12 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/conditionalcomponent",
+  "_name": "definition.conditionalcomponent",
+  "nestable": true,
+  "title": "Conditional component",
+  "description": "Component revealed when user chooses option",
+  "allOf": [
+    {
+      "$ref": "definition.component"
+    }
+  ]
+}

--- a/schemas/definition/fieldset.json
+++ b/schemas/definition/fieldset.json
@@ -1,0 +1,37 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/fieldset",
+  "_name": "definition.fieldset",
+  "title": "Fieldset",
+  "description": "Group related form inputs",
+  "type": "object",
+  "category": [
+    "control",
+    "fieldset"
+  ],
+  "properties": {
+    "_type": {
+      "const": "fieldset"
+    },
+    "legend": {
+      "title": "Legend",
+      "description": "Text to use in fieldset legend",
+      "type": "string"
+    },
+    "hint": {
+      "title": "Hint",
+      "description": "Text to help users answer a question - appears in grey under the legend",
+      "type": "string"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.repeatable"
+    },
+    {
+      "$ref": "definition.grouping"
+    }
+  ],
+  "required": [
+    "legend"
+  ]
+}

--- a/schemas/definition/grouping.json
+++ b/schemas/definition/grouping.json
@@ -1,0 +1,27 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/grouping",
+  "_name": "definition.grouping",
+  "title": "Grouping definition",
+  "allOf": [
+    {
+      "$ref": "definition.component"
+    },
+    {
+      "$ref": "definition.components"
+    },
+    {
+      "$ref": "definition.namespace"
+    },
+    {
+      "$ref": "definition.html_attributes"
+    }
+  ],
+  "category": [
+    "grouping"
+  ],
+  "transforms": {
+    "namespace": {
+      "propagation": "components[?(@.$control || @.$grouping)]"
+    }
+  }
+}

--- a/schemas/definition/option.json
+++ b/schemas/definition/option.json
@@ -1,0 +1,35 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/option",
+  "_name": "definition.option",
+  "title": "Option definition",
+  "properties": {
+    "value": {
+      "title": "Option value",
+      "description": "Value captured by system when users choose this option",
+      "type": "string"
+    },
+    "hasDivider": {
+      "title": "Option divider",
+      "description": "Whether to display a textual divider before the option - defaults to ‘or’",
+      "type": "boolean"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.block"
+    },
+    {
+      "$ref": "definition.label"
+    },
+    {
+      "$ref": "definition.namespace"
+    }
+  ],
+  "required": [
+    "value"
+  ],
+  "category": [
+    "component",
+    "option"
+  ]
+}

--- a/schemas/definition/radio.json
+++ b/schemas/definition/radio.json
@@ -1,0 +1,30 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/radio",
+  "_name": "definition.radio",
+  "idSeed": "value",
+  "title": "Radio option",
+  "description": "Component that provides a radio option",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "radio"
+    },
+    "hint": {
+      "title": "Hint text",
+      "description": "Text to help users understand an option - appears in grey under the label",
+      "type": "string",
+      "content": true
+    },
+    "conditional_component": {
+      "$ref": "definition.conditionalcomponent"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.option"
+    }
+  ],
+  "required": [
+    "label"
+  ]
+}


### PR DESCRIPTION
## Add radio buttons default metadata and schemas

This adds the schemas and default metadata required for the radio buttons components. Also required is a radio schema which is for a single item inside a radios fieldset.

Additional schemas that are needed include:

- definition.grouping
- definition.fieldset
- definition.option

## version 0.8.1