### PR TITLE
Changes the label for added radio option from ["Required option text"] to "option" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+## [1.0.3] - 2021-04-27
+
+### Changed
+
+- Default content text for collection component changed to be just "Option"
+
 ## [1.0.2] - 2021-04-26
 
 ### Fixed

--- a/default_text/content.json
+++ b/default_text/content.json
@@ -4,6 +4,6 @@
   "body": "[Optional content]",
   "content": "[Optional content]",
   "hint": "[Optional hint text]",
-  "option": "[Required option text]",
+  "option": "Option",
   "option_hint": "[Optional hint text]"
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.0.3'.freeze
 end


### PR DESCRIPTION
Changes the label for added radio option from ["Required option text"] to "option" so the new option and the "existing options" will have the same label as they should.