### PR TITLE
Use item id in collection components

### DIFF
--- a/app/models/metadata_presenter/item.rb
+++ b/app/models/metadata_presenter/item.rb
@@ -1,8 +1,4 @@
 class MetadataPresenter::Item < MetadataPresenter::Metadata
-  def id
-    label
-  end
-
   def name
     label
   end

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -350,7 +350,8 @@
           "_type": "content",
           "html": "Check yourself before you wreck yourself."
         }
-      ]
+      ],
+      "extra_components": []
     },
     {
       "_uuid": "b238a22f-c180-48d0-a7d9-8aad2036f1f2",

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -178,14 +178,14 @@
           "legend": "Do you like Star Wars?",
           "items": [
             {
-              "_id": "do-you-like-star-wars_radio_1",
+              "_id": "do-you-like-star-wars_radios_1_item_1",
               "_type": "radio",
               "label": "Only on weekends",
               "hint": "Optional item hint",
               "value": "only-on-weekends"
             },
             {
-              "_id": "do-you-like-star-wars_radio_2",
+              "_id": "do-you-like-star-wars_radios_1_item_2",
               "_type": "radio",
               "label": "Hell no!",
               "hint": "Optional item hint",
@@ -236,21 +236,21 @@
           "legend": "What would you like on your burger?",
           "items": [
             {
-              "_id": "burgers_checkbox_1",
+              "_id": "burgers_checkboxes_1_item_1",
               "_type": "checkbox",
               "label": "Beef, cheese, tomato",
               "hint": "Optional item hint",
               "value": "beef-cheese-tomato"
             },
             {
-              "_id": "burgers_checkbox_2",
+              "_id": "burgers_checkboxes_1_item_2",
               "_type": "checkbox",
               "label": "Chicken, cheese, tomato",
               "hint": "Optional item hint",
               "value": "chicken-cheese-tomato"
             },
             {
-              "_id": "burgers_checkbox_3",
+              "_id": "burgers_checkboxes_1_item_3",
               "_type": "checkbox",
               "label": "Mozzarella, cheddar, feta",
               "hint": "Optional item hint",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.24.0'.freeze
+  VERSION = '0.25.0'.freeze
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -2,10 +2,15 @@ RSpec.describe MetadataPresenter::Item do
   subject(:item) { described_class.new(metadata) }
 
   describe '#id' do
-    let(:metadata) { { 'label' => 'Some label' } }
+    let(:metadata) do
+      {
+        '_id' => 'some-id',
+        'label' => 'Some label'
+      }
+    end
 
-    it 'returns label' do
-      expect(item.id).to eq('Some label')
+    it 'returns the id' do
+      expect(item.id).to eq('some-id')
     end
   end
 


### PR DESCRIPTION
## Use item ID in collection component templates

If we use the label then the DFE gem just generates all the collection items with the same IDs which then conflict.

Using label means that that gem would generate:

`answers-label-name-option-field`

But not increment any number to it, so would not be unique within a given collection.

As we generate item IDs each time we create a new collection component, and those IDs are always unique, we should use this.

We don't need to override the id method as the parent metadata object has it and is correctly retrieving _id from the passed in metadata JSON which in the instance of an Item and is the specific collection item, not the parent collection component.

Unfortunately this does mean that the generated item IDs will be a little silly. E.g

Given the page url 'some-page' and the component id 'some-component' the gem will now generate:

```
answers-some-page-some-component-1-some-page-some-component-item-1-field
answers-some-page-some-component-1-some-page-some-component-item-2-field
```

etc

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>

## Update the versions fixture collection item IDs


## Add extra_components property to checkanswers in fixture

## 0.25.0

https://trello.com/c/sv8f7IM1/1427-bug-radio-buttons-and-check-box-clicking-second-item-label

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>