### PR TITLE
Add ability to remove file from user answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+## [1.2.0] - 2021-06-03
+
+### Added
+
+- Add ability to remove a previously uploaded file from user answers
+
+## [1.1.1] - 2021-06-02
+
+### Added
+
+- Add the allowed file types to the upload component default metadata
+
+## [1.1.0] - 2021-06-01
+
+### Added
+
+- Added file upload compononent and templates
+
 ## [1.0.8] - 2021-05-04
 
 ### Changed

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -17,6 +17,11 @@ module MetadataPresenter
     end
     helper_method :back_link
 
+    def answered?(component_id)
+      @page_answers.send(component_id).present?
+    end
+    helper_method :answered?
+
     private
 
     def not_found

--- a/app/controllers/metadata_presenter/file_controller.rb
+++ b/app/controllers/metadata_presenter/file_controller.rb
@@ -1,0 +1,12 @@
+module MetadataPresenter
+  class FileController < EngineController
+    def destroy
+      remove_user_data(params[:component_id])
+      redirect_back(fallback_location: root_path)
+    end
+
+    def remove_user_data
+      super if defined?(super)
+    end
+  end
+end

--- a/app/views/metadata_presenter/component/_upload.html.erb
+++ b/app/views/metadata_presenter/component/_upload.html.erb
@@ -1,9 +1,22 @@
-<%= f.govuk_file_field component.id.to_sym,
-  label: { text: input_title },
-  hint: {
-      data: { "fb-default-text" => default_text('upload_hint') },
-      text: component.hint.present? ? component.hint : default_text('upload_hint')
-    },
-  accept: component.validation['accept'],
-  disabled: editable?
-%>
+<% if answered?(component.id) %>
+  <h1 class="govuk-heading-xl"><%= input_title %></h1>
+  <span class="govuk-hint" id="answers-dog-picture-upload-1-hint" data-fb-default-text="<%= default_text('upload_hint') %>">
+    <%= component.hint.present? ? component.hint : default_text('upload_hint') %>
+  </span>
+
+  <p><%= @page_answers.send(component.id)['original_filename'] %></p>
+
+  <p>
+    <%= link_to 'Remove file', remove_file_path(component.id), method: :delete, class: 'govuk-link' %>
+  </p>
+<% else %>
+  <%= f.govuk_file_field component.id.to_sym,
+    label: { text: input_title },
+    hint: {
+        data: { "fb-default-text" => default_text('upload_hint') },
+        text: component.hint.present? ? component.hint : default_text('upload_hint')
+      },
+    accept: component.validation['accept'],
+    disabled: editable?
+  %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ MetadataPresenter::Engine.routes.draw do
 
   post '/reserved/submissions', to: 'submissions#create', as: :reserved_submissions
   get '/reserved/change-answer', to: 'change_answer#create', as: :change_answer
+  delete '/reserved/file/:component_id', to: 'file#destroy', as: :remove_file
 
   post '/', to: 'answers#create'
   match '*path', to: 'answers#create', via: :post

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.2.0'.freeze
 end


### PR DESCRIPTION
So the mounted apps needs to implement the remove_user_data method
in the controller.

Add method signature remove_user_data when removing the file

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>