### PR TITLE
Content page lede text size

### DIFF
--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -18,7 +18,7 @@
       <% end %>
 
       <% if @page.lede %>
-        <div class="fb-editable"
+        <div class="fb-editable govuk-body-l"
              data-fb-content-id="page[lede]"
              data-fb-content-type="content">
           <%= @page.lede.html_safe %>

--- a/default_metadata/page/content.json
+++ b/default_metadata/page/content.json
@@ -3,7 +3,7 @@
   "_type": "page.content",
   "section_heading": "[Optional section heading]",
   "heading": "Title",
-  "lede": "[Optional lead paragraph]",
+  "lede": "[Optional lede paragraph]",
   "body": "[Optional content]",
   "components": [],
   "url": ""

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.18.1'
+  VERSION = '0.18.2'
 end


### PR DESCRIPTION
## Make content page lede text 24px

The lede element of the content page needs to be 24px which corresponds to the govuk-body-l css class.

## 0.18.2

![Screenshot 2021-03-15 at 17 27 58](https://user-images.githubusercontent.com/3466862/111195149-dd196000-85b3-11eb-8d15-e79e289e8562.png)
