### PR TITLE
Handle Radio Button components in the metadata

### DIFF
--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -3,7 +3,7 @@ module MetadataPresenter
     def main_h1(component)
       if component.legend.present?
         content_tag(:legend, class: 'govuk-fieldset__legend govuk-fieldset__legend--l') do
-          content_tag(:h1, class: 'govuk-fieldset__heading') do
+          content_tag(:h1, class: 'govuk-heading-xl') do
             component.legend
           end
         end

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -2,4 +2,18 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
   def to_partial_path
     "metadata_presenter/component/#{type}"
   end
+
+  def humanised_title
+    self.label || self.legend
+  end
+
+  def items
+    metadata.items.map do |item|
+      OpenStruct.new(
+        id: item['label'],
+        name: item['label'],
+        description: item['hint']
+      )
+    end
+  end
 end

--- a/app/validators/metadata_presenter/base_validator.rb
+++ b/app/validators/metadata_presenter/base_validator.rb
@@ -115,7 +115,7 @@ module MetadataPresenter
     #
     def error_message_hash
       {
-        control: component.label,
+        control: component.humanised_title,
         schema_key.to_sym => component.validation[schema_key]
       }
     end

--- a/app/views/metadata_presenter/component/_radios.html.erb
+++ b/app/views/metadata_presenter/component/_radios.html.erb
@@ -1,0 +1,9 @@
+<%=
+  f.govuk_collection_radio_buttons component.id.to_sym,
+    component.items,
+    :id,
+    :name,
+    :description,
+    legend: { text: input_title },
+    hint: { text: component.hint }
+%>

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -31,7 +31,7 @@
             <% Array(page.components).each do |component| %>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
-                  <%= component.label %>
+                  <%= component.humanised_title %>
                 </dt>
 
                 <dd class="govuk-summary-list__value">

--- a/default_metadata/component/radios.json
+++ b/default_metadata/component/radios.json
@@ -3,7 +3,6 @@
   "_type": "radios",
   "errors": {},
   "hint": "Component hint",
-  "label": "Component label",
   "items": [],
   "name": "component-name",
   "legend": "Required legend"

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -166,6 +166,42 @@
       "url": "/family-hobbies"
     },
     {
+      "_uuid": "4251b25e-08de-4dcb-8f2f-dd9848dcdca6",
+      "_id": "page.do-you-like-star-wars",
+      "_type": "page.singlequestion",
+      "components": [
+        {
+          "_id": "do-you-like-star-wars_radios_1",
+          "_type": "radios",
+          "errors": {},
+          "hint": "Component hint",
+          "legend": "Do you like Star Wars?",
+          "items": [
+            {
+              "_id": "do-you-like-star-wars_radio_1",
+              "_type": "radio",
+              "label": "Only on weekends",
+              "hint": "Optional item hint",
+              "value": "only-on-weekends"
+            },
+            {
+              "_id": "do-you-like-star-wars_radio_2",
+              "_type": "radio",
+              "label": "Hell no!",
+              "hint": "Optional item hint",
+              "value": "hell-no"
+            }
+          ],
+          "name": "do-you-like-star-wars_radios_1",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "heading": "Radio buttons",
+      "url": "/do-you-like-star-wars"
+    },
+    {
       "_uuid": "e819d0c2-7062-4997-89cf-44d26d098404",
       "_id": "page._check-answers",
       "_type": "page.checkanswers",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
 
       it 'returns h1 wrapped in a legend' do
         expect(helper.main_h1(component)).to eq(
-          %{<legend class="govuk-fieldset__legend govuk-fieldset__legend--l"><h1 class="govuk-fieldset__heading">Luke Skywalker</h1></legend>}
+          %{<legend class="govuk-fieldset__legend govuk-fieldset__legend--l"><h1 class="govuk-heading-xl">Luke Skywalker</h1></legend>}
         )
       end
     end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -10,4 +10,44 @@ RSpec.describe MetadataPresenter::Component do
       )
     end
   end
+
+  describe '#items' do
+    let(:component) do
+      service.find_page_by_url('do-you-like-star-wars').components.first
+    end
+
+    it 'returns an array of openstruct component item objects' do
+      expect(component.items).to be_an(Array)
+    end
+
+    it 'contains objects that respond to the necessary properties' do
+      component.items.each do |item|
+        expect(item).to respond_to(:id)
+        expect(item).to respond_to(:name)
+        expect(item).to respond_to(:description)
+      end
+    end
+  end
+
+  describe '#humanised_title' do
+    context 'when the component has a label' do
+      let(:component) do
+        service.find_page_by_url('name').components.first
+      end
+
+      it 'returns the label value' do
+        expect(component.humanised_title).to eq('Full name')
+      end
+    end
+
+    context 'when the component has a legend' do
+      let(:component) do
+        service.find_page_by_url('do-you-like-star-wars').components.first
+      end
+
+      it 'returns the legend value' do
+        expect(component.humanised_title).to eq('Do you like Star Wars?')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Handle radio button components in metadata

This adds the ability for the presenter to handle the radio buttons component as well as validate it as a required field.

We added the humanised_title method in order to be able to correctly choose between using a label or legend property for page headings/questions, the check your answers page, as well as the key when creating the errors hash on the page answers object.

## Default radios metadata does not require label property

The radios metadata makes use of the legend as the main title or question for a given page.

## Use correct govuk heading css class for legend properties 

govuk-heading-xl is the correct css class required for the h1 of a page.

## Update version fixture to include a radio buttons page

## Publish version 0.11.0


https://trello.com/c/vo4dqCu4/1237-add-radio-buttons-component-to-a-single-question-page