### PR TITLE
Additional fixtures

### DIFF
--- a/fixtures/invalid_content_page.json
+++ b/fixtures/invalid_content_page.json
@@ -1,0 +1,72 @@
+{
+  "_id": "service.base",
+  "_type": "service.base",
+  "service_name": "Service name",
+  "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+  "configuration": {
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    },
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "_type": "link",
+          "href": "/cookies",
+          "text": "Cookies"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "_type": "link",
+          "href": "/privacy",
+          "text": "Privacy"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "_type": "link",
+          "href": "/accessibility",
+          "text": "Accessibility"
+        }
+      ]
+    }
+  },
+  "pages": [
+    {
+      "_uuid": "9626b2e9-5ef0-4070-8331-ac55151b22c4",
+      "_id": "page.start",
+      "_type": "page.start",
+      "heading": "Service name goes here",
+      "lede": "Use this service to:",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally.",
+      "steps": [],
+      "url": "/"
+    },
+    {
+      "_uuid": "1ed3e4ad-5098-41c9-b4b6-426e89f7804e",
+      "_id": "page.how-many-lights",
+      "_type": "page.content",
+      "section_heading": "Chain of Command",
+      "heading": "Tell me how many lights you see",
+      "body": "There are four lights!",
+      "components": [
+        {
+          "_id": "name_text_1",
+          "_type": "text",
+          "label": "Full name",
+          "name": "name_text_1",
+          "validation": {
+            "required": true,
+            "max_length": 10,
+            "min_length": 2
+          }
+        }
+      ],
+      "url": "how-many-lights"
+    }
+  ],
+  "locale": "en"
+}

--- a/fixtures/no_component_page.json
+++ b/fixtures/no_component_page.json
@@ -1,0 +1,60 @@
+{
+  "_id": "service.base",
+  "_type": "service.base",
+  "service_name": "Service name",
+  "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+  "configuration": {
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    },
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "_type": "link",
+          "href": "/cookies",
+          "text": "Cookies"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "_type": "link",
+          "href": "/privacy",
+          "text": "Privacy"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "_type": "link",
+          "href": "/accessibility",
+          "text": "Accessibility"
+        }
+      ]
+    }
+  },
+  "pages": [
+    {
+      "_uuid": "9626b2e9-5ef0-4070-8331-ac55151b22c4",
+      "_id": "page.start",
+      "_type": "page.start",
+      "heading": "Service name goes here",
+      "lede": "Use this service to:",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally.",
+      "steps": [],
+      "url": "/"
+    },
+    {
+      "_uuid": "b238a22f-c180-48d0-a7d9-8aad2036f1f2",
+      "_id": "page._confirmation",
+      "_type": "page.confirmation",
+      "body": "You'll receive a confirmation email",
+      "heading": "Complaint sent",
+      "lede": "Optional lede",
+      "url": "/confirmation",
+      "components": []
+    }
+  ],
+  "locale": "en"
+}

--- a/lib/metadata_presenter/test_helpers.rb
+++ b/lib/metadata_presenter/test_helpers.rb
@@ -11,7 +11,6 @@ module MetadataPresenter
 
     def service_metadata
       metadata_fixture(:version)
-      JSON.parse(File.read(fixtures_directory.join('version.json')))
     end
 
     def metadata_fixture(fixture_name)

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.21.0'
+  VERSION = '0.21.1'
 end


### PR DESCRIPTION
Some of our tests require a version of metadata that has a page with no components. This adds a fixture for that.

Also add an invalid content page fixture. Content pages can only have content components.

Also remove an unnecessary line in the service_metadata test helper