### PR TITLE
Default text for elements and components

### DIFF
--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -21,5 +21,9 @@ module MetadataPresenter
       (Kramdown::Document.new(text).to_html).html_safe
     end
     alias to_markdown m
+
+    def default_text(property)
+      MetadataPresenter::DefaultText[property]
+    end
   end
 end

--- a/app/helpers/metadata_presenter/default_text.rb
+++ b/app/helpers/metadata_presenter/default_text.rb
@@ -1,0 +1,7 @@
+module MetadataPresenter
+  class DefaultText
+    def self.[](property)
+      Rails.application.config.default_text[property.to_s]
+    end
+  end
+end

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -9,11 +9,7 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
 
   def items
     metadata.items.map do |item|
-      OpenStruct.new(
-        id: item['label'],
-        name: item['label'],
-        description: item['hint']
-      )
+      MetadataPresenter::Item.new(item, editor: editor?)
     end
   end
 end

--- a/app/models/metadata_presenter/item.rb
+++ b/app/models/metadata_presenter/item.rb
@@ -1,0 +1,9 @@
+class MetadataPresenter::Item < MetadataPresenter::Metadata
+  def name
+    label
+  end
+
+  def description
+    hint
+  end
+end

--- a/app/models/metadata_presenter/metadata.rb
+++ b/app/models/metadata_presenter/metadata.rb
@@ -4,8 +4,9 @@ class MetadataPresenter::Metadata
 
   attr_reader :metadata
 
-  def initialize(metadata)
+  def initialize(metadata, editor: false)
     @metadata = OpenStruct.new(metadata)
+    @editor = editor
   end
 
   def to_json
@@ -25,6 +26,11 @@ class MetadataPresenter::Metadata
   end
 
   def method_missing(method_name, *args, &block)
-    metadata.send(method_name, *args, &block)
+    value = metadata.send(method_name, *args, &block)
+    value.blank? && editor? ? MetadataPresenter::DefaultText[method_name] : value
+  end
+
+  def editor?
+    @editor.present?
   end
 end

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -16,7 +16,7 @@ module MetadataPresenter
 
     def components
       metadata.components&.map do |component|
-        MetadataPresenter::Component.new(component)
+        MetadataPresenter::Component.new(component, editor: editor?)
       end
     end
 

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -1,6 +1,8 @@
 class MetadataPresenter::Service < MetadataPresenter::Metadata
   def pages
-    @_pages ||= metadata.pages.map { |page| MetadataPresenter::Page.new(page) }
+    @_pages ||= metadata.pages.map do |page|
+      MetadataPresenter::Page.new(page, editor: editor?)
+    end
   end
 
   def start_page

--- a/app/views/metadata_presenter/attribute/_body.html.erb
+++ b/app/views/metadata_presenter/attribute/_body.html.erb
@@ -1,0 +1,8 @@
+<% if @page.body %>
+  <div class="fb-editable"
+        data-fb-content-id="page[body]"
+        data-fb-content-type="content"
+        data-fb-default-text="<%= default_text('body') %>">
+    <%= to_markdown(@page.body) %>
+  </div>
+<%- end %>

--- a/app/views/metadata_presenter/attribute/_lede.html.erb
+++ b/app/views/metadata_presenter/attribute/_lede.html.erb
@@ -1,0 +1,8 @@
+<% if @page.lede %>
+  <div class="fb-editable govuk-body-l"
+        data-fb-content-id="page[lede]"
+        data-fb-content-type="element"
+        data-fb-default-text="<%= default_text('lede') %>">
+    <%= @page.lede %>
+  </div>
+<%- end %>

--- a/app/views/metadata_presenter/attribute/_section_heading.html.erb
+++ b/app/views/metadata_presenter/attribute/_section_heading.html.erb
@@ -1,0 +1,8 @@
+<% if @page.section_heading %>
+  <p class="fb-editable govuk-caption-l fb-section_heading"
+      data-fb-content-type="element"
+      data-fb-content-id="page[section_heading]"
+      data-fb-default-text="<%= default_text('section_heading') %>">
+    <%= @page.section_heading %>
+  </p>
+<%- end %>

