### PR TITLE
Reject non editable attributes

### DIFF
--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -5,6 +5,15 @@ module MetadataPresenter
   class Page < MetadataPresenter::Metadata
     include ActiveModel::Validations
 
+    NOT_EDITABLE = %i[
+      _uuid
+      _id
+      _type
+      steps
+      add_component
+      add_extra_component
+    ].freeze
+
     def uuid
       _uuid
     end
@@ -14,7 +23,7 @@ module MetadataPresenter
     end
 
     def editable_attributes
-      to_h.reject { |k, _| k.in?(%i[_id _type steps]) }
+      to_h.reject { |k, _| k.in?(NOT_EDITABLE) }
     end
 
     def components

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.28.6'.freeze
+  VERSION = '0.28.7'.freeze
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -51,13 +51,21 @@ RSpec.describe MetadataPresenter::Page do
   end
 
   describe '#editable_attributes' do
-    it 'rejects non editable attributes' do
+    it 'does not reject editable attributes' do
       expect(service.pages.first.editable_attributes.keys).to include(
         :heading,
         :body,
         :lede,
         :url
       )
+    end
+
+    it 'rejects all not editable attributes' do
+      not_editable = MetadataPresenter::Page::NOT_EDITABLE
+      attributes = not_editable.index_with { |_k| SecureRandom.uuid }
+      page = MetadataPresenter::Page.new(attributes)
+
+      expect(page.editable_attributes.keys).to_not include(not_editable)
     end
   end
 


### PR DESCRIPTION
There are some additional attributes that we do not want to be editable when the page is rendered in the editor. add_component and add_extra_component are fields which the JS writes as hidden fields as and when a user interacts with the UI. Therefore we don't want them there on page load.


## 0.28.7

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>