### PR TITLE
Add content page schema, default metadata and template

### DIFF
--- a/app/views/metadata_presenter/footer/footer.html.erb
+++ b/app/views/metadata_presenter/footer/footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="govuk-footer " role="contentinfo">
+<footer class="govuk-footer fb-editor-footer" role="contentinfo">
   <div class="govuk-width-container ">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -1,0 +1,56 @@
+<div class="fb-main-grid-wrapper" data-fb-pagetype="<%= @page.type %>">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if @page.section_heading -%>
+        <p class="fb-editable govuk-caption-l fb-section_heading"
+           data-fb-content-type="element"
+           data-fb-content-id="page[section_heading]">
+          <%= @page.section_heading.html_safe %>
+        </p>
+      <%- end %>
+
+      <% if @page.heading %>
+        <h1 class="fb-editable govuk-heading-xl"
+            data-fb-content-id="page[heading]"
+            data-fb-content-type="element">
+          <%= @page.heading.html_safe %>
+        </h1>
+      <% end %>
+
+      <% if @page.lede %>
+        <div class="fb-editable"
+             data-fb-content-id="page[lede]"
+             data-fb-content-type="content">
+          <%= @page.lede.html_safe %>
+        </div>
+      <%- end %>
+
+      <% if @page.body %>
+        <div class="fb-editable"
+             data-fb-content-id="page[body]"
+             data-fb-content-type="content">
+          <%= to_markdown(@page.body) %>
+        </div>
+      <%- end %>
+
+      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <% @page.components.each_with_index do |component, index| %>
+          <div class="fb-editable"
+               data-fb-content-type="<%= component._type %>"
+               data-fb-content-id="<%= "page[components[#{index}]]" %>"
+               data-fb-content-data="<%= component.to_json %>">
+            <%= render partial: component, locals: {
+              component: component,
+              f: f,
+              input_title: main_title(component: component) }
+            %>
+          </div>
+        <% end %>
+
+        <%= f.govuk_submit(disabled: editable?) %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -10,7 +10,7 @@
       <%- end %>
 
       <% if @page.heading %>
-        <h1 class="fb-editable <%= @page.heading_class %>"
+        <h1 class="fb-editable govuk-heading-xl"
             data-fb-content-id="page[heading]"
             data-fb-content-type="element">
           <%= @page.heading.html_safe %>

--- a/default_metadata/component/content.json
+++ b/default_metadata/component/content.json
@@ -1,5 +1,5 @@
 {
   "_id": "component.content",
   "_type": "content",
-  "html": "Content HTML"
+  "html": "[Optional content]"
 }

--- a/default_metadata/page/content.json
+++ b/default_metadata/page/content.json
@@ -1,0 +1,10 @@
+{
+  "_id": "page.content",
+  "_type": "page.content",
+  "section_heading": "[Optional section heading]",
+  "heading": "Title",
+  "lede": "[Optional lead paragraph]",
+  "body": "[Optional content]",
+  "components": [],
+  "url": ""
+}

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -320,6 +320,16 @@
       "url": "/star-wars-knowledge"
     },
     {
+      "_uuid": "1ed3e4ad-5098-41c9-b4b6-426e89f7804e",
+      "_id": "page.how-many-lights",
+      "_type": "page.content",
+      "section_heading": "Chain of Command",
+      "heading": "Tell me how many lights you see",
+      "body": "There are four lights!",
+      "components": [],
+      "url": "how-many-lights"
+    },
+    {
       "_uuid": "e819d0c2-7062-4997-89cf-44d26d098404",
       "_id": "page._check-answers",
       "_type": "page.checkanswers",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.17.1'
+  VERSION = '0.18.0'
 end

--- a/schemas/page/content.json
+++ b/schemas/page/content.json
@@ -1,0 +1,23 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/page/content",
+  "_name": "page.content",
+  "title": "Content",
+  "description": "Display content to users without asking any questions",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "page.content"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.page.content"
+    }
+  ],
+  "uiCategory": {
+    "main": [
+      "lede",
+      "body"
+    ]
+  }
+}


### PR DESCRIPTION
## Add content page schema and default metadata

This adds the content page schema, default metadata and the template. There is only meant to be the section heading, heading, lede and body. So very similar to the start page.

On top of that there will be the ability to add another content component in a future story.

The continue button remains as the page is meant to be for informative purposes. Since the public user is not going to be entering any information this content page will never appear on the check your answers page nor in the submission itself.

## Add the necessary class to the footer

This will make it sticky when used in the runner

## Use correct heading class on start page

The page object has now heading_class method. Set it to be govuk-heading-xl for now. This makes it match all the other page headings.

## 0.18.0

https://trello.com/c/vnNbK8rZ/1370-content-page-mvp-version-m-add-and-edit