### PR TITLE
Add upload componentschema

### DIFF
--- a/schemas/component/upload.json
+++ b/schemas/component/upload.json
@@ -1,0 +1,92 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/upload",
+  "_name": "component.upload",
+  "title": "Upload",
+  "description": "Let users select and upload one or more files",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "upload"
+    },
+    "max_files": {
+      "title": "Maximum number of files",
+      "description": "Maximum number of files a user can upload",
+      "type": "number",
+      "default": 1
+    },
+    "min_files": {
+      "title": "Minimum number of files",
+      "description": "Minimum number of files a user can upload - 1 if required, 0 if not required",
+      "type": "number"
+    },
+    "accept": {
+      "title": "Accepted types",
+      "description": "Which file types to accept",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "audio/*",
+          "image/bmp",
+          "text/csv",
+          "application/vnd.ms-excel",
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+          "application/vnd.ms-excel.sheet.macroEnabled.12",
+          "application/vnd.ms-excel.template.macroEnabled.12",
+          "application/vnd.ms-excel.addin.macroEnabled.12",
+          "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+          "image/gif",
+          "image/*",
+          "application/x-iwork-pages-sffpages",
+          "image/jpeg",
+          "applicattion/pdf",
+          "text/plain",
+          "image/png",
+          "application/vnd.ms-powerpoint",
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "application/vnd.openxmlformats-officedocument.presentationml.template",
+          "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+          "application/vnd.ms-powerpoint.addin.macroEnabled.12",
+          "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
+          "application/vnd.ms-powerpoint.template.macroEnabled.12",
+          "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
+          "text/rtf",
+          "excel",
+          "csv",
+          "image/svg+xml",
+          "pdf",
+          "word",
+          "rtf",
+          "plaintext",
+          "image/tiff",
+          "video/*",
+          "application/msword",
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+          "application/vnd.ms-word.document.macroEnabled.12",
+          "application/vnd.ms-word.template.macroEnabled.12"
+        ]
+      }
+    },
+    "max_size": {
+      "title": "Maximum size",
+      "description": "Maximum file size as human readable string or bytes",
+      "type": "string"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.field"
+    },
+    {
+      "$ref": "definition.width_class.input"
+    },
+    {
+      "$ref": "validations#/defintion/errors_accept"
+    },
+    {
+      "$ref": "validations#/definition/errors_max_size"
+    }
+  ]
+}


### PR DESCRIPTION
This adds the schema required for the upload component along with the allowed file types

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>