### PR TITLE
Update confirmation page in fixture

### DIFF
--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -360,13 +360,7 @@
       "heading": "Complaint sent",
       "lede": "Optional lede",
       "url": "/confirmation",
-      "components": [
-        {
-          "_id": "confirmation_content_1",
-          "_type": "content",
-          "html": "Some day I will be the most powerful Jedi ever!"
-        }
-      ]
+      "components": []
     }
   ],
   "locale": "en"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.21.0'
+  VERSION = '0.21.1'
 end


### PR DESCRIPTION
For the moment our tests rely heavily on the version fixture having a certain structure. Some of those tests rely on the fact that the confirmation page has no components in it by default.

Publish 0.21.1