### PR TITLE
Validate individual pages in before hook

### DIFF
--- a/app/validators/metadata_presenter/validate_schema.rb
+++ b/app/validators/metadata_presenter/validate_schema.rb
@@ -7,6 +7,11 @@ class MetadataPresenter::ValidateSchema
       return unless controller.request.post?
 
       validate(controller.request.params, 'request.service')
+
+      metadata = controller.request.params['metadata']
+      Array(metadata['pages']).each do |page|
+        validate(page, page['_type'])
+      end
     rescue JSON::Schema::ValidationError, JSON::Schema::SchemaError, SchemaNotFoundError => e
       controller.render(
         json: ErrorsSerializer.new(message: e.message).attributes,

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.21.1'
+  VERSION = '0.22.0'
 end

--- a/schemas/service/base.json
+++ b/schemas/service/base.json
@@ -35,7 +35,26 @@
     "pages": {
       "type": "array",
       "items": {
-        "$ref": "definition.page"
+        "anyOf": [
+          {
+            "$ref": "page.start"
+          },
+          {
+            "$ref": "page.checkanswers"
+          },
+          {
+            "$ref": "page.confirmation"
+          },
+          {
+            "$ref": "page.content"
+          },
+          {
+            "$ref": "page.multiplequestions"
+          },
+          {
+            "$ref": "page.singlequestion"
+          }
+        ]
       }
     }
   },


### PR DESCRIPTION
Validation of the whole metadata is not working quite as expected at the moment. In the short term validate each page against the correct schema.

This is used mainly by the metadata api on every request it receives.

Also add in the page types as references to the base schema instead of referencing the page definition.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>