### PR TITLE
Adjust page schemas

### DIFF
--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.16.2'
+  VERSION = '0.17.0'
 end

--- a/schemas/definition/page.json
+++ b/schemas/definition/page.json
@@ -100,6 +100,8 @@
   ],
   "required": [
     "_uuid",
+    "_id",
+    "_type",
     "url"
   ],
   "category": [

--- a/schemas/page/checkanswers.json
+++ b/schemas/page/checkanswers.json
@@ -48,13 +48,10 @@
     }
   },
   "required": [
-    "_id",
-    "_type",
     "heading",
     "send_heading",
     "send_body"
   ],
-  "additionalProperties": false,
   "allOf": [
     {
       "$ref": "definition.page.form"

--- a/schemas/page/confirmation.json
+++ b/schemas/page/confirmation.json
@@ -22,11 +22,8 @@
     }
   },
   "required": [
-    "_id",
-    "_type",
     "heading"
   ],
-  "additionalProperties": false,
   "allOf": [
     {
       "$ref": "definition.page.content"

--- a/schemas/page/singlequestion.json
+++ b/schemas/page/singlequestion.json
@@ -21,6 +21,7 @@
     }
   ],
   "required": [
+    "heading",
     "components"
   ],
   "surplus_properties": [

--- a/schemas/page/start.json
+++ b/schemas/page/start.json
@@ -37,8 +37,6 @@
     ]
   },
   "required": [
-    "_id",
-    "_type",
     "heading",
     "steps"
   ]


### PR DESCRIPTION
## Move _id and _type to page schema …

The _id and _type are always required when generating a new page. We may as well put them as required fields in the page definition as all the pages eventually inherit from that definition.

Also remove the additionalProperties = false for the checkanswers and confirmation pages because that flag validates too early. The definition that relates to properties such as _id and _uuid is in the page definition and would therefore always fail.

For example, with the confirmation page we define properties such as heading, body and lede. However the metadata generated will contain _uuid which is correct, but the additionalProperties flag would fail the validation before it goes to 

## 0.17.0