### PR TITLE
Component/checkbox

### DIFF
--- a/default_metadata/component/checkboxes.json
+++ b/default_metadata/component/checkboxes.json
@@ -3,7 +3,22 @@
   "_type": "checkboxes",
   "errors": {},
   "hint": "[Hint text (optional)]",
-  "items": [],
+  "items": [
+    {
+      "_id": "component_checkbox_1",
+      "_type": "checkbox",
+      "label": "Option",
+      "hint": "[Hint text (optional)]",
+      "value": "value-1"
+    },
+    {
+      "_id": "component_checkbox_2",
+      "_type": "checkbox",
+      "label": "Option",
+      "hint": "[Hint text (optional)]",
+      "value": "value-2"
+    }
+  ],
   "name": "component-name",
   "legend": "Question"
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.13.1'
+  VERSION = '0.13.2'
 end

--- a/schemas/definition/checkbox.json
+++ b/schemas/definition/checkbox.json
@@ -36,7 +36,6 @@
     }
   ],
   "required": [
-    "name",
     "label"
   ],
   "transforms": {


### PR DESCRIPTION
This PR:
- adds items to the checkbox default metadata, which is required for the editor
- Removes `name` from the required fields as it is not used
- Bumps the version to 0.13.2