### PR TITLE
Do not parse raw HTML in certain element fields

### DIFF
--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -5,7 +5,7 @@
         <p class="fb-editable govuk-caption-l fb-section_heading"
            data-fb-content-type="element"
            data-fb-content-id="page[section_heading]">
-          <%= @page.section_heading.html_safe %>
+          <%= @page.section_heading %>
         </p>
       <%- end %>
 
@@ -13,7 +13,7 @@
         <h1 class="fb-editable govuk-heading-xl"
             data-fb-content-id="page[heading]"
             data-fb-content-type="element">
-          <%= @page.heading.html_safe %>
+          <%= @page.heading %>
         </h1>
       <% end %>
 
@@ -21,7 +21,7 @@
         <div class="fb-editable govuk-body-l"
              data-fb-content-id="page[lede]"
              data-fb-content-type="element">
-          <%= @page.lede.html_safe %>
+          <%= @page.lede %>
         </div>
       <%- end %>
 

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -5,7 +5,7 @@
         <p class="fb-editable govuk-caption-l fb-section_heading"
            data-fb-content-type="element"
            data-fb-content-id="page[section_heading]">
-          <%= @page.section_heading.html_safe %>
+          <%= @page.section_heading %>
         </p>
       <%- end %>
 

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -5,7 +5,7 @@
         <p class="fb-editable govuk-caption-l fb-section_heading"
            data-fb-content-type="element"
            data-fb-content-id="page[section_heading]">
-          <%= @page.section_heading.html_safe %>
+          <%= @page.section_heading %>
         </p>
       <%- end %>
 
@@ -13,7 +13,7 @@
         <h1 class="fb-editable govuk-heading-xl"
             data-fb-content-id="page[heading]"
             data-fb-content-type="element">
-          <%= @page.heading.html_safe %>
+          <%= @page.heading %>
         </h1>
       <% end %>
 
@@ -21,7 +21,7 @@
         <div class="fb-editable"
              data-fb-content-id="page[lede]"
              data-fb-content-type="element">
-          <%= @page.lede.html_safe %>
+          <%= @page.lede %>
         </div>
       <%- end %>
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.18.3'
+  VERSION = '0.18.4'
 end


### PR DESCRIPTION
We only want markdown to be parsed in order to correctly display formatted html back to the user. Therefore we do not want to support an editor entering raw html into a section heading, heading, question or lede.