### PR TITLE
Fix/check answers page

### DIFF
--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -18,9 +18,11 @@ module MetadataPresenter
     end
 
     def components
-      metadata.components&.map do |component|
-        MetadataPresenter::Component.new(component, editor: editor?)
-      end
+      to_components(metadata.components, collection: :components)
+    end
+
+    def extra_components
+      to_components(metadata.extra_components, collection: :extra_components)
     end
 
     def to_partial_path
@@ -40,6 +42,15 @@ module MetadataPresenter
     end
 
     private
+
+    def to_components(node_components, collection:)
+      node_components&.map do |component|
+        MetadataPresenter::Component.new(
+          component.merge(collection: collection),
+          editor: editor?
+        )
+      end
+    end
 
     def page_components(page_type)
       values = Rails.application.config.page_components[page_type]

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -1,14 +1,14 @@
-<% @page.components.each_with_index do |component, index| %>
+<% components.each_with_index do |component, index| %>
   <div class="fb-editable"
         id="<%= component.id %>"
         data-fb-content-type="<%= component.type %>"
-        data-fb-content-id="<%= "page[components[#{index}]]" %>"
+        data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
         data-fb-content-data="<%= component.to_json %>">
 
     <%= render partial: component, locals: {
         f: f,
         component: component,
-        component_id: "page[components[#{index}]]",
+        component_id: "page[#{component.collection}[#{index}]]",
         input_title: main_title(
           component: component,
           tag: :h2,

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -44,7 +44,7 @@
                 </dd>
                 <dd class="govuk-summary-list__actions">
                   <%= link_to(
-                    change_answer_path(url: page_answers_presenter.url),
+                    editable? ? '#' : change_answer_path(url: page_answers_presenter.url),
                     class: 'govuk-link'
                   ) do %>
                     Change<span class="govuk-visually-hidden"> Your answer for <%= page_answers_presenter.humanised_title %></span>

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -351,7 +351,13 @@
           "content": "Check yourself before you wreck yourself."
         }
       ],
-      "extra_components": []
+      "extra_components": [
+        {
+          "_id": "check-answers_content_1",
+          "_type": "content",
+          "content": "Take the cannoli."
+        }
+      ]
     },
     {
       "_uuid": "b238a22f-c180-48d0-a7d9-8aad2036f1f2",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.28.5'.freeze
+  VERSION = '0.28.6'.freeze
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -27,11 +27,25 @@ RSpec.describe MetadataPresenter::Page do
     end
   end
 
-  context 'when creating a new service object' do
-    it '#components should return an array of Component objects' do
+  describe '#components' do
+    it 'returns an array of Component objects' do
       components = service.pages.map(&:components).flatten.compact
       components.each do |component|
         expect(component).to be_kind_of(MetadataPresenter::Component)
+        expect(component.collection).to eq(:components)
+      end
+    end
+  end
+
+  describe '#extra_components' do
+    it 'returns an array of Component objects' do
+      components = service.pages.map(&:extra_components).flatten.compact
+
+      expect(components.size).to eq(1)
+
+      components.each do |component|
+        expect(component).to be_kind_of(MetadataPresenter::Component)
+        expect(component.collection).to eq(:extra_components)
       end
     end
   end


### PR DESCRIPTION
## Make components/extra_components to render properly

When the page has components and extra components it should render them.

## Disable change link on CYA page when in editor

We do not want the link to be usable when inside the editor

## 0.28.6

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>