### PR TITLE
Legend or label

### DIFF
--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -1,5 +1,19 @@
 module MetadataPresenter
   module ApplicationHelper
+    def main_h1(component)
+      if component.legend.present?
+        content_tag(:legend, class: 'govuk-fieldset__legend govuk-fieldset__legend--l') do
+          content_tag(:h1, class: 'govuk-fieldset__heading') do
+            component.legend
+          end
+        end
+      else
+        content_tag(:h1, class: 'govuk-heading-xl') do
+          component.label
+        end
+      end
+    end
+
     ## Display user answers on the view
     ## When the user doesn't answered yet the component will be blank
     # or with data otherwise, so doing the if in every output is not

--- a/app/views/metadata_presenter/component/_number.html.erb
+++ b/app/views/metadata_presenter/component/_number.html.erb
@@ -1,6 +1,6 @@
 <%=
   f.govuk_text_field component.id.to_sym,
-    label: { text: component.label },
+    label: { text: input_title },
     hint: { text: component.hint },
     name: "answers[#{component.name}]",
     value: answer(component.name),

--- a/app/views/metadata_presenter/component/_text.html.erb
+++ b/app/views/metadata_presenter/component/_text.html.erb
@@ -1,6 +1,6 @@
 <%=
   f.govuk_text_field component.id.to_sym,
-    label: { text: component.label },
+    label: { text: input_title },
     hint: { text: component.hint },
     name: "answers[#{component.name}]",
     value: answer(component.name)

--- a/app/views/metadata_presenter/component/_textarea.html.erb
+++ b/app/views/metadata_presenter/component/_textarea.html.erb
@@ -1,6 +1,6 @@
 <%=
   f.govuk_text_area component.id.to_sym,
-    label: { text: component.label },
+    label: { text: input_title },
     hint: { text: component.hint },
     name: "answers[#{component.name}]",
     value: answer(component.name),

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -1,14 +1,14 @@
 <div class="fb-main-grid-wrapper" data-block-id="<%= @page.id %>" data-block-type="page" data-block-pagetype="<%= @page.type %>">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="<%= @page.heading_class %>" data-block-id="<%= @page.id %>" data-block-property="heading">
-          <%= @page.heading.html_safe %>
-      </h1>
-
-      <%= form_for @page, url: @page.url, method: :post do |f| %>
+      <%= form_for @page, as: :answers, url: @page.url, method: :post do |f| %>
         <%= f.govuk_error_summary %>
         <% @page.components.each do |component| %>
-          <%= render partial: component, locals: { component: component, f: f } %>
+          <%= render partial: component, locals: {
+            component: component,
+            f: f,
+            input_title: main_h1(component) }
+          %>
         <% end %>
 
         <%= f.govuk_submit(disabled: editable?) %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.8.2'
+  VERSION = '0.9.0'
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,4 +1,30 @@
 RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
+  describe '#main_h1' do
+    context 'when component has a legend' do
+      let(:component) do
+        MetadataPresenter::Component.new(legend: 'Luke Skywalker')
+      end
+
+      it 'returns h1 wrapped in a legend' do
+        expect(helper.main_h1(component)).to eq(
+          %{<legend class="govuk-fieldset__legend govuk-fieldset__legend--l"><h1 class="govuk-fieldset__heading">Luke Skywalker</h1></legend>}
+        )
+      end
+    end
+
+    context 'when component has a label' do
+      let(:component) do
+        MetadataPresenter::Component.new(label: 'Luke Skywalker')
+      end
+
+      it 'returns h1 wrapped in a legend' do
+        expect(helper.main_h1(component)).to eq(
+          %{<h1 class="govuk-heading-xl">Luke Skywalker</h1>}
+        )
+      end
+    end
+  end
+
   describe '#a' do
     before do
       helper.instance_variable_set(:@user_data, user_data)

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
     end
 
     it 'renders the view correctly' do
-      page_heading = service_metadata['pages'][1]['heading']
+      page_heading = service_metadata['pages'][1]['components'][0]['label']
       expect(response.body).to include(page_heading)
     end
   end
@@ -72,7 +72,7 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
       end
 
       it 'render same page' do
-        page_heading = service_metadata['pages'][1]['heading']
+        page_heading = service_metadata['pages'][1]['components'][0]['label']
         expect(response.body).to include(page_heading)
       end
     end


### PR DESCRIPTION
# Context

This adds the possibility to use legend as main heading (h1) in single question or the label.

[Trello card](https://trello.com/c/djsW5lHE/1282-all-single-question-components-should-have-the-heading-as-the-label)