### PR TITLE
Add UUID to component

### DIFF
--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -18,9 +18,5 @@ module MetadataPresenter
     def default_text(property)
       MetadataPresenter::DefaultText[property]
     end
-
-    def meta_items
-      service.meta.items
-    end
   end
 end

--- a/app/models/metadata_presenter/metadata.rb
+++ b/app/models/metadata_presenter/metadata.rb
@@ -13,6 +13,10 @@ class MetadataPresenter::Metadata
     to_h.to_json
   end
 
+  def uuid
+    metadata._uuid
+  end
+
   def id
     metadata._id
   end

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -14,10 +14,6 @@ module MetadataPresenter
       add_extra_component
     ].freeze
 
-    def uuid
-      _uuid
-    end
-
     def ==(other)
       id == other.id if other.respond_to? :id
     end

--- a/app/views/metadata_presenter/footer/_meta.html.erb
+++ b/app/views/metadata_presenter/footer/_meta.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-visually-hidden">Support links</h2>
 <ul class="govuk-footer__inline-list">
-<% meta_items.each do |item| %>
+<% service.meta.items.each do |item| %>
   <li class="govuk-footer__inline-list-item">
     <a class="govuk-footer__link" href=<%= File.join(request.script_name, item.href) %>><%= item.text %></a>
   </li>

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -346,6 +346,7 @@
       "url": "/check-answers",
       "components": [
         {
+          "_uuid": "256291c2-8ffa-4bda-8282-88e0724ccd10",
           "_id": "check-answers_content_1",
           "_type": "content",
           "content": "Check yourself before you wreck yourself."
@@ -353,6 +354,7 @@
       ],
       "extra_components": [
         {
+          "_uuid": "09961c6a-29f8-4d4f-a6d2-af00cff15536",
           "_id": "check-answers_content_1",
           "_type": "content",
           "content": "Take the cannoli."

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.28.7'.freeze
+  VERSION = '0.28.8'.freeze
 end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe MetadataPresenter::Component do
 
     it 'returns an array of openstruct component item objects' do
       expect(component.items).to be_an(Array)
+      expect(component.items.size).to eq(2)
     end
 
     it 'contains objects that respond to the necessary properties' do
@@ -47,6 +48,22 @@ RSpec.describe MetadataPresenter::Component do
 
       it 'returns the legend value' do
         expect(component.humanised_title).to eq('Do you like Star Wars?')
+      end
+    end
+  end
+
+  describe '#content?' do
+    context 'when type is content' do
+      it 'returns true' do
+        component = described_class.new(_type: 'content')
+        expect(component.content?).to be_truthy
+      end
+    end
+
+    context 'when type is not content' do
+      it 'returns false' do
+        component = described_class.new({})
+        expect(component.content?).to be_falsey
       end
     end
   end

--- a/spec/models/metadata_spec.rb
+++ b/spec/models/metadata_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe MetadataPresenter::Metadata do
       end
     end
 
+    context 'when there is a uuid' do
+      let(:meta) { { '_uuid' => 'some awesome uuid' } }
+
+      it 'should present back the text' do
+        expect(metadata.uuid).to eq('some awesome uuid')
+      end
+    end
+
     context 'when there is no default text for an empty property' do
       let(:meta) { { 'nope' => '' } }
 

--- a/spec/presenters/page_answers_presenter_spec.rb
+++ b/spec/presenters/page_answers_presenter_spec.rb
@@ -111,4 +111,41 @@ RSpec.describe MetadataPresenter::PageAnswersPresenter do
       end
     end
   end
+
+  describe '#display_heading?' do
+    let(:answers) { {} }
+
+    context 'when multiple question page' do
+      let(:page) do
+        service.find_page_by_url('/star-wars-knowledge')
+      end
+
+      context 'when first answer' do
+        let(:index) { 0 }
+
+        it 'returns true' do
+          expect(subject.display_heading?(index)).to be_truthy
+        end
+      end
+
+      context 'when not first answer' do
+        let(:index) { 1 }
+
+        it 'returns false' do
+          expect(subject.display_heading?(index)).to be_falsey
+        end
+      end
+    end
+
+    context 'when any other page' do
+      let(:page) do
+        service.find_page_by_url('/burgers')
+      end
+      let(:index) { 0 }
+
+      it 'returns false' do
+        expect(subject.display_heading?(index)).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
@brenetic
@tomas-stefano
@njseeto
## Add uuid method to the parent metadata object …

Since we are now also adding a uuid to the component objects we may as well but the uuid method into the parent metadata object and take it out of the page object

## Remove the meta_items method

Call service.meta.items directly in the view

## Make the test coverage 100%

## 0.28.8

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>