### PR TITLE
Branching checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [1.5.0] - 2021-06-28
+
+### Added
+
+- Simple branching (single conditions) with checkboxes
+
 ## [1.4.0] - 2021-06-24
 
 ### Added

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -27,6 +27,8 @@ module MetadataPresenter
         date_answer(component.id)
       elsif component && component.type == 'upload'
         upload_answer(component.id)
+      elsif component && component.type == 'checkboxes'
+        answers[method_name.to_s].to_a
       else
         answers[method_name.to_s]
       end

--- a/app/operators/metadata_presenter/base_operator.rb
+++ b/app/operators/metadata_presenter/base_operator.rb
@@ -6,5 +6,15 @@ module MetadataPresenter
       @actual = actual
       @expected = expected
     end
+
+    def evaluate?
+      raise NotImplementedError
+    end
+
+    # Method signature for collection components (a.k.a checkboxes)
+    #
+    def evaluate_collection?
+      evaluate?
+    end
   end
 end

--- a/app/operators/metadata_presenter/is_not_operator.rb
+++ b/app/operators/metadata_presenter/is_not_operator.rb
@@ -3,5 +3,9 @@ module MetadataPresenter
     def evaluate?
       @actual != @expected
     end
+
+    def evaluate_collection?
+      Array(@expected).exclude?(@actual)
+    end
   end
 end

--- a/app/operators/metadata_presenter/is_operator.rb
+++ b/app/operators/metadata_presenter/is_operator.rb
@@ -3,5 +3,9 @@ module MetadataPresenter
     def evaluate?
       @actual == @expected
     end
+
+    def evaluate_collection?
+      Array(@expected).include?(@actual)
+    end
   end
 end

--- a/app/operators/metadata_presenter/operator.rb
+++ b/app/operators/metadata_presenter/operator.rb
@@ -10,10 +10,13 @@ module MetadataPresenter
     end
 
     def evaluate(actual, expected)
-      klass
-        .constantize
-        .new(actual, expected)
-        .evaluate?
+      operator = klass.constantize.new(actual, expected)
+
+      if expected.is_a?(Array)
+        operator.evaluate_collection?
+      else
+        operator.evaluate?
+      end
     rescue NameError
       raise NoOperator,
             "Operator '#{operator}' is not implemented. You need to create the class #{klass}"

