### PR TITLE
Render upload page

### DIFF
--- a/app/validators/metadata_presenter/accept_validator.rb
+++ b/app/validators/metadata_presenter/accept_validator.rb
@@ -1,0 +1,4 @@
+module MetadataPresenter
+  class AcceptValidator < BaseValidator
+  end
+end

--- a/app/validators/metadata_presenter/accept_validator.rb
+++ b/app/validators/metadata_presenter/accept_validator.rb
@@ -1,6 +1,5 @@
 module MetadataPresenter
   class AcceptValidator < BaseValidator
-    def invalid_answer?
-    end
+    def invalid_answer?; end
   end
 end

--- a/app/validators/metadata_presenter/accept_validator.rb
+++ b/app/validators/metadata_presenter/accept_validator.rb
@@ -1,4 +1,6 @@
 module MetadataPresenter
   class AcceptValidator < BaseValidator
+    def invalid_answer?
+    end
   end
 end

--- a/app/validators/metadata_presenter/max_size_validator.rb
+++ b/app/validators/metadata_presenter/max_size_validator.rb
@@ -1,6 +1,5 @@
 module MetadataPresenter
   class MaxSizeValidator < BaseValidator
-    def invalid_answer?
-    end
+    def invalid_answer?; end
   end
 end

--- a/app/validators/metadata_presenter/max_size_validator.rb
+++ b/app/validators/metadata_presenter/max_size_validator.rb
@@ -1,4 +1,6 @@
 module MetadataPresenter
   class MaxSizeValidator < BaseValidator
+    def invalid_answer?
+    end
   end
 end

--- a/app/validators/metadata_presenter/max_size_validator.rb
+++ b/app/validators/metadata_presenter/max_size_validator.rb
@@ -1,0 +1,4 @@
+module MetadataPresenter
+  class MaxSizeValidator < BaseValidator
+  end
+end

--- a/app/views/metadata_presenter/component/_upload.html.erb
+++ b/app/views/metadata_presenter/component/_upload.html.erb
@@ -1,2 +1,8 @@
 <%= f.govuk_file_field component.id.to_sym,
-  label: { text: input_title }, accept: component.validation['accept'] %>
+  label: { text: input_title },
+  hint: {
+      data: { "fb-default-text" => default_text('upload_hint') },
+      text: component.hint.present? ? component.hint : default_text('upload_hint')
+    },
+  accept: component.validation['accept']
+%>

--- a/app/views/metadata_presenter/component/_upload.html.erb
+++ b/app/views/metadata_presenter/component/_upload.html.erb
@@ -1,0 +1,2 @@
+<%= f.govuk_file_field component.id.to_sym,
+  label: { text: input_title }, accept: component.validation['accept'] %>

--- a/default_metadata/page/singlequestion.json
+++ b/default_metadata/page/singlequestion.json
@@ -2,7 +2,7 @@
   "_id": "page.singlequestion",
   "_type": "page.singlequestion",
   "section_heading": "",
-  "heading": "Question",
+  "heading": "",
   "lede": "",
   "body": "Body section",
   "components": [],

--- a/default_text/content.json
+++ b/default_text/content.json
@@ -5,5 +5,6 @@
   "content": "[Optional content]",
   "hint": "[Optional hint text]",
   "option": "Option",
-  "option_hint": "[Optional hint text]"
+  "option_hint": "[Optional hint text]",
+  "upload_hint": "Maximum file size is 7 MB"
 }

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -439,13 +439,14 @@
       "body": "We need a photograph of your dog",
       "_type": "page.singlequestion",
       "_uuid": "2ef7d11e-0307-49e9-9fe2-345dc528dd66",
