### PR TITLE
Fix Check answers table layout

### DIFF
--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -22,12 +22,24 @@ module MetadataPresenter
       to_h.reject { |k, _| k.in?(NOT_EDITABLE) }
     end
 
+    def all_components
+      [components, extra_components].flatten.compact
+    end
+
     def components
       to_components(metadata.components, collection: :components)
     end
 
     def extra_components
       to_components(metadata.extra_components, collection: :extra_components)
+    end
+
+    def components_by_type(type)
+      supported_components = page_components(raw_type)[type]
+
+      all_components.select do |component|
+        supported_components.include?(component.type)
+      end
     end
 
     def to_partial_path
@@ -39,11 +51,11 @@ module MetadataPresenter
     end
 
     def input_components
-      page_components(raw_type)[:input_components]
+      page_components(raw_type)[:input]
     end
 
     def content_components
-      page_components(raw_type)[:content_components]
+      page_components(raw_type)[:content]
     end
 
     private

--- a/app/presenters/metadata_presenter/page_answers_presenter.rb
+++ b/app/presenters/metadata_presenter/page_answers_presenter.rb
@@ -1,11 +1,16 @@
 module MetadataPresenter
   class PageAnswersPresenter
     FIRST_ANSWER = 0
-    NO_USER_INPUT = %w[page.checkanswers page.confirmation page.content].freeze
+    NO_USER_INPUT = %w[
+      page.checkanswers
+      page.confirmation
+      page.content
+      page.start
+    ].freeze
 
     def self.map(view:, pages:, answers:)
       user_input_pages(pages).map { |page|
-        Array(page.components).map do |component|
+        Array(page.components_by_type(:input)).map do |component|
           new(
             view: view,
             component: component,
@@ -47,10 +52,18 @@ module MetadataPresenter
     end
 
     def display_heading?(index)
-      page.type == 'page.multiplequestions' && index == FIRST_ANSWER
+      multiplequestions_page? && index == FIRST_ANSWER
+    end
+
+    def last_multiple_question?(index, presenters_count_for_page)
+      multiplequestions_page? && index == presenters_count_for_page - 1
     end
 
     private
+
+    def multiplequestions_page?
+      page.type == 'page.multiplequestions'
+    end
 
     def date(value)
       I18n.l(

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -49,6 +49,11 @@
                   <% end %>
                 </dd>
               </div>
+
+              <% if page_answers_presenter.last_multiple_question?(index, page_answers_presenters.size) %>
+        </dl>
+        <dl class="fb-block fb-block-answers govuk-summary-list">
+              <% end %>
             <% end %>
           <% end %>
         </dl>

--- a/config/initializers/page_components.rb
+++ b/config/initializers/page_components.rb
@@ -1,19 +1,23 @@
 Rails.application.config.page_components =
   ActiveSupport::HashWithIndifferentAccess.new({
     checkanswers: {
-      input_components: %w(),
-      content_components: %w(content)
+      input: %w(),
+      content: %w(content)
     },
     confirmation: {
-      input_components: %w(),
-      content_components: %w(content)
+      input: %w(),
+      content: %w(content)
     },
     content: {
-      input_components: %w(),
-      content_components: %w(content)
+      input: %w(),
+      content: %w(content)
     },
     multiplequestions: {
-      input_components: %w(text textarea number date radios checkboxes),
-      content_components: %w(content)
-    }
+      input: %w(text textarea number date radios checkboxes),
+      content: %w(content)
+    },
+    singlequestion: {
+      input: %w(text textarea number date radios checkboxes),
+      content: %w()
+     }
   })

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '0.28.9'.freeze
+  VERSION = '0.28.10'.freeze
 end

--- a/spec/presenters/page_answers_presenter_spec.rb
+++ b/spec/presenters/page_answers_presenter_spec.rb
@@ -148,4 +148,55 @@ RSpec.describe MetadataPresenter::PageAnswersPresenter do
       end
     end
   end
+
+  describe '#last_multiple_question?' do
+    let(:answers) { {} }
+
+    context 'when multiple question page' do
+      let(:page) do
+        service.find_page_by_url('/star-wars-knowledge')
+      end
+      let(:page_answers_count) do
+        page.components_by_type(:input).size
+      end
+
+      context 'when last question' do
+        let(:index) { page_answers_count - 1 }
+
+        it 'returns true' do
+          expect(subject.last_multiple_question?(index, page_answers_count)).to be_truthy
+        end
+      end
+
+      context 'when only one question on the page' do
+        let(:index) { 0 }
+
+        it 'returns true' do
+          expect(subject.last_multiple_question?(index, 1)).to be_truthy
+        end
+      end
+
+      context 'when not the last question' do
+        let(:index) { 0 }
+
+        it 'returns false' do
+          expect(subject.last_multiple_question?(index, page_answers_count)).to be_falsey
+        end
+      end
+    end
+
+    context 'when not multiple question page' do
+      let(:page) do
+        service.find_page_by_url('/burgers')
+      end
+      let(:page_answers_count) do
+        page.components_by_type(:input).size
+      end
+      let(:index) { 0 }
+
+      it 'returns false' do
+        expect(subject.last_multiple_question?(index, page_answers_count)).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Fix CYA table layout to not include content components

The CYA table was accidentally including content components in the layout. These should be removed from the components that the answers presenter gathers.

Also if there was a multiple question we need to close the </dl> tag and open another <dl> tag when it's the last question for that page. Otherwise it groups the next question into the same part of the table as the multiple questions pages questions.

## 0.28.10

## Before

![Screenshot 2021-04-16 at 19 12 06](https://user-images.githubusercontent.com/3466862/115067177-735ce080-9ee8-11eb-8ed7-6405f5a18e64.png)


## After

![Screenshot 2021-04-16 at 19 12 27](https://user-images.githubusercontent.com/3466862/115067188-75bf3a80-9ee8-11eb-9ec1-a7e5b848fa9c.png)
