### PR TITLE
Remove optional hint text

### DIFF
--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -184,7 +184,7 @@
           "items": [
             {
               "_id": "do-you-like-star-wars_radios_1_item_1",
-              "hint": "[Optional hint text]",
+              "hint": "",
               "name": "do-you-like-star-wars_radios_1",
               "_type": "radio",
               "_uuid": "ac41be35-914e-4b22-8683-f5477716b7d4",
@@ -199,7 +199,7 @@
             },
             {
               "_id": "do-you-like-star-wars_radios_1_item_2",
-              "hint": "[Optional hint text]",
+              "hint": "",
               "name": "do-you-like-star-wars_radios_1",
               "_type": "radio",
               "_uuid": "ac41be35-914e-4b22-8683-f5477716b7d4",
@@ -266,7 +266,7 @@
           "items": [
             {
               "_id": "burgers_checkboxes_1_item_1",
-              "hint": "[Optional hint text]",
+              "hint": "",
               "name": "burgers_checkboxes_1",
               "_type": "checkbox",
               "_uuid": "4c409737-80bb-48c7-afa7-6e9360b65004",
@@ -281,7 +281,7 @@
             },
             {
               "_id": "burgers_checkboxes_1_item_2",
-              "hint": "[Optional hint text]",
+              "hint": "",
               "name": "burgers_checkboxes_1",
               "_type": "checkbox",
               "_uuid": "4c409737-80bb-48c7-afa7-6e9360b65004",
@@ -296,7 +296,7 @@
             },
             {
               "_id": "burgers_checkboxes_1_item_3",
-              "hint": "[Optional hint text]",
+              "hint": "",
               "name": "burgers_checkboxes_1",
               "_type": "checkbox",
               "_uuid": "4c409737-80bb-48c7-afa7-6e9360b65004",
@@ -356,7 +356,7 @@
           "items": [
             {
               "_id": "star-wars-knowledge_radios_1_item_1",
-              "hint": "[Optional hint text]",
+              "hint": "",
               "name": "star-wars-knowledge_radios_1",
               "_type": "radio",
               "_uuid": "51efe2ca-fc47-4584-8129-e91589a46b9e",
@@ -371,7 +371,7 @@
             },
             {
               "_id": "star-wars-knowledge_radios_1_item_2",
-              "hint": "[Optional hint text]",
+              "hint": "",
               "name": "star-wars-knowledge_radios_1",
               "_type": "radio",
               "_uuid": "51efe2ca-fc47-4584-8129-e91589a46b9e",
@@ -386,7 +386,7 @@
             },
             {
               "_id": "star-wars-knowledge_radios_1_item_3",
-              "hint": "[Optional hint text]",
+              "hint": "",
               "name": "star-wars-knowledge_radios_1",
               "_type": "radio",
               "_uuid": "51efe2ca-fc47-4584-8129-e91589a46b9e",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end


### PR DESCRIPTION
This fixture was created by the actual Editor which unfortunately is
still saving optional hint text to the metadata which it should not be
doing.

Remove this from the fixture. We will add acceptance tests around these
not appearing in the metadata that the runner uses.

## 1.0.1