### PR TITLE
Schemas validate page components

### DIFF
--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -1,14 +1,8 @@
 module MetadataPresenter
   module ApplicationHelper
     def main_title(component:, tag: :h1, classes: 'govuk-heading-xl')
-      if component.legend.present?
-        content_tag(:h1, class: 'govuk-heading-xl') do
-          component.legend
-        end
-      else
-        content_tag(tag, class: classes) do
-          component.label
-        end
+      content_tag(tag, class: classes) do
+        component.humanised_title
       end
     end
 

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -12,4 +12,8 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
       MetadataPresenter::Item.new(item, editor: editor?)
     end
   end
+
+  def content?
+    type == 'content'
+  end
 end

--- a/app/presenters/metadata_presenter/page_answers_presenter.rb
+++ b/app/presenters/metadata_presenter/page_answers_presenter.rb
@@ -1,9 +1,10 @@
 module MetadataPresenter
   class PageAnswersPresenter
     FIRST_ANSWER = 0.freeze
+    NO_USER_INPUT = %w(page.checkanswers page.confirmation page.content).freeze
 
     def self.map(view:, pages:, answers:)
-      pages.map do |page|
+      user_input_pages(pages).map do |page|
         Array(page.components).map do |component|
           new(
             view: view,
@@ -13,6 +14,10 @@ module MetadataPresenter
           )
         end
       end.reject { |page| page.empty? }
