### PR TITLE
Return empty hash when answer is blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+## [1.3.1] - 2021-06-04
+
+### Fixed
+
+- Return and empty file object when there is no file to be uploaded
+
 ## [1.3.0] - 2021-06-04
 
 ### Changed

--- a/app/models/metadata_presenter/file_uploader.rb
+++ b/app/models/metadata_presenter/file_uploader.rb
@@ -8,11 +8,17 @@ module MetadataPresenter
     end
 
     def upload_file
+      return {} if file_details.blank?
+
       adapter.new(
         session: session,
-        file_details: page_answers.send(component.id),
+        file_details: file_details,
         allowed_file_types: component.validation['accept']
       ).call
+    end
+
+    def file_details
+      page_answers.send(component.id)
     end
   end
 end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.3.0'.freeze
+  VERSION = '1.3.1'.freeze
 end

--- a/spec/models/file_uploader_spec.rb
+++ b/spec/models/file_uploader_spec.rb
@@ -9,36 +9,57 @@ RSpec.describe MetadataPresenter::FileUploader do
   end
   let(:adapter) { double }
   let(:session) { { session_id: '3337407fcd59870be6f15daccf17d311' } }
-  let(:page_answers) do
-    double(
-      'dog-picture' => file_details
-    )
-  end
-  let(:file_details) do
-    {
-      'original_filename' => './spec/fixtures/thats-not-a-knife.txt',
-      'content_type' => 'text/plain',
-      'tempfile' => Rails.root.join('spec', 'fixtures', 'thats-not-a-knife.txt')
-    }
-  end
   let(:component) do
     double(id: 'dog-picture', validation: { 'accept' => accept })
   end
   let(:accept) { %w[text/csv] }
 
   describe '#upload' do
-    it 'returns uploaded file' do
-      expect(adapter).to receive(:new).with(
-        session: session,
-        file_details: file_details,
-        allowed_file_types: accept
-      ).and_return(double(call: { 'fingerprint' => '28d' }))
-      expect(file_uploader.upload).to eq(
-        MetadataPresenter::UploadedFile.new(
-          file: { 'fingerprint' => '28d' },
-          component: component
+    context 'when there is no file' do
+      let(:page_answers) do
+        double(
+          'dog-picture' => nil
         )
-      )
+      end
+
+      it 'returns an empty uploaded file' do
+        expect(adapter).to_not receive(:new)
+        expect(file_uploader.upload).to eq(
+          MetadataPresenter::UploadedFile.new(
+            file: {},
+            component: component
+          )
+        )
+      end
+    end
+
+    context 'when there is a file' do
+      let(:page_answers) do
+        double(
+          'dog-picture' => file_details
+        )
+      end
+      let(:file_details) do
+        {
+          'original_filename' => './spec/fixtures/thats-not-a-knife.txt',
+          'content_type' => 'text/plain',
+          'tempfile' => Rails.root.join('spec', 'fixtures', 'thats-not-a-knife.txt')
+        }
+      end
+
+      it 'returns uploaded file' do
+        expect(adapter).to receive(:new).with(
+          session: session,
+          file_details: file_details,
+          allowed_file_types: accept
+        ).and_return(double(call: { 'fingerprint' => '28d' }))
+        expect(file_uploader.upload).to eq(
+          MetadataPresenter::UploadedFile.new(
+            file: { 'fingerprint' => '28d' },
+            component: component
+          )
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
When we are using filestore and there is no file we shouldn't
call filestore and we should return an empty uploaded file.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>