### PR TITLE
Remove section heading start page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+## [1.0.6] - 2021-04-30
+
+### Changed
+
+- Remove section heading from start pages
+
 ## [1.0.5] - 2021-04-30
 
 ### Fixed

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -2,7 +2,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <%= render 'metadata_presenter/attribute/section_heading' %>
       <%= render 'metadata_presenter/attribute/heading' %>
       <%= render 'metadata_presenter/attribute/lede' %>
       <%= render 'metadata_presenter/attribute/body' %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.0.5'.freeze
+  VERSION = '1.0.6'.freeze
 end


### PR DESCRIPTION
Start pages should not have section headings

Publish 1.0.6