--- a/app/views/metadata_presenter/component/_checkboxes.html.erb
+++ b/app/views/metadata_presenter/component/_checkboxes.html.erb
@@ -5,6 +5,9 @@
     :name,
     :description,
     legend: { text: input_title },
-    hint: { text: component.hint },
+    hint: {
+      data: { "fb-default-text" => default_text('hint') },
+      text: component.hint
+    },
     include_hidden: false
 %>

--- a/app/views/metadata_presenter/component/_content.html.erb
+++ b/app/views/metadata_presenter/component/_content.html.erb
@@ -1,0 +1,1 @@
+<%= to_markdown(component.html) %>

--- a/app/views/metadata_presenter/component/_date.html.erb
+++ b/app/views/metadata_presenter/component/_date.html.erb
@@ -1,5 +1,8 @@
 <%=
   f.govuk_date_field component.id.to_sym,
-    hint: { text: component.hint },
+    hint: {
+      data: { "fb-default-text" => default_text('hint') },
+      text: component.hint
+    },
     legend: { text: input_title }
 %>

--- a/app/views/metadata_presenter/component/_number.html.erb
+++ b/app/views/metadata_presenter/component/_number.html.erb
@@ -1,7 +1,10 @@
 <%=
   f.govuk_text_field component.id.to_sym,
     label: { text: input_title },
-    hint: { text: component.hint },
+    hint: {
+      data: { "fb-default-text" => default_text('hint') },
+      text: component.hint
+    },
     name: "answers[#{component.name}]",
     width: component.width_class_input.to_i
 %>

--- a/app/views/metadata_presenter/component/_radios.html.erb
+++ b/app/views/metadata_presenter/component/_radios.html.erb
@@ -5,5 +5,8 @@
     :name,
     :description,
     legend: { text: input_title },
-    hint: { text: component.hint }
+    hint: {
+      data: { "fb-default-text" => default_text('hint') },
+      text: component.hint
+    }
 %>

--- a/app/views/metadata_presenter/component/_text.html.erb
+++ b/app/views/metadata_presenter/component/_text.html.erb
@@ -1,6 +1,9 @@
 <%=
   f.govuk_text_field component.id.to_sym,
     label: { text: input_title },
-    hint: { text: component.hint },
+    hint: {
+      data: { "fb-default-text" => default_text('hint') },
+      text: component.hint
+    },
     name: "answers[#{component.name}]"
 %>

--- a/app/views/metadata_presenter/component/_textarea.html.erb
+++ b/app/views/metadata_presenter/component/_textarea.html.erb
@@ -1,7 +1,10 @@
 <%=
   f.govuk_text_area component.id.to_sym,
     label: { text: input_title },
-    hint: { text: component.hint },
+    hint: {
+      data: { "fb-default-text" => default_text('hint') },
+      text: component.hint
+    },
     name: "answers[#{component.name}]",
     max_chars: component.maxchars,
     max_words: component.maxwords,

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -11,15 +11,9 @@
       </h1>
     <% end %>
 
-    <%= render partial: 'metadata_presenter/attribute/lede' %>
+    <%= render 'metadata_presenter/attribute/lede' %>
 
-    <% if @page.body.present? %>
-      <div class="fb-body fb-editable govuk-prose-scope"
-           data-fb-content-type="content"
-           data-fb-content-id="page[body]">
-        <%= @page.body %>
-      </div>
-    <% end %>
+    <%= render 'metadata_presenter/attribute/body' %>
 
     <%= form_for @page, url: reserved_submissions_path do |f| %>
       <div data-block-id="page.checkanswers.answers" data-block-type="answers">

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -1,12 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @page.section_heading.present? %>
-      <p class="fb-section-heading fb-editable govuk-caption-l"
-         data-fb-content-type="element"
-         data-fb-content-id="page[section_heading]">
-        <%= @page.section_heading %>
-      </p>
-    <% end %>
+
+    <%= render partial: 'metadata_presenter/attribute/section_heading' %>
 
     <% if @page.heading.present? %>
       <h1 class="fb-editable govuk-heading-xl"

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -11,13 +11,7 @@
       </h1>
     <% end %>
 
