### PR TITLE
Allow component title helper method to accept tags and classes

### DIFF
--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -1,14 +1,14 @@
 module MetadataPresenter
   module ApplicationHelper
-    def main_h1(component)
+    def main_title(component:, tag: :h1, classes: 'govuk-heading-xl')
       if component.legend.present?
         content_tag(:legend, class: 'govuk-fieldset__legend govuk-fieldset__legend--l') do
-          content_tag(:h1, class: 'govuk-heading-xl') do
+          content_tag(tag, class: classes) do
             component.legend
           end
         end
       else
-        content_tag(:h1, class: 'govuk-heading-xl') do
+        content_tag(tag, class: classes) do
           component.label
         end
       end

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -8,7 +8,7 @@
             component: component,
             component_id: "page[components[#{index}]]",
             f: f,
-            input_title: main_h1(component) }
+            input_title: main_title(component: component) }
           %>
         <% end %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
-  describe '#main_h1' do
+  describe '#main_title' do
     context 'when component has a legend' do
       let(:component) do
         MetadataPresenter::Component.new(legend: 'Luke Skywalker')
       end
 
-      it 'returns h1 wrapped in a legend' do
-        expect(helper.main_h1(component)).to eq(
+      it 'returns h1 wrapped in a legend by default' do
+        expect(helper.main_title(component: component)).to eq(
           %{<legend class="govuk-fieldset__legend govuk-fieldset__legend--l"><h1 class="govuk-heading-xl">Luke Skywalker</h1></legend>}
         )
       end
@@ -17,9 +17,23 @@ RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
         MetadataPresenter::Component.new(label: 'Luke Skywalker')
       end
 
-      it 'returns h1 wrapped in a legend' do
-        expect(helper.main_h1(component)).to eq(
+      it 'returns h1 default' do
+        expect(helper.main_title(component: component)).to eq(
           %{<h1 class="govuk-heading-xl">Luke Skywalker</h1>}
+        )
+      end
+    end
+
+    context 'when tag and classes supplied' do
+      let(:component) do
+        MetadataPresenter::Component.new(label: 'Mace Windu')
+      end
+
+      it 'returns the element wrapped in the right tag with classes' do
+        expect(
+          helper.main_title(component: component, tag: :h2, classes: 'govuk-heading-m govuk-margin-top-5')
+        ).to eq(
+          %{<h2 class="govuk-heading-m govuk-margin-top-5">Mace Windu</h2>}
         )
       end
     end


### PR DESCRIPTION
For the multiple question page neither the component legend of label should be the h1 element nor be styled as extra large. Therefore we need to be able to allow for a tag and additional classes to be supplied to the helper in order to flexibly render components on multiple questions pages.

https://trello.com/c/ZiXnSx8Q/1335-multi-question-page