-      "heading": "Upload your best dog photo",
+      "heading": "Question",
       "components": [
         {
           "_id":  "dog-picture_upload_1",
           "name": "dog-picture_upload_1",
           "_type": "upload",
           "_uuid": "f056a76e-ec3f-47ae-b625-1bba92220ad1",
+          "legend": "Upload your best dog photo",
           "max_files": 1,
           "validation": {
             "required": true,

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -436,7 +436,6 @@
     {
       "_id": "page.dog-picture",
       "url": "dog-picture",
-      "body": "We need a photograph of your dog",
       "_type": "page.singlequestion",
       "_uuid": "2ef7d11e-0307-49e9-9fe2-345dc528dd66",
       "heading": "Question",
@@ -446,6 +445,7 @@
           "name": "dog-picture_upload_1",
           "_type": "upload",
           "_uuid": "f056a76e-ec3f-47ae-b625-1bba92220ad1",
+          "hint": "",
           "legend": "Upload your best dog photo",
           "max_files": 1,
           "validation": {

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -20,6 +20,7 @@
         "page.burgers",
         "page.star-wars-knowledge",
         "page.how-many-lights",
+        "page.dog-picture",
         "page.check-answers",
         "page.confirmation"
       ],
@@ -431,6 +432,69 @@
       ],
       "add_component": "content",
       "section_heading": "Chain of Command"
+    },
+    {
+      "_id": "page.dog-picture",
+      "url": "dog-picture",
+      "body": "We need a photograph of your dog",
+      "_type": "page.singlequestion",
+      "_uuid": "2ef7d11e-0307-49e9-9fe2-345dc528dd66",
+      "heading": "Upload your best dog photo",
+      "components": [
+        {
+          "_id":  "dog-picture_upload_1",
+          "name": "dog-picture_upload_1",
+          "_type": "upload",
+          "_uuid": "f056a76e-ec3f-47ae-b625-1bba92220ad1",
+          "max_files": 1,
+          "validation": {
+            "required": true,
+            "accept": [
+              "audio/*",
+              "image/bmp",
+              "text/csv",
+              "application/vnd.ms-excel",
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+              "application/vnd.ms-excel.sheet.macroEnabled.12",
+              "application/vnd.ms-excel.template.macroEnabled.12",
+              "application/vnd.ms-excel.addin.macroEnabled.12",
+              "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+              "image/gif",
+              "image/*",
+              "application/x-iwork-pages-sffpages",
+              "image/jpeg",
+              "applicattion/pdf",
+              "text/plain",
+              "image/png",
+              "application/vnd.ms-powerpoint",
+              "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+              "application/vnd.openxmlformats-officedocument.presentationml.template",
+              "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+              "application/vnd.ms-powerpoint.addin.macroEnabled.12",
+              "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
+              "application/vnd.ms-powerpoint.template.macroEnabled.12",
+              "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
+              "text/rtf",
+              "excel",
+              "csv",
+              "image/svg+xml",
+              "pdf",
+              "word",
+              "rtf",
+              "plaintext",
+              "image/tiff",
+              "video/*",
+              "application/msword",
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+              "application/vnd.ms-word.document.macroEnabled.12",
+              "application/vnd.ms-word.template.macroEnabled.12"
+            ],
+            "max_size": "7340032"
+          }
+        }
+      ]
     },
     {
       "_id": "page.check-answers",

--- a/schemas/component/upload.json
+++ b/schemas/component/upload.json
@@ -18,61 +18,6 @@
       "title": "Minimum number of files",
       "description": "Minimum number of files a user can upload - 1 if required, 0 if not required",
       "type": "number"
-    },
-    "accept": {
-      "title": "Accepted types",
-      "description": "Which file types to accept",
-      "type": "array",
-      "items": {
-        "type": "string",
-        "enum": [
-          "audio/*",
-          "image/bmp",
-          "text/csv",
-          "application/vnd.ms-excel",
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
-          "application/vnd.ms-excel.sheet.macroEnabled.12",
-          "application/vnd.ms-excel.template.macroEnabled.12",
-          "application/vnd.ms-excel.addin.macroEnabled.12",
-          "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
-          "image/gif",
-          "image/*",
-          "application/x-iwork-pages-sffpages",
-          "image/jpeg",
-          "applicattion/pdf",
-          "text/plain",
-          "image/png",
-          "application/vnd.ms-powerpoint",
-          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-          "application/vnd.openxmlformats-officedocument.presentationml.template",
-          "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
-          "application/vnd.ms-powerpoint.addin.macroEnabled.12",
-          "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
-          "application/vnd.ms-powerpoint.template.macroEnabled.12",
-          "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
-          "text/rtf",
-          "excel",
-          "csv",
-          "image/svg+xml",
-          "pdf",
-          "word",
-          "rtf",
-          "plaintext",
-          "image/tiff",
-          "video/*",
-          "application/msword",
-          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-          "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
-          "application/vnd.ms-word.document.macroEnabled.12",
-          "application/vnd.ms-word.template.macroEnabled.12"
-        ]
-      }
-    },
-    "max_size": {
-      "title": "Maximum size",
-      "description": "Maximum file size as human readable string or bytes",
-      "type": "string"
     }
   },
   "allOf": [

--- a/schemas/validations/validations.json
+++ b/schemas/validations/validations.json
@@ -270,6 +270,61 @@
         }
       ]
     },
