### PR TITLE
From to_markdown to to_html

### DIFF
--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -6,15 +6,14 @@ module MetadataPresenter
       end
     end
 
-    # Renders markdown given a text.
+    # Renders html given markdown.
     #
     # @example
-    #   <%=m '# Some markdown' %>
+    #   <%=to_html '# Some markdown' %>
     #
-    def m(text)
+    def to_html(text)
       Kramdown::Document.new(text).to_html.html_safe
     end
-    alias_method :to_markdown, :m
 
     def default_text(property)
       MetadataPresenter::DefaultText[property]

--- a/app/views/metadata_presenter/attribute/_body.html.erb
+++ b/app/views/metadata_presenter/attribute/_body.html.erb
@@ -3,6 +3,6 @@
         data-fb-content-id="page[body]"
         data-fb-content-type="content"
         data-fb-default-text="<%= default_text('body') %>">
-    <%= to_markdown(@page.body) %>
+    <%= to_html(@page.body) %>
   </div>
 <%- end %>

--- a/app/views/metadata_presenter/component/_content.html.erb
+++ b/app/views/metadata_presenter/component/_content.html.erb
@@ -1,1 +1,1 @@
-<%= to_html(component.html) %>
+<%= to_html(component.content) %>

--- a/app/views/metadata_presenter/component/_content.html.erb
+++ b/app/views/metadata_presenter/component/_content.html.erb
@@ -1,1 +1,1 @@
-<%= to_markdown(component.html) %>
+<%= to_html(component.html) %>

--- a/app/views/metadata_presenter/page/form.html.erb
+++ b/app/views/metadata_presenter/page/form.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-two-thirds">
       <% if @page.body %>
         <p class="govuk-body-l" data-block-id="<%= @page.id %>" data-block-property="body">
-        <%= to_markdown(@page.body) %>
+        <%= to_html(@page.body) %>
         </p>
       <%- end %>
        <%= form_tag(reserved_answers_path, method: :post) do  %>

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -20,7 +20,7 @@
         <div class="fb-editable"
              data-fb-content-id="page[before_you_start]"
              data-fb-content-type="content">
-          <%= to_markdown(@page.before_you_start) %>
+          <%= to_html(@page.before_you_start) %>
         </div>
       <%- end %>
     </div>

--- a/default_metadata/component/content.json
+++ b/default_metadata/component/content.json
@@ -1,5 +1,5 @@
 {
   "_id": "component.content",
   "_type": "content",
-  "html": "[Optional content]"
+  "content": "[Optional content]"
 }

--- a/default_text/content.json
+++ b/default_text/content.json
@@ -2,6 +2,6 @@
   "section_heading": "[Optional section heading]",
   "lede": "[Optional lede paragraph]",
   "body": "[Optional content]",
-  "html": "[Optional content]",
+  "content": "[Optional content]",
   "hint": "[Optional hint text]"
 }

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -330,7 +330,7 @@
         {
           "_id": "how-many-lights_content_1",
           "_type": "content",
-          "html": "What lights?"
+          "content": "What lights?"
         }
       ],
       "url": "how-many-lights"
@@ -348,7 +348,7 @@
         {
           "_id": "check-answers_content_1",
           "_type": "content",
-          "html": "Check yourself before you wreck yourself."
+          "content": "Check yourself before you wreck yourself."
         }
       ],
       "extra_components": []
@@ -365,7 +365,7 @@
         {
           "_id": "confirmation_content_1",
           "_type": "content",
-          "html": "Some day I will be the most powerful Jedi ever!"
+          "content": "Some day I will be the most powerful Jedi ever!"
         }
       ]
     }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.26.1'.freeze
+  VERSION = '0.27.0'.freeze
 end

--- a/schemas/component/content.json
+++ b/schemas/component/content.json
@@ -11,7 +11,7 @@
     "_type": {
       "const": "content"
     },
-    "html": {
+    "content": {
       "title": "Content",
       "description": "Content to display - use [markdown](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown) to format text or add hyperlinks",
       "type": "string",
@@ -25,6 +25,6 @@
     }
   ],
   "required": [
-    "html"
+    "content"
   ]
 }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#to_markdown' do
+  describe '#to_html' do
     it 'renders markdown' do
-      expect(helper.m('# Jedi Denial - Obi-Wan Cannot be')).to eq(
+      expect(helper.to_html('# Jedi Denial - Obi-Wan Cannot be')).to eq(
         "<h1 id=\"jedi-denial---obi-wan-cannot-be\">Jedi Denial - Obi-Wan Cannot be</h1>\n"
       )
     end


### PR DESCRIPTION
Story: https://trello.com/c/ZHcE8Mr4/1239-add-component-button

This PR:
- Changes the method `to_markdown` to `to_html`
- Changes references of `html` to `content` in schemas
- Bumps to version 0.27.0

Co-authored by: Brendan Butler <brendan.butler@digital.justice.gov.uk>