### PR TITLE
Page component configuration

### DIFF
--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -1,4 +1,7 @@
 module MetadataPresenter
+  class PageComponentsNotDefinedError < StandardError
+  end
+
   class Page < MetadataPresenter::Metadata
     include ActiveModel::Validations
 
@@ -26,6 +29,29 @@ module MetadataPresenter
 
     def template
       "metadata_presenter/#{type.gsub('.', '/')}"
+    end
+
+    def input_components
+      page_components(raw_type)[:input_components]
+    end
+
+    def content_components
+      page_components(raw_type)[:content_components]
+    end
+
+    private
+
+    def page_components(page_type)
+      values = Rails.application.config.page_components[page_type]
+      if values.blank?
+        raise PageComponentsNotDefinedError, "No page components defined for #{page_type} in config initialiser"
+      end
+
+      values
+    end
+
+    def raw_type
+      type.gsub('page.', '')
     end
   end
 end

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -18,3 +18,23 @@
     %>
   </div>
 <% end %>
+
+<% if editable? %>
+  <ul class="component-activated-menu govuk-navigation editor-button govuk-button fb-govuk-button">
+    <% if input_components.present? %>
+      <ul>
+        <% input_components.each do |component| %>
+          <li><a href="#add-input-component" data-component-type="<%= component %>"></a>+ Add <%= component %> component</li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <% if content_components.present? %>
+      <ul>
+        <% content_components.each do |component| %>
+          <li><a href="#add-content-component" data-component-type="<%= component %>">+ Add <%= component %> component</a></li>
+        <% end %>
+      </ul>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -69,7 +69,9 @@
                    f: f,
                    components: @page.components,
                    tag: nil,
-                   classes: nil
+                   classes: nil,
+                   input_components: @page.input_components,
+                   content_components: @page.content_components
                  } %>
 
       <button <%= 'disabled' if editable? %> data-prevent-double-click="true" class="fb-block fb-block-actions govuk-button" data-module="govuk-button" data-block-id="actions" data-block-type="actions">

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -12,6 +12,17 @@
     <% end %>
 
     <%= form_for @page, url: reserved_submissions_path do |f| %>
+
+    <%= render partial: 'metadata_presenter/component/components',
+                locals: {
+                  f: f,
+                  components: @page.extra_components,
+                  tag: nil,
+                  classes: nil,
+                  input_components: @page.input_components,
+                  content_components: @page.content_components
+                } %>
+
       <div data-block-id="page.checkanswers.answers" data-block-type="answers">
         <dl class="fb-block fb-block-answers govuk-summary-list">
           <% pages_presenters.each do |page_answers_presenters| %>

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -19,5 +19,7 @@
              f: nil,
              components: @page.components,
              tag: nil,
-             classes: nil
+             classes: nil,
+             input_components: @page.input_components,
+             content_components: @page.content_components
            } %>

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -23,7 +23,9 @@
                      f: f,
                      components: @page.components,
                      tag: nil,
-                     classes: nil
+                     classes: nil,
+                     input_components: @page.input_components,
+                     content_components: @page.content_components
                    } %>
 
         <%= f.govuk_submit(disabled: editable?) %>

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -12,7 +12,9 @@
             f: f,
             components: @page.components,
             tag: :h2,
-            classes: 'govuk-heading-m govuk-!-margin-top-8'
+            classes: 'govuk-heading-m govuk-!-margin-top-8',
+            input_components: @page.input_components,
+            content_components: @page.content_components
           }
         %>
 

--- a/config/initializers/page_components.rb
+++ b/config/initializers/page_components.rb
@@ -1,0 +1,19 @@
+Rails.application.config.page_components =
+  ActiveSupport::HashWithIndifferentAccess.new({
+    checkanswers: {
+      input_components: %w(),
+      content_components: %w(content)
+    },
+    confirmation: {
+      input_components: %w(),
+      content_components: %w(content)
+    },
+    content: {
+      input_components: %w(),
+      content_components: %w(content)
+    },
+    multiplequestions: {
+      input_components: %w(text textarea number date radios checkboxes),
+      content_components: %w(content)
+    }
+  })

--- a/default_metadata/page/checkanswers.json
+++ b/default_metadata/page/checkanswers.json
@@ -4,5 +4,6 @@
   "heading": "Check your answers",
   "send_heading": "Now send your application",
   "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
-  "components": []
+  "components": [],
+  "extra_components": []
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.23.0'.freeze
+  VERSION = '0.24.0'.freeze
 end

--- a/schemas/page/checkanswers.json
+++ b/schemas/page/checkanswers.json
@@ -43,6 +43,14 @@
       "items": {
         "$ref": "component.content"
       }
+    },
+    "extra_components": {
+      "title": "Extra Components",
+      "description": "More form or content elements used on the page",
+      "type": "array",
+      "items": {
+        "$ref": "component.content"
+      }
     }
   },
   "required": [

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -62,4 +62,52 @@ RSpec.describe MetadataPresenter::Page do
       expect(page.to_partial_path).to eq('page/singlequestion')
     end
   end
+
+  describe '#input_components' do
+    context 'when page has input components' do
+      subject(:page) { described_class.new(_type: 'page.multiplequestions') }
+
+      it 'returns the correct input components' do
+        expect(page.input_components).to match_array(%w[text textarea number date radios checkboxes])
+      end
+    end
+
+    context 'when page does not have input components' do
+      subject(:page) { described_class.new(_type: 'page.checkanswers') }
+
+      it 'returns an empty array' do
+        expect(page.input_components).to be_empty
+      end
+    end
+
+    context 'when the page is not configured' do
+      subject(:page) { described_class.new(_type: 'page.boba-fett') }
+
+      it 'raises a PageComponentsNotDefinedError' do
+        expect {
+          page.input_components
+        }.to raise_error(MetadataPresenter::PageComponentsNotDefinedError)
+      end
+    end
+  end
+
+  describe '#content_components' do
+    context 'when page has content components' do
+      subject(:page) { described_class.new(_type: 'page.multiplequestions') }
+
+      it 'returns the correct content components' do
+        expect(page.content_components).to match_array(%w[content])
+      end
+    end
+
+    context 'when the page is not configured' do
+      subject(:page) { described_class.new(_type: 'page.jar-jar-binks') }
+
+      it 'raises a PageComponentsNotDefinedError' do
+        expect {
+          page.content_components
+        }.to raise_error(MetadataPresenter::PageComponentsNotDefinedError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Add page component configuration 

The majority of pages have two types of components, input and content. The specific component used on a page differs from page to page therefore we need to define which components can be used.


## Add extra components property to checkanswers page

The checkanswers page has two sets of components on the page, on above the user answers table and one below.

## 0.24.0

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>