### PR TITLE
Feature/preview

### DIFF
--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -8,7 +8,9 @@ module MetadataPresenter
     def back_link
       return if @page.blank?
 
-      @back_link ||= service.previous_page(current_page: @page)&.url
+      previous_page = service.previous_page(current_page: @page)&.url
+
+      @back_link ||= File.join(request.script_name, previous_page) if previous_page
     end
     helper_method :back_link
 

--- a/app/views/metadata_presenter/header/show.html.erb
+++ b/app/views/metadata_presenter/header/show.html.erb
@@ -26,7 +26,7 @@
     </div>
     <% if service.service_name.present? %>
       <div class="govuk-header__content">
-        <a href="/" class="govuk-header__link govuk-header__link--service-name">
+        <a href="<%= root_path %>" class="govuk-header__link govuk-header__link--service-name">
           <%= service.service_name %>
         </a>
     <% end %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.13.2'
+  VERSION = '0.13.3'
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -1,20 +1,54 @@
 RSpec.describe MetadataPresenter::EngineController, type: :controller do
   describe '#back_link' do
-    context 'when there is a page' do
-      let(:page) { MetadataPresenter::Page.new(service.pages.second) }
+    before do
+      allow(controller.request).to receive(:script_name).and_return(script_name)
+    end
+
+    context 'when in preview' do
+      let(:script_name) do
+        '/services/1/preview'
+      end
 
       before do
         controller.instance_variable_set(:@page, page)
       end
 
-      it 'returns the previous page' do
-        expect(controller.back_link).to eq('/')
+      context 'when there is a page' do
+        let(:page) { MetadataPresenter::Page.new(service.pages.second) }
+
+        it 'returns the previous page' do
+          expect(controller.back_link).to eq('/services/1/preview/')
+        end
+      end
+
+      context 'when there is no page' do
+        let(:page) { MetadataPresenter::Page.new(service.pages.first) }
+
+        it 'returns nil' do
+          expect(controller.back_link).to be_nil
+        end
       end
     end
 
-    context 'when there is no page' do
-      it 'returns nil' do
-        expect(controller.back_link).to be_nil
+    context 'when in the runner' do
+      let(:script_name) { '' }
+
+      context 'when there is a page' do
+        let(:page) { MetadataPresenter::Page.new(service.pages.second) }
+
+        before do
+          controller.instance_variable_set(:@page, page)
+        end
+
+        it 'returns the previous page' do
+          expect(controller.back_link).to eq('/')
+        end
+      end
+
+      context 'when there is no page' do
+        it 'returns nil' do
+          expect(controller.back_link).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
When a user clicks on the preview button on the page flow page or the preview link from the forms page a new tab is opened in their browser.

The preview will function as if it is on the runner and therefore the back links needed to be adjusted to accommodate this.

https://trello.com/c/opSQzaPH/1285-preview-form-from-button

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>

