### PR TITLE
Default file upload allowed types

### DIFF
--- a/default_metadata/component/upload.json
+++ b/default_metadata/component/upload.json
@@ -8,6 +8,18 @@
   "validation": {
     "required": true,
     "max_size": "7340032",
-    "virus_scan": true
+    "virus_scan": true,
+    "accept": [
+      "text/csv",
+      "text/plain",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/msword",
+      "application/vnd.oasis.opendocument.text",
+      "application/pdf",
+      "application/rtf",
+      "image/jpeg",
+      "image/png",
+      "application/vnd.ms-excel"
+    ]
   }
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.1.1'.freeze
 end


### PR DESCRIPTION
The upload component default metadata needs to have the list of default allowed file upload types.

Publish 1.1.1