### PR TITLE
Revert Item ID back to being label

### DIFF
--- a/app/models/metadata_presenter/item.rb
+++ b/app/models/metadata_presenter/item.rb
@@ -1,4 +1,8 @@
 class MetadataPresenter::Item < MetadataPresenter::Metadata
+  def id
+    label
+  end
+
   def name
     label
   end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.25.0'.freeze
+  VERSION = '0.26.0'.freeze
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,14 +3,11 @@ RSpec.describe MetadataPresenter::Item do
 
   describe '#id' do
     let(:metadata) do
-      {
-        '_id' => 'some-id',
-        'label' => 'Some label'
-      }
+      { 'label' => 'Some label' }
     end
 
     it 'returns the id' do
-      expect(item.id).to eq('some-id')
+      expect(item.id).to eq('Some label')
     end
   end
 


### PR DESCRIPTION
Revert Item ID back to being label

In reality an editor is not going to leave the label of a collection item to be the one set in the default metadata. The confusion comes from the fact that the label for an item in the default metadata is "Option" so when a user previews a form the collections do not work properly as the DFE gem uses the label to create the item ID. However its expectation is that the label will be unique, which is entirely reasonable.

So swap the Item ID back to being the label. Our expectation is that an editor will always change the labels to be unique.

Publish 0.26.0