+    end
+
+    def self.user_input_pages(pages)
+      pages.reject { |page| page.type.in?(NO_USER_INPUT) }
     end
 
     attr_reader :view, :component, :page, :answers

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -1,0 +1,20 @@
+<% @page.components.each_with_index do |component, index| %>
+  <div class="fb-editable"
+        id="<%= component.id %>"
+        data-fb-content-type="<%= component.type %>"
+        data-fb-content-id="<%= "page[components[#{index}]]" %>"
+        data-fb-content-data="<%= component.to_json %>">
+
+    <%= render partial: component, locals: {
+        f: f,
+        component: component,
+        component_id: "page[components[#{index}]]",
+        input_title: main_title(
+          component: component,
+          tag: :h2,
+          classes: classes
+        )
+      }
+    %>
+  </div>
+<% end %>

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -64,6 +64,14 @@
         </div>
       <% end %>
 
+      <%= render partial: 'metadata_presenter/component/components',
+                 locals: {
+                   f: f,
+                   components: @page.components,
+                   tag: nil,
+                   classes: nil
+                 } %>
+
       <button <%= 'disabled' if editable? %> data-prevent-double-click="true" class="fb-block fb-block-actions govuk-button" data-module="govuk-button" data-block-id="actions" data-block-type="actions">
         Accept and send application
       </button>

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -11,10 +11,6 @@
       </h1>
     <% end %>
 
-    <%= render 'metadata_presenter/attribute/lede' %>
-
-    <%= render 'metadata_presenter/attribute/body' %>
-
     <%= form_for @page, url: reserved_submissions_path do |f| %>
       <div data-block-id="page.checkanswers.answers" data-block-type="answers">
         <dl class="fb-block fb-block-answers govuk-summary-list">

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -13,3 +13,11 @@
     <%= render 'metadata_presenter/attribute/body' %>
   </div>
 </div>
+
+<%= render partial: 'metadata_presenter/component/components',
+           locals: {
+             f: nil,
+             components: @page.components,
+             tag: nil,
+             classes: nil
+           } %>

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -17,20 +17,14 @@
       <%= render 'metadata_presenter/attribute/body' %>
 
       <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
-        <%= f.govuk_error_summary %>
 
-        <% @page.components.each_with_index do |component, index| %>
-          <div class="fb-editable"
-               data-fb-content-type="<%= component._type %>"
-               data-fb-content-id="<%= "page[components[#{index}]]" %>"
-               data-fb-content-data="<%= component.to_json %>">
-            <%= render partial: component, locals: {
-              component: component,
-              f: f,
-              input_title: main_title(component: component) }
-            %>
-          </div>
-        <% end %>
+        <%= render partial: 'metadata_presenter/component/components',
+                   locals: {
+                     f: f,
+                     components: @page.components,
+                     tag: nil,
+                     classes: nil
+                   } %>
 
         <%= f.govuk_submit(disabled: editable?) %>
       <% end %>

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -9,16 +9,23 @@
       <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
         <%= f.govuk_error_summary %>
         <% @page.components.each_with_index do |component, index| %>
-          <%= render partial: component, locals: {
-            component: component,
-            component_id: "page[components[#{index}]]",
-            f: f,
-            input_title: main_title(
+          <div class="fb-editable"
+               id="<%= component.id %>"
+               data-fb-content-type="<%= component.type %>"
+               data-fb-content-id="<%= "page[components[#{index}]]" %>"
+               data-fb-content-data="<%= component.to_json %>">
+
+            <%= render partial: component, locals: {
               component: component,
-              tag: :h2,
-              classes: 'govuk-heading-m govuk-!-margin-top-8'
-            ) }
-          %>
+              component_id: "page[components[#{index}]]",
+              f: f,
+              input_title: main_title(
+                component: component,
+                tag: :h2,
+                classes: 'govuk-heading-m govuk-!-margin-top-8'
+              ) }
+            %>
+          </div>
         <% end %>
 
         <%= f.govuk_submit(disabled: editable?) %>

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -8,25 +8,14 @@
 
       <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
         <%= f.govuk_error_summary %>
-        <% @page.components.each_with_index do |component, index| %>
-          <div class="fb-editable"
-               id="<%= component.id %>"
-               data-fb-content-type="<%= component.type %>"
-               data-fb-content-id="<%= "page[components[#{index}]]" %>"
-               data-fb-content-data="<%= component.to_json %>">
 
-            <%= render partial: component, locals: {
-              component: component,
-              component_id: "page[components[#{index}]]",
-              f: f,
-              input_title: main_title(
-                component: component,
-                tag: :h2,
-                classes: 'govuk-heading-m govuk-!-margin-top-8'
-              ) }
-            %>
-          </div>
-        <% end %>
+        <%= render partial: 'metadata_presenter/component/components', locals: {
+            f: f,
+            components: @page.components,
+            tag: :h2,
+            classes: 'govuk-heading-m govuk-!-margin-top-8'
+          }
+        %>
 
         <%= f.govuk_submit(disabled: editable?) %>
       <% end %>

--- a/default_metadata/page/confirmation.json
+++ b/default_metadata/page/confirmation.json
@@ -1,5 +1,6 @@
 {
   "_id": "page.confirmation",
   "_type": "page.confirmation",
-  "heading": "Application complete"
+  "heading": "Application complete",
+  "components": []
 }

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -326,20 +326,31 @@
       "section_heading": "Chain of Command",
       "heading": "Tell me how many lights you see",
       "body": "There are four lights!",
-      "components": [],
+      "components": [
+        {
+          "_id": "how-many-lights_content_1",
+          "_type": "content",
+          "html": "What lights?"
+        }
+      ],
       "url": "how-many-lights"
     },
     {
       "_uuid": "e819d0c2-7062-4997-89cf-44d26d098404",
       "_id": "page._check-answers",
       "_type": "page.checkanswers",
-      "body": "Optional content",
       "heading": "Review your answer",
-      "lede": "First paragraph",
       "section_heading": "This section is optional",
       "send_body": "By submitting this answer you confirm all your answers",
       "send_heading": "Send your answer",
-      "url": "/check-answers"
+      "url": "/check-answers",
+      "components": [
+        {
+          "_id": "check-answers_content_1",
+          "_type": "content",
+          "html": "Check yourself before you wreck yourself."
+        }
+      ]
     },
     {
       "_uuid": "b238a22f-c180-48d0-a7d9-8aad2036f1f2",
@@ -348,7 +359,14 @@
       "body": "You'll receive a confirmation email",
       "heading": "Complaint sent",
       "lede": "Optional lede",
-      "url": "/confirmation"
+      "url": "/confirmation",
+      "components": [
+        {
+          "_id": "confirmation_content_1",
+          "_type": "content",
+          "html": "Some day I will be the most powerful Jedi ever!"
+        }
+      ]
     }
   ],
   "locale": "en"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.20.0'
+  VERSION = '0.21.0'
 end

--- a/schemas/page/checkanswers.json
+++ b/schemas/page/checkanswers.json
@@ -17,16 +17,6 @@
       "type": "string",
       "default": "Check your answers"
     },
-    "lede": {
-      "title": "Lede",
-      "type": "string",
-      "description": "Content before the body"
-    },
-    "body": {
-      "title": "Body",
-      "type": "string",
-      "description": "Optional content before showing the summary"
-    },
     "summary_of": {
       "title": "Summary of",
       "description": "Page/section that summary summarises"

--- a/schemas/page/checkanswers.json
+++ b/schemas/page/checkanswers.json
@@ -45,6 +45,14 @@
       "content": true,
       "multiline": true,
       "default": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct."
+    },
+    "components": {
+      "title": "Components",
+      "description": "The form or content elements used on the page",
+      "type": "array",
+      "items": {
+        "$ref": "component.content"
+      }
     }
   },
   "required": [

--- a/schemas/page/confirmation.json
+++ b/schemas/page/confirmation.json
@@ -19,6 +19,14 @@
     },
     "lede": {
       "multiline": true
+    },
+    "components": {
+      "title": "Components",
+      "description": "The form or content elements used on the page",
+      "type": "array",
+      "items": {
+        "$ref": "component.content"
+      }
     }
   },
   "required": [

--- a/schemas/page/content.json
+++ b/schemas/page/content.json
@@ -7,6 +7,14 @@
   "properties": {
     "_type": {
       "const": "page.content"
+    },
+    "components": {
+      "title": "Components",
+      "description": "The form or content elements used on the page",
+      "type": "array",
+      "items": {
+        "$ref": "component.content"
+      }
     }
   },
   "allOf": [


### PR DESCRIPTION
## Support adding components to pages

This adds the ability to add components to the pages. The multiple questions page needs to be able to add all the different types of components.

However the content, checkanswers and confirmation pages should only be allowed to add content components.

## Publish 0.21.0

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>