### PR TITLE
Add id to item model

### DIFF
--- a/app/models/metadata_presenter/item.rb
+++ b/app/models/metadata_presenter/item.rb
@@ -1,4 +1,8 @@
 class MetadataPresenter::Item < MetadataPresenter::Metadata
+  def id
+    label
+  end
+
   def name
     label
   end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.19.0'
+  VERSION = '0.19.1'
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,10 +1,18 @@
 RSpec.describe MetadataPresenter::Item do
   subject(:item) { described_class.new(metadata) }
 
+  describe '#id' do
+    let(:metadata) { { 'label' => 'Some label' } }
+
+    it 'returns label' do
+      expect(item.id).to eq('Some label')
+    end
+  end
+
   describe '#name' do
     let(:metadata) { { 'label' => 'Some label' } }
 
-    it 'returns hint' do
+    it 'returns label' do
       expect(item.name).to eq('Some label')
     end
   end


### PR DESCRIPTION
Without this the radio/checkboxes will use the component.id for
the values in the radios and that's not what we want.