### PR TITLE
Add footer

### DIFF
--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -27,6 +27,8 @@
         <%= yield %>
       </main>
     </div>
+    <%= render template: 'metadata_presenter/footer/footer' %>
+
     <%= javascript_pack_tag 'application' %>
     <%= javascript_pack_tag 'govuk' %>
   </body>

--- a/app/views/metadata_presenter/footer/footer.html.erb
+++ b/app/views/metadata_presenter/footer/footer.html.erb
@@ -1,0 +1,19 @@
+<footer class="govuk-footer " role="contentinfo">
+  <div class="govuk-width-container ">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.14.2'
+  VERSION = '0.15.0'
 end


### PR DESCRIPTION
## Add footer to application layout

This just adds the generic GOV.UK footer to the application layout.

The links to accessibility, cookies and privacy will be added once those are available.

## 0.15.0

## Screenshot

![Screenshot 2021-03-02 at 09 53 39](https://user-images.githubusercontent.com/3466862/109632385-e2e85d80-7b3e-11eb-8ef0-7cb01819056f.png)
