### PR TITLE
Multiple questions page

### DIFF
--- a/app/controllers/metadata_presenter/pages_controller.rb
+++ b/app/controllers/metadata_presenter/pages_controller.rb
@@ -12,13 +12,13 @@ module MetadataPresenter
       end
     end
 
-    def page_answers_presenters
+    def pages_presenters
       PageAnswersPresenter.map(
         view: view_context,
         pages: service.pages,
         answers: @user_data
       )
     end
-    helper_method :page_answers_presenters
+    helper_method :pages_presenters
   end
 end

--- a/app/presenters/metadata_presenter/page_answers_presenter.rb
+++ b/app/presenters/metadata_presenter/page_answers_presenter.rb
@@ -1,5 +1,7 @@
 module MetadataPresenter
   class PageAnswersPresenter
+    FIRST_ANSWER = 0.freeze
+
     def self.map(view:, pages:, answers:)
       pages.map do |page|
         Array(page.components).map do |component|
@@ -10,7 +12,7 @@ module MetadataPresenter
             answers: answers
           )
         end
-      end.flatten
+      end.reject { |page| page.empty? }
     end
 
     attr_reader :view, :component, :page, :answers
@@ -35,6 +37,10 @@ module MetadataPresenter
       else
         value
       end
+    end
+
+    def display_heading?(index)
+      page.type == 'page.multiplequestions' && index == FIRST_ANSWER
     end
 
     private

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -35,25 +35,36 @@
     <%= form_for @page, url: reserved_submissions_path do |f| %>
       <div data-block-id="page.checkanswers.answers" data-block-type="answers">
         <dl class="fb-block fb-block-answers govuk-summary-list">
-          <% page_answers_presenters.each do |page_answers_presenter| %>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                <%= page_answers_presenter.humanised_title %>
-              </dt>
+          <% pages_presenters.each do |page_answers_presenters| %>
+            <% page_answers_presenters.each_with_index do |page_answers_presenter, index| %>
 
-              <dd class="govuk-summary-list__value">
-                <%= page_answers_presenter.answer %>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-              <%= link_to(
-                    change_answer_path(url: page_answers_presenter.url),
-                    class: 'govuk-link'
-                  ) do %>
-                     Change<span class="govuk-visually-hidden"> Your answer for <%= page_answers_presenter.humanised_title %></span>
-                <% end %>
-                </a>
-              </dd>
-            </div>
+              <% if page_answers_presenter.display_heading?(index) %>
+                </dl>
+
+                <h3 class="govuk-heading-m"><%= page_answers_presenter.page.heading %></h3>
+
+                <dl class="fb-block fb-block-answers govuk-summary-list">
+              <% end %>
+
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  <%= page_answers_presenter.humanised_title %>
+                </dt>
+
+                <dd class="govuk-summary-list__value">
+                  <%= page_answers_presenter.answer %>
+                </dd>
+                <dd class="govuk-summary-list__actions">
+                <%= link_to(
+                      change_answer_path(url: page_answers_presenter.url),
+                      class: 'govuk-link'
+                    ) do %>
+                      Change<span class="govuk-visually-hidden"> Your answer for <%= page_answers_presenter.humanised_title %></span>
+                  <% end %>
+                  </a>
+                </dd>
+              </div>
+            <% end %>
           <% end %>
         </dl>
       </div>

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -1,0 +1,33 @@
+<div class="fb-main-grid-wrapper" data-block-id="<%= @page.id %>" data-block-type="page" data-block-pagetype="<%= @page.type %>">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if @page.section_heading %>
+        <p class="fb-editable govuk-caption-l fb-section_heading"
+           data-fb-content-type="element"
+           data-fb-content-id="page[section_heading]">
+          <%= @page.section_heading.html_safe %>
+        </p>
+      <%- end %>
+
+      <h1 class="govuk-heading-xl"><%= @page.heading %></h1>
+
+      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
+        <%= f.govuk_error_summary %>
+        <% @page.components.each_with_index do |component, index| %>
+          <%= render partial: component, locals: {
+            component: component,
+            component_id: "page[components[#{index}]]",
+            f: f,
+            input_title: main_title(
+              component: component,
+              tag: :h2,
+              classes: 'govuk-heading-m govuk-!-margin-top-8'
+            ) }
+          %>
+        <% end %>
+
+        <%= f.govuk_submit(disabled: editable?) %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/default_metadata/page/multiplequestions.json
+++ b/default_metadata/page/multiplequestions.json
@@ -1,0 +1,8 @@
+{
+  "_id": "page.multiplequestions",
+  "_type": "page.multiplequestions",
+  "section_heading": "[Section heading (optional)]",
+  "heading": "Question",
+  "components": [],
+  "url": ""
+}

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -267,6 +267,59 @@
       "url": "/burgers"
     },
     {
+      "_uuid": "9403b67a-19b5-4422-a91d-0774537e4c96",
+      "_id": "page.star-wars-knowledge",
+      "_type": "page.multiplequestions",
+      "components": [
+        {
+          "_id": "star-wars-knowledge_text_1",
+          "_type": "text",
+          "label": "What was the name of the band playing in Jabba's palace?",
+          "name": "star-wars-knowledge_text_1",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "_id": "star-wars-knowledge_radios_1",
+          "_type": "radios",
+          "errors": {},
+          "hint": "Component hint",
+          "legend": "What is The Mandalorian's real name?",
+          "items": [
+            {
+              "_id": "star-wars-knowledge_radio_1",
+              "_type": "radio",
+              "label": "Harry Potter",
+              "hint": "Optional item hint",
+              "value": "harry-potter"
+            },
+            {
+              "_id": "star-wars-knowledge_radio_2",
+              "_type": "radio",
+              "label": "Din Jarrin",
+              "hint": "Optional item hint",
+              "value": "din-jarrin"
+            },
+            {
+              "_id": "star-wars-knowledge_radio_3",
+              "_type": "radio",
+              "label": "Tony Stark",
+              "hint": "Optional item hint",
+              "value": "tony-stark"
+            }
+          ],
+          "name": "star-wars-knowledge_radios_1",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "heading": "How well do you know Star Wars?",
+      "section_heading": "That's no moon",
+      "url": "/star-wars-knowledge"
+    },
+    {
       "_uuid": "e819d0c2-7062-4997-89cf-44d26d098404",
       "_id": "page._check-answers",
       "_type": "page.checkanswers",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.15.3'
+  VERSION = '0.16.0'
 end

--- a/schemas/page/multiplequestions.json
+++ b/schemas/page/multiplequestions.json
@@ -1,0 +1,20 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/page/multiplequestions",
+  "_name": "page.multiplequestions",
+  "title": "Multiple questions",
+  "description": "Ask users more than one question on a page",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "page.multiplequestions"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.page.form"
+    }
+  ],
+  "required": [
+    "heading"
+  ]
+}

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MetadataPresenter::PagesController do
 
     it 'maps the answers' do
       expect(MetadataPresenter::PageAnswersPresenter).to receive(:map)