-    <% if @page.lede.present? %>
-      <p class="fb-editable govuk-body-l"
-         data-fb-content-type="element"
-         data-fb-content-id="page[lede]">
-        <%= @page.lede %>
-      </p>
-    <% end %>
+    <%= render partial: 'metadata_presenter/attribute/lede' %>
 
     <% if @page.body.present? %>
       <div class="fb-body fb-editable govuk-prose-scope"

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -8,14 +8,8 @@
   <%= render 'metadata_presenter/attribute/lede' %>
 </div>
 
-<% if @page.body %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="fb-editable fb-body govuk-prose-scope"
-           data-fb-content-type="content"
-           data-fb-content-id="page[body]">
-        <%= @page.body %>
-      </div>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'metadata_presenter/attribute/body' %>
   </div>
-<% end %>
+</div>

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -5,13 +5,7 @@
     <%= @page.heading %>
   </h1>
 
-  <% if @page.lede %>
-    <p class="fb-editable govuk-panel__body"
-       data-fb-content-type="element"
-       data-fb-content-id="page[lede]">
-      <%= @page.lede %>
-    </p>
-  <% end %>
+  <%= render 'metadata_presenter/attribute/lede' %>
 </div>
 
 <% if @page.body %>

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -1,13 +1,8 @@
 <div class="fb-main-grid-wrapper" data-fb-pagetype="<%= @page.type %>">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if @page.section_heading -%>
-        <p class="fb-editable govuk-caption-l fb-section_heading"
-           data-fb-content-type="element"
-           data-fb-content-id="page[section_heading]">
-          <%= @page.section_heading %>
-        </p>
-      <%- end %>
+
+      <%= render 'metadata_presenter/attribute/section_heading' %>
 
       <% if @page.heading %>
         <h1 class="fb-editable govuk-heading-xl"

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -12,13 +12,7 @@
         </h1>
       <% end %>
 
-      <% if @page.lede %>
-        <div class="fb-editable govuk-body-l"
-             data-fb-content-id="page[lede]"
-             data-fb-content-type="element">
-          <%= @page.lede %>
-        </div>
-      <%- end %>
+      <%= render 'metadata_presenter/attribute/lede' %>
 
       <% if @page.body %>
         <div class="fb-editable"

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -14,13 +14,7 @@
 
       <%= render 'metadata_presenter/attribute/lede' %>
 
-      <% if @page.body %>
-        <div class="fb-editable"
-             data-fb-content-id="page[body]"
-             data-fb-content-type="content">
-          <%= to_markdown(@page.body) %>
-        </div>
-      <%- end %>
+      <%= render 'metadata_presenter/attribute/body' %>
 
       <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
         <%= f.govuk_error_summary %>

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -1,13 +1,8 @@
 <div class="fb-main-grid-wrapper" data-block-id="<%= @page.id %>" data-block-type="page" data-block-pagetype="<%= @page.type %>">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if @page.section_heading %>
-        <p class="fb-editable govuk-caption-l fb-section_heading"
-           data-fb-content-type="element"
-           data-fb-content-id="page[section_heading]">
-          <%= @page.section_heading %>
-        </p>
-      <%- end %>
+
+      <%= render 'metadata_presenter/attribute/section_heading' %>
 
       <h1 class="govuk-heading-xl"><%= @page.heading %></h1>
 

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -1,13 +1,8 @@
 <div class="fb-main-grid-wrapper" data-fb-pagetype="<%= @page.type %>">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if @page.section_heading -%>
-        <p class="fb-editable govuk-caption-l fb-section_heading"
-           data-fb-content-type="element"
-           data-fb-content-id="page[section_heading]">
-          <%= @page.section_heading %>
-        </p>
-      <%- end %>
+
+    <%= render 'metadata_presenter/attribute/section_heading' %>
 
       <% if @page.heading %>
         <h1 class="fb-editable govuk-heading-xl"

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -14,13 +14,7 @@
 
       <%= render 'metadata_presenter/attribute/lede' %>
 
-      <% if @page.body %>
-        <div class="fb-editable"
-             data-fb-content-id="page[body]"
-             data-fb-content-type="content">
-          <%= to_markdown(@page.body) %>
-        </div>
-      <%- end %>
+      <%= render 'metadata_presenter/attribute/body' %>
 
       <%= form_tag(root_path, method: :post) do %>
         <button <%= 'disabled' if editable? %> class='govuk-button govuk-button--start govuk-!-margin-top-2'>

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -12,13 +12,7 @@
         </h1>
       <% end %>
 
