### PR TITLE
Component/number

### DIFF
--- a/app/validators/metadata_presenter/base_validator.rb
+++ b/app/validators/metadata_presenter/base_validator.rb
@@ -42,6 +42,8 @@ module MetadataPresenter
     end
 
     def valid?
+      return true if user_answer.blank? && allow_blank?
+
       if invalid_answer?
         error_message = custom_error_message || default_error_message
         page.errors.add(component.id, error_message)
@@ -120,6 +122,16 @@ module MetadataPresenter
         control: component.label,
         schema_key.to_sym => component.validation[schema_key]
       }
+    end
+
+    # Method signature to be overwrite in the subclass if you do not want to allow
+    # blank values. We should not allow blank when performing the required
+    # validation.
+    #
+    # @return [TrueClass]
+    #
+    def allow_blank?
+      true unless self.class.name.demodulize.include?('RequiredValidator')
     end
   end
 end

--- a/app/validators/metadata_presenter/validate_answers.rb
+++ b/app/validators/metadata_presenter/validate_answers.rb
@@ -31,18 +31,7 @@ module MetadataPresenter
     def component_validations(component)
       return [] if component.validation.blank?
 
-      component.validation.reject do |_, value|
-        value.blank? ||
-        (optional_question?(component) && question_not_answered?)
-      end.keys
-    end
-
-    def optional_question?(component)
-      component.validation['required'] == false
-    end
-
-    def question_not_answered?
-      answers.values.any?(&:blank?)
+      component.validation.select { |_,value| value.present? }.keys
     end
   end
 end

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -139,8 +139,8 @@
           "label": "Your age",
           "errors": {},
           "validation": {
-            "required": true,
-            "number": true
+            "number": true,
+            "required": true
           },
           "width_class_input": "10"
         }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end

--- a/spec/validators/max_length_validator_spec.rb
+++ b/spec/validators/max_length_validator_spec.rb
@@ -4,9 +4,18 @@ RSpec.describe MetadataPresenter::MaxLengthValidator do
   end
   let(:component) { page.components.first }
 
-  describe '#validate' do
+  describe '#valid?' do
     before do
       validator.valid?
+    end
+
+    context 'when answer is blank' do
+      let(:answers) { {'full_name' => '' } }
+      let(:page) { service.find_page_by_url('/name') }
+
+      it 'returns valid' do
+        expect(validator).to be_valid
+      end
     end
 
     context 'when maximum length is invalid' do

--- a/spec/validators/min_length_validator_spec.rb
+++ b/spec/validators/min_length_validator_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe MetadataPresenter::MinLengthValidator do
       validator.valid?
     end
 
+    context 'when answer is blank' do
+      let(:answers) { {'full_name' => '' } }
+      let(:page) { service.find_page_by_url('/name') }
+
+      it 'returns valid' do
+        expect(validator).to be_valid
+      end
+    end
+
     context 'when minimum length is invalid' do
       let(:answers) { {'full_name' => 'T' } }
 


### PR DESCRIPTION
## Context

I found a bug to reproduce.

Have on the metadata any validation **before** the required node:

```
  validation: {
      min_length: 10
      required: true
  }
```

It was making the min length to be triggering before the required and showing the min length validation when user answer is blank.

So I changed the logic to select all validations which are true and all of them should allow blank and only the required validator should validate the blanks.

This makes the code more reliable as any future validation that we will write will return valid if the user answer is blank letting the required validator to have the responsibilities to validate the empty inputs.