+    "accept": {
+      "title": "Accepted types",
+      "description": "Which file types to accept",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "audio/*",
+          "image/bmp",
+          "text/csv",
+          "application/vnd.ms-excel",
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+          "application/vnd.ms-excel.sheet.macroEnabled.12",
+          "application/vnd.ms-excel.template.macroEnabled.12",
+          "application/vnd.ms-excel.addin.macroEnabled.12",
+          "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+          "image/gif",
+          "image/*",
+          "application/x-iwork-pages-sffpages",
+          "image/jpeg",
+          "applicattion/pdf",
+          "text/plain",
+          "image/png",
+          "application/vnd.ms-powerpoint",
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "application/vnd.openxmlformats-officedocument.presentationml.template",
+          "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+          "application/vnd.ms-powerpoint.addin.macroEnabled.12",
+          "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
+          "application/vnd.ms-powerpoint.template.macroEnabled.12",
+          "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
+          "text/rtf",
+          "excel",
+          "csv",
+          "image/svg+xml",
+          "pdf",
+          "word",
+          "rtf",
+          "plaintext",
+          "image/tiff",
+          "video/*",
+          "application/msword",
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+          "application/vnd.ms-word.document.macroEnabled.12",
+          "application/vnd.ms-word.template.macroEnabled.12"
+        ]
+      }
+    },
+    "max_size": {
+      "title": "Maximum size",
+      "description": "Maximum file size as human readable string or bytes",
+      "type": "string"
+    },
     "required_bundle": {
       "properties": {
         "validation": {
@@ -289,43 +344,6 @@
           "properties": {
             "required": {
               "$ref": "#/definitions/errors_required"
-            }
-          }
-        }
-      }
-    },
-    "upload_bundle": {
-      "properties": {
-        "validation": {
-          "title": "Validation",
-          "description": "Values for default validation",
-          "role": "validation",
-          "properties": {
-            "accept": {
-              "title": "Accepted types",
-              "description": "Which file types to accept",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "max_size": {
-              "title": "Maximum size",
-              "description": "Maximum file size as human readable string or bytes",
-              "type": "string"
-            }
-          }
-        },
-        "errors": {
-          "title": "Errors",
-          "description": "Strings to override for default error messages",
-          "role": "error_strings",
-          "properties": {
-            "accept": {
-              "$ref": "#/definitions/errors_accept"
-            },
-            "maxSize": {
-              "$ref": "#/definitions/errors_max_size"
             }
           }
         }


### PR DESCRIPTION
Story: https://trello.com/c/O2irOD1S/1555-file-upload-render-file-upload-page

### Add upload page to fixture
We also moved the accept and max_size to the validations schema.
We don't need uploadBundle property because the new runner is different from the classic/legacy form builder.

On the new runner we have errors and validation as separate nodes
```
   components: [
     {
       errors: {
         "required": "Some custom required message"
       },
       validation: {
         "required": true
       }
     }
   ]
```

So we are not separating by component type like number_bundle, uploadBundle etc

### Render upload pages

### Create empty validators
This will be tackled by the next trello cards:
https://trello.com/c/alACDOD0/1556-file-upload-upload-a-file-to-the-form

### Add methods in the validators
### Add default hint text to upload component

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>