-      <% if @page.lede %>
-        <div class="fb-editable"
-             data-fb-content-id="page[lede]"
-             data-fb-content-type="element">
-          <%= @page.lede %>
-        </div>
-      <%- end %>
+      <%= render 'metadata_presenter/attribute/lede' %>
 
       <% if @page.body %>
         <div class="fb-editable"

--- a/config/initializers/default_text.rb
+++ b/config/initializers/default_text.rb
@@ -1,0 +1,5 @@
+Rails.application.config.default_text = JSON.parse(
+  File.read(
+    MetadataPresenter::Engine.root.join('default_text', 'content.json')
+  )
+)

--- a/default_metadata/component/checkboxes.json
+++ b/default_metadata/component/checkboxes.json
@@ -2,20 +2,20 @@
   "_id": "component.checkboxes",
   "_type": "checkboxes",
   "errors": {},
-  "hint": "[Optional hint text]",
+  "hint": "",
   "items": [
     {
       "_id": "component_checkbox_1",
       "_type": "checkbox",
       "label": "Option",
-      "hint": "[Optional hint text]",
+      "hint": "",
       "value": "value-1"
     },
     {
       "_id": "component_checkbox_2",
       "_type": "checkbox",
       "label": "Option",
-      "hint": "[Optional hint text]",
+      "hint": "",
       "value": "value-2"
     }
   ],

--- a/default_metadata/component/date.json
+++ b/default_metadata/component/date.json
@@ -2,7 +2,7 @@
   "_id": "component.date",
   "_type": "date",
   "errors": {},
-  "hint": "[Optional hint text]",
+  "hint": "",
   "legend": "Question",
   "name": "component-name",
   "date_type": "day-month-year",

--- a/default_metadata/component/number.json
+++ b/default_metadata/component/number.json
@@ -2,7 +2,7 @@
   "_id": "component.number",
   "_type": "number",
   "errors": {},
-  "hint": "[Optional hint text]",
+  "hint": "",
   "label": "Question",
   "name": "component-name",
   "width_class_input": "10",

--- a/default_metadata/component/radios.json
+++ b/default_metadata/component/radios.json
@@ -2,20 +2,20 @@
   "_id": "component.radios",
   "_type": "radios",
   "errors": {},
-  "hint": "[Optional hint text]",
+  "hint": "",
   "items": [
     {
       "_id": "component_radio_1",
       "_type": "radio",
       "label": "Option",
-      "hint": "[Optional hint text]",
+      "hint": "",
       "value": "value-1"
     },
     {
       "_id": "component_radio_2",
       "_type": "radio",
       "label": "Option",
-      "hint": "[Optional hint text]",
+      "hint": "",
       "value": "value-2"
     }
   ],

--- a/default_metadata/component/text.json
+++ b/default_metadata/component/text.json
@@ -3,7 +3,7 @@
   "_type": "text",
   "errors": {},
   "label": "Question",