--- a/fixtures/branching.json
+++ b/fixtures/branching.json
@@ -137,7 +137,7 @@
     "cf8b3e18-dacf-4e91-92e1-018035961003": {
       "_type": "branch",
       "next": {
-        "default": "e337070b-f636-49a3-a65c-f506675265f0",
+        "default": "0c022e95-0748-4dda-8ba5-12fd1d2f596b",
         "conditions": [
           {
             "condition_type": "if",
@@ -152,6 +152,62 @@
             ]
           }
         ]
+      }
+    },
+    "b5efc09c-ece7-45ae-b0b3-8a7905e25040": {
+      "_type": "page",
+      "next": {
+        "default": "0c022e95-0748-4dda-8ba5-12fd1d2f596b"
+      }
+    },
+    "0c022e95-0748-4dda-8ba5-12fd1d2f596b": {
+      "_type": "page",
+      "next": {
+        "default": "618b7537-b42b-4551-ae7d-053afa4d9ca9"
+      }
+    },
+    "618b7537-b42b-4551-ae7d-053afa4d9ca9": {
+      "_type": "branch",
+      "next": {
+        "default": "e337070b-f636-49a3-a65c-f506675265f0",
+        "conditions": [
+          {
+            "condition_type": "if",
+            "next": "bc666714-c0a2-4674-afe5-faff2e20d847",
+            "criterias": [
+              {
+                "operator": "is",
+                "page": "0c022e95-0748-4dda-8ba5-12fd1d2f596b",
+                "component": "4c409737-80bb-48c7-afa7-6e9360b65004",
+                "field": "3251098f-c8e0-4ac5-a637-95fd2e1c4dc4"
+              }
+            ]
+          },
+          {
+            "condition_type": "if",
+            "next": "e2887f44-5e8d-4dc0-b1de-496ab6039430",
+            "criterias": [
+              {
+                "operator": "is_not",
+                "page": "0c022e95-0748-4dda-8ba5-12fd1d2f596b",
+                "component": "4c409737-80bb-48c7-afa7-6e9360b65004",
+                "field": "3251098f-c8e0-4ac5-a637-95fd2e1c4dc4"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "bc666714-c0a2-4674-afe5-faff2e20d847": {
+      "_type": "page",
+      "next": {
+        "default": "e337070b-f636-49a3-a65c-f506675265f0"
+      }
+    },
+    "e2887f44-5e8d-4dc0-b1de-496ab6039430": {
+      "_type": "page",
+      "next": {
+        "default": "e337070b-f636-49a3-a65c-f506675265f0"
       }
     },
     "e337070b-f636-49a3-a65c-f506675265f0": {
@@ -607,6 +663,115 @@
           }
         }
       ]
+    },
+    {
+      "_id": "page.burgers",
+      "url": "burgers",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "0c022e95-0748-4dda-8ba5-12fd1d2f596b",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "burgers_checkboxes_1",
+          "hint": "",
+          "name": "burgers_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "4c409737-80bb-48c7-afa7-6e9360b65004",
+          "items": [
+            {
+              "_id": "burgers_checkboxes_1_item_1",
+              "hint": "",
+              "name": "burgers_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "3251098f-c8e0-4ac5-a637-95fd2e1c4dc4",
+              "label": "Beef, cheese, tomato",
+              "value": "value-1",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "burgers_checkboxes_1_item_2",
+              "hint": "",
+              "name": "burgers_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "a0717bbd-0b9f-47a0-bf2b-2a9d208e1168",
+              "label": "Chicken, cheese, tomato",
+              "value": "value-2",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "burgers_checkboxes_1_item_3",
+              "hint": "",
+              "name": "burgers_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "4c409737-80bb-48c7-afa7-6e9360b65004",
+              "label": "Mozzarella, cheddar, feta",
+              "value": "value-3",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {},
+          "legend": "What would you like on your burger?",
+          "collection": "components",
+          "validation": {
+            "required": false
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.global-warming",
+      "url": "global-warming",
+      "body": "What about the trees?",
+      "lede": "",
+      "_type": "page.content",
+      "_uuid": "bc666714-c0a2-4674-afe5-faff2e20d847",
+      "heading": "Global warming",
+      "components": [
+        {
+          "_id": "global-warming_content_1",
+          "name": "global-warming_content_1",
+          "_type": "content",
+          "_uuid": "957917c3-7473-4c30-b713-5aae77a1c22f",
+          "content": "They will come for you"
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.we-love-chickens",
+      "url": "we-love-chickens",
+      "body": "Cluck cluck",
+      "lede": "",
+      "_type": "page.content",
+      "_uuid": "e2887f44-5e8d-4dc0-b1de-496ab6039430",
+      "heading": "We love chickens",
+      "components": [
+        {
+          "_id": "global-warming_content_1",
+          "name": "global-warming_content_1",
+          "_type": "content",
+          "_uuid": "49ff5c79-2e63-45fe-bbf7-de0bd061b909",
+          "content": "Cruella ain't got nothing on Cluckeralla"
+        }
+      ],
+      "section_heading": ""
     },
     {
       "_id": "page.check-answers",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.4.0'.freeze
+  VERSION = '1.5.0'.freeze
 end

--- a/lib/tasks/metadata_presenter_tasks.rake
+++ b/lib/tasks/metadata_presenter_tasks.rake
@@ -1,4 +1,52 @@
-# desc "Explaining what the task does"
-# task :metadata_presenter do
-#   # Task goes here
-# end
+require 'metadata_presenter/test_helpers'
+
+namespace :metadata do
+  include MetadataPresenter::TestHelpers
+
+  desc 'Represent the flow objects in human readable form'
+  task flow: :environment do
+    service = MetadataPresenter::Service.new(metadata_fixture('branching'))
+
+    start_page = service.start_page
+    flow = service.flow(start_page.uuid)
+    first_page = service.find_page_by_uuid(flow.default_next)
+
+    humanized_flow = {}
+
+    humanized_flow[start_page.url] = {
+      next: first_page.url
+    }
+
+    service.metadata['flow'].each do |id, _metadata|
+      flow = service.flow(id)
+
+      if flow.branch?
+        page = service.find_page_by_uuid(flow.default_next)
+        humanized_flow[page.url] = {
+          conditions: flow.conditions.map do |condition|
+            {
+              condition_type: condition.condition_type,
+              criterias: condition.criterias.map do |criteria|
+                criteria.service = service
+                {
+                  operator: criteria.operator,
+                  page: criteria.criteria_page.url,
+                  component: criteria.criteria_component.humanised_title,
+                  field: criteria.field_label
+                }
+              end
+            }
+          end
+        }
+      else
+        page = service.find_page_by_uuid(id)
+        next_page = service.find_page_by_uuid(flow.default_next)
+        if next_page
+          humanized_flow[page.url] = { next: next_page.url }
+        end
+      end
+    end
+
+    pp humanized_flow
+  end
+end

--- a/spec/models/evaluate_conditions_spec.rb
+++ b/spec/models/evaluate_conditions_spec.rb
@@ -76,14 +76,53 @@ RSpec.describe MetadataPresenter::EvaluateConditions do
           end
         end
       end
+
+      context 'when the question is a checkbox component' do
+        let(:flow) { service.flow('618b7537-b42b-4551-ae7d-053afa4d9ca9') }
+
+        context 'when beef cheese and tomato condition "is" met' do
+          let(:user_data) do
+            {
+              'burgers_checkboxes_1' => ['Beef, cheese, tomato']
+            }
+          end
+
+          it 'returns the page uuid for the default page' do
+            expect(page).to eq(service.find_page_by_url('global-warming'))
+          end
+        end
+
+        context 'when beef cheese and tomator "is not" met' do
+          let(:user_data) do
+            {
+              'burgers_checkboxes_1' => ['Chicken, cheese, tomato']
+            }
+          end
+
+          it 'returns the page uuid for the default page' do
+            expect(page).to eq(service.find_page_by_url('we-love-chickens'))
+          end
+        end
+      end
     end
 
     context 'when the question is optional' do
-      let(:flow) { service.flow('ffadeb22-063b-4e4f-9502-bd753c706b1d') }
-      let(:user_data) { { 'favourite-fruit_radios_1' => '' } }
+      context 'for single answer questions' do
+        let(:flow) { service.flow('ffadeb22-063b-4e4f-9502-bd753c706b1d') }
+        let(:user_data) { { 'favourite-fruit_radios_1' => '' } }
 
-      it 'returns the page uuid for the default page' do
-        expect(page).to eq(service.find_page_by_url('favourite-band'))
+        it 'returns the page uuid for the default page' do
+          expect(page).to eq(service.find_page_by_url('favourite-band'))
+        end
+      end
+
+      context 'for multiple answer (checkboxes) questions' do
+        let(:flow) { service.flow('ffadeb22-063b-4e4f-9502-bd753c706b1d') }
+        let(:user_data) { { 'burgers_checkboxes_1' => [] } }
+
+        it 'returns the page uuid for the default page' do
+          expect(page).to eq(service.find_page_by_url('favourite-band'))
+        end
       end
     end
   end

--- a/spec/models/page_answers_spec.rb
+++ b/spec/models/page_answers_spec.rb
@@ -107,10 +107,18 @@ RSpec.describe MetadataPresenter::PageAnswers do
       end
     end
 
-    context 'when the components do not exist' do
-      # This will be tested when we add multiple questions pages
-      #
-      # DO THIS
+    context 'when the components are optional' do
+      let(:page) { service.find_page_by_url('burgers') }
+
+      context 'checkboxes component' do
+        let(:answers) { {} }
+
+        it 'returns empty array' do
+          expect(
+            page_answers.send('burgers_checkboxes_1')
+          ).to eq([])
+        end
+      end
     end
   end
 

--- a/spec/operators/is_answered_operator_spec.rb
+++ b/spec/operators/is_answered_operator_spec.rb
@@ -27,4 +27,30 @@ RSpec.describe MetadataPresenter::IsAnsweredOperator do
       end
     end
   end
+
+  describe '#evaluate_collection?' do
+    context 'when is answered' do
+      let(:expected) { %w[foo] }
+
+      it 'returns true' do
+        expect(operator.evaluate_collection?).to be_truthy
+      end
+    end
+
+    context 'when is not answered' do
+      let(:expected) { [] }
+
+      it 'returns false' do
+        expect(operator.evaluate_collection?).to be_falsey
+      end
+    end
+
+    context 'when is nil' do
+      let(:expected) { nil }
+
+      it 'returns false' do
+        expect(operator.evaluate_collection?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/operators/is_not_answered_operator_spec.rb
+++ b/spec/operators/is_not_answered_operator_spec.rb
@@ -27,4 +27,30 @@ RSpec.describe MetadataPresenter::IsNotAnsweredOperator do
       end
     end
   end
+
+  describe '#evaluate_collection?' do
+    context 'when is answered' do
+      let(:expected) { %w[foo] }
+
+      it 'returns false' do
+        expect(operator.evaluate_collection?).to be_falsey
+      end
+    end
+
+    context 'when is not answered' do
+      let(:expected) { [] }
+
+      it 'returns true' do
+        expect(operator.evaluate_collection?).to be_truthy
+      end
+    end
+
+    context 'when is nil' do
+      let(:expected) { nil }
+
+      it 'returns true' do
+        expect(operator.evaluate_collection?).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/operators/is_not_operator_spec.rb
+++ b/spec/operators/is_not_operator_spec.rb
@@ -20,4 +20,44 @@ RSpec.describe MetadataPresenter::IsNotOperator do
       end
     end
   end
+
+  describe '#evaluate_collection?' do
+    context 'when is included' do
+      let(:actual) { 'Apples' }
+      let(:expected) { %w[Apples] }
+
+      it 'returns false' do
+        expect(operator.evaluate_collection?).to be_falsey
+      end
+    end
+
+    context 'when is not included' do
+      context 'when other choices are selected' do
+        let(:actual) { 'Apples' }
+        let(:expected) { %w[Pears] }
+
+        it 'returns true' do
+          expect(operator.evaluate_collection?).to be_truthy
+        end
+      end
+
+      context 'when is not answered' do
+        let(:actual) { 'Apples' }
+        let(:expected) { [] }
+
+        it 'returns true' do
+          expect(operator.evaluate_collection?).to be_truthy
+        end
+      end
+
+      context 'when is nil' do
+        let(:actual) { 'Apples' }
+        let(:expected) { nil }
+
+        it 'returns true' do
+          expect(operator.evaluate_collection?).to be_truthy
+        end
+      end
+    end
+  end
 end

--- a/spec/operators/is_operator_spec.rb
+++ b/spec/operators/is_operator_spec.rb
@@ -20,4 +20,44 @@ RSpec.describe MetadataPresenter::IsOperator do
       end
     end
   end
+
+  describe '#evaluate_collection?' do
+    context 'when is included' do
+      let(:actual) { 'Apples' }
+      let(:expected) { %w[Apples] }
+
+      it 'returns true' do
+        expect(operator.evaluate_collection?).to be_truthy
+      end
+    end
+
+    context 'when is not included' do
+      context 'when other choices are selected' do
+        let(:actual) { 'Apples' }
+        let(:expected) { %w[Pears] }
+
+        it 'returns false' do
+          expect(operator.evaluate_collection?).to be_falsey
+        end
+      end
+
+      context 'when is not answered' do
+        let(:actual) { 'Apples' }
+        let(:expected) { [] }
+
+        it 'returns false' do
+          expect(operator.evaluate_collection?).to be_falsey
+        end
+      end
+
+      context 'when is nil' do
+        let(:actual) { 'Apples' }
+        let(:expected) { nil }
+
+        it 'returns false' do
+          expect(operator.evaluate_collection?).to be_falsey
+        end
+      end
+    end
+  end
 end

--- a/spec/operators/operator_spec.rb
+++ b/spec/operators/operator_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe MetadataPresenter::Operator do
           subject.evaluate(actual, expected)
         end
       end
+
+      context 'when expected answer is an array' do
+        let(:operator) { 'is' }
+        let(:expected) { [] }
+
+        it 'should call evaluate_collection?' do
+          expect_any_instance_of(MetadataPresenter::IsOperator).to receive(:evaluate_collection?)
+          subject.evaluate(actual, expected)
+        end
+      end
     end
 
     context 'when operator does not exist' do


### PR DESCRIPTION
## Context

This PR adds support for checkboxes on evaluating conditions (a.k.a branching).

We add a method signature called `#evaluate_collection?` for checkboxes. If an operator needs special treatment for collections then just overwrite the method in the operator subclass.

## Rake script to humanize the flow

There is a rake script to humanize the flow but it is not 100% right yet. Please do let me know if you want to exclude it from the PR or leave it there to finish properly later.
