### PR TITLE
Standalone pages preview fix

### DIFF
--- a/app/views/metadata_presenter/footer/_meta.html.erb
+++ b/app/views/metadata_presenter/footer/_meta.html.erb
@@ -1,9 +1,8 @@
 <h2 class="govuk-visually-hidden">Support links</h2>
-
 <ul class="govuk-footer__inline-list">
 <% meta_items.each do |item| %>
   <li class="govuk-footer__inline-list-item">
-    <a class="govuk-footer__link" href=<%= item.href %>><%= item.text %></a>
+    <a class="govuk-footer__link" href=<%= File.join(request.script_name, item.href) %>><%= item.text %></a>
   </li>
 <% end %>
 </ul>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.28.1'.freeze
+  VERSION = '0.28.2'.freeze
 end


### PR DESCRIPTION
### Fix standalone pages preview links
Currently, the standalone pages on Preview do not work.
This is because the links direct us to the incorrect links, ie: `localhost:3000/services/cookies`

This PR fixes this by directing to the correct links, ie: `localhost:3000/services/:service_id/preview/cookies`

### Bump version 0.28.2

Story: https://trello.com/c/LtJSIu15/1422-represent-non-flow-standalone-pages-for-mvp