### PR TITLE
Add wrapper_tag to textarea

### DIFF
--- a/app/presenters/metadata_presenter/page_answers_presenter.rb
+++ b/app/presenters/metadata_presenter/page_answers_presenter.rb
@@ -37,7 +37,7 @@ module MetadataPresenter
           format: '%d %B %Y'
         )
       elsif component.type == 'textarea'
-        view.simple_format(value)
+        view.simple_format(value, {}, wrapper_tag: 'span')
       else
         value
       end

--- a/spec/presenters/page_answers_presenter_spec.rb
+++ b/spec/presenters/page_answers_presenter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe MetadataPresenter::PageAnswersPresenter do
 
         it 'returns formatted value' do
           expect(presenter.answer).to eq(
-            %{<p>Play Star Wars\n<br />Watch Mandalorian</p>}
+            %{<span>Play Star Wars\n<br />Watch Mandalorian</span>}
           )
         end
       end


### PR DESCRIPTION
There is padding above the answers for a textarea on the check your answers page.
This is because the `simple_format` method wraps the answer in a <p> tag.

This PR will replace the <p> tag with a <span> which will remove the whitespace.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>


### Before
<img width="586" alt="Screenshot 2021-02-15 at 18 10 14" src="https://user-images.githubusercontent.com/29227502/107980970-21b3da80-6fb9-11eb-988f-0448a1e6d0bc.png">

### After
<img width="585" alt="Screenshot 2021-02-15 at 18 09 37" src="https://user-images.githubusercontent.com/29227502/107980973-24aecb00-6fb9-11eb-90d9-e8cc8e930582.png">