-  "hint": "[Optional hint text]",
+  "hint": "",
   "name": "component-name",
   "validation": {
     "required": true

--- a/default_metadata/component/textarea.json
+++ b/default_metadata/component/textarea.json
@@ -2,7 +2,7 @@
   "_id": "component.textarea",
   "_type": "textarea",
   "errors": {},
-  "hint": "[Optional hint text]",
+  "hint": "",
   "label": "Question",
   "name": "component-name",
   "rows": 5,

--- a/default_metadata/page/content.json
+++ b/default_metadata/page/content.json
@@ -3,7 +3,7 @@
   "_type": "page.content",
   "section_heading": "",
   "heading": "Title",
-  "lede": "[Optional lede paragraph]",
+  "lede": "",
   "body": "[Optional content]",
   "components": [],
   "url": ""

--- a/default_metadata/page/content.json
+++ b/default_metadata/page/content.json
@@ -1,7 +1,7 @@
 {
   "_id": "page.content",
   "_type": "page.content",
-  "section_heading": "[Optional section heading]",
+  "section_heading": "",
   "heading": "Title",
   "lede": "[Optional lede paragraph]",
   "body": "[Optional content]",

--- a/default_metadata/page/multiplequestions.json
+++ b/default_metadata/page/multiplequestions.json
@@ -1,7 +1,7 @@
 {
   "_id": "page.multiplequestions",
   "_type": "page.multiplequestions",
-  "section_heading": "[Optional section heading]",
+  "section_heading": "",
   "heading": "Title",
   "components": [],
   "url": ""

--- a/default_metadata/page/singlequestion.json
+++ b/default_metadata/page/singlequestion.json
@@ -2,7 +2,7 @@
   "_id": "page.singlequestion",
   "_type": "page.singlequestion",
   "heading": "Question",
-  "lede": "This is the lede",
+  "lede": "",
   "body": "Body section",
   "components": [],
   "url": ""

--- a/default_text/content.json
+++ b/default_text/content.json
@@ -1,0 +1,7 @@
+{
+  "section_heading": "[Optional section heading]",
+  "lede": "[Optional lede paragraph]",
+  "body": "[Optional content]",
+  "html": "[Optional content]",
+  "hint": "[Optional hint text]"
+}

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.18.4'
+  VERSION = '0.19.0'
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe MetadataPresenter::Item do
+  subject(:item) { described_class.new(metadata) }
+
+  describe '#name' do
+    let(:metadata) { { 'label' => 'Some label' } }
+
+    it 'returns hint' do
+      expect(item.name).to eq('Some label')
+    end
+  end
+
+  describe '#description' do
+    let(:metadata) { { 'hint' => 'Some hint' } }
+
+    it 'returns hint' do
+      expect(item.description).to eq('Some hint')
+    end
+  end
+end

--- a/spec/models/metadata_spec.rb
+++ b/spec/models/metadata_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe MetadataPresenter::Metadata do
+  subject(:metadata) { described_class.new(meta, editor: editor) }
+
+  context 'when editor' do
+    let(:editor) { true }
+
+    context 'when no text is in the metadata for a field with default content' do
+      let(:meta) { { 'section_heading' => '' } }
+
+
+      it 'should present the default text' do
+        expect(metadata.section_heading).to eq('[Optional section heading]')
+      end
+    end
+
+    context 'when there is text in the metadata property' do
+      let(:meta) { { 'section_heading' => 'some text' } }
+
+      it 'should present back the text' do
+        expect(metadata.section_heading).to eq('some text')
+      end
+    end
+
+    context 'when there is no default text for an empty property' do
+      let(:meta) { { 'nope' => '' } }
+
+      it 'should be nil' do
+        expect(metadata.nope).to be_nil
+      end
+    end
+  end
+
+  context 'not the editor' do
+    let(:editor) { false }
+
+    context 'when no text is in the metadata for a field with default content' do
+      let(:meta) { { 'section_heading' => '' } }
+
+      it 'should remain an empty string' do
+        expect(metadata.section_heading).to eq('')
+      end
+    end
+
+    context 'when there is text in the metadata property' do
+      let(:meta) { { 'section_heading' => 'some text' } }
+
+      it 'should present back the text' do
+        expect(metadata.section_heading).to eq('some text')
+      end
+    end
+
+    context 'when there is no default text for an empty property' do
+      let(:meta) { { 'nope' => '' } }
+
+      it 'should be an empty string' do
+        expect(metadata.nope).to eq('')
+      end
+    end
+  end
+
+  describe '#editor?' do
+    context 'when using the default' do
+      subject(:metadata) { described_class.new({}) }
+
+      it 'returns false' do
+        expect(metadata.editor?).to be_falsey
+      end
+    end
+
+    context 'when passing editor true' do
+      subject(:metadata) { described_class.new({}, editor: true) }
+
+      it 'returns true' do
+        expect(metadata.editor?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
We set the initializer method for the metadata object to now take an attribute called editor which by default will be false. This is used to check whether or not to show any default text for any given element.

In the editor we want default text to be shown if the user has not entered any custom text into a field. However in the runner if the editor user has not entered any custom text then we do not want the default text to be shown to the public user.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>

Story: https://trello.com/c/YSHgwzER/1382-placeholder-text