### PR TITLE
Suppress hidden fields in checkbox collections

### DIFF
--- a/app/presenters/metadata_presenter/page_answers_presenter.rb
+++ b/app/presenters/metadata_presenter/page_answers_presenter.rb
@@ -51,7 +51,7 @@ module MetadataPresenter
     end
 
     def checkboxes(value)
-      value.reject(&:blank?).join("<br>").html_safe
+      value.join("<br>").html_safe
     end
   end
 end

--- a/app/validators/metadata_presenter/base_validator.rb
+++ b/app/validators/metadata_presenter/base_validator.rb
@@ -63,12 +63,7 @@ module MetadataPresenter
     # @return [String] user answer for the specific component
     #
     def user_answer
-      value = page_answers.send(component.name)
-      if component.type == 'checkboxes'
-        Array(value).reject(&:blank?)
-      else
-        value
-      end
+      page_answers.send(component.name)
     end
 
     # The default error message will be look using the schema key.

--- a/app/views/metadata_presenter/component/_checkboxes.html.erb
+++ b/app/views/metadata_presenter/component/_checkboxes.html.erb
@@ -5,5 +5,6 @@
     :name,
     :description,
     legend: { text: input_title },
-    hint: { text: component.hint }
+    hint: { text: component.hint },
+    include_hidden: false
 %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.13.3'
+  VERSION = '0.13.4'
 end


### PR DESCRIPTION
Now that the dfe formbuilder gem allows `include_hidden: false`, we can use this in our checkbox collection and remove our old workaround.

This PR also bumps the metadata-presenter version to 0.13.4.

For context: https://github.com/DFE-Digital/govuk_design_system_formbuilder/pull/240