-      controller.page_answers_presenters
+      controller.pages_presenters
     end
   end
 end

--- a/spec/presenters/page_answers_presenter_spec.rb
+++ b/spec/presenters/page_answers_presenter_spec.rb
@@ -13,11 +13,18 @@ RSpec.describe MetadataPresenter::PageAnswersPresenter do
 
   describe '.map' do
     let(:answers) { {} }
+    let(:page_answers) do
+      described_class.map(view: view, pages: pages, answers: answers)
+    end
 
-    it 'returns instance of page answers' do
-      expect(
-        described_class.map(view: view, pages: pages, answers: answers).collect(&:url)
-      ).to include('/name')
+    it 'returns a collection of page answers presenters' do
+      expect(page_answers.flatten).to all(be_a(MetadataPresenter::PageAnswersPresenter))
+    end
+
+    it 'groups page answer presenters by page' do
+      page_answers.each do |page|
+        page.map(&:page).collect(&:id).uniq.length == 1
+      end
     end
   end
 


### PR DESCRIPTION
## Add multiple question schemas and default metadata

This adds the multiple questions schema and metadata.

It was necessary to adjust how the PageAnswersPresenter collected the answers when passing them into the CYA page.

Previously the map function returned a flat array of Presenters. When there is only one question per page this is fine as the CYA page uses the label or the legend of the component and does not think about the page at all.

However for multiple question pages the questions are essentially grouped by the heading on the page. By the time we get to the CYA page it makes sense to group the answers by the page heading and present that back to the user.

In order to achieve this we now collect the page answers grouped by the page that they are found on, then iterate over those pages and then the answers checking whether it is necessary to show the heading of the page or not.

## 0.16.0

## Multiple Questions Page

![Screenshot 2021-03-04 at 14 56 56](https://user-images.githubusercontent.com/3466862/109982550-eb38c800-7cf9-11eb-9e1c-c819cae9840d.png)


## Check Your Answers Page (After)

![Screenshot 2021-03-04 at 11 22 09](https://user-images.githubusercontent.com/3466862/109962181-cab14380-7ce2-11eb-8ddf-15439de91b29.png)

https://trello.com/c/ZiXnSx8Q/1335-multi-question-page