### PR TITLE
Generate flow diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,15 @@ service.
 ## Generate documentation
 
 Run `rake doc` and open the doc/index.html
+
+## Flow diagrams
+
+You can generate flow diagrams calling a rake task:
+
+```
+  brew install graphviz
+  SERVICE_METADATA="some-form-metadata" rails metadata:flow
+```
+
+This will generate an image with the flow for that metadata. Open that image
+and profit!

--- a/app/models/metadata_presenter/flow.rb
+++ b/app/models/metadata_presenter/flow.rb
@@ -13,5 +13,9 @@ module MetadataPresenter
         Condition.new(condition_metadata)
       end
     end
+
+    def group_by_page
+      conditions.group_by(&:next)
+    end
   end
 end

--- a/fixtures/branching.json
+++ b/fixtures/branching.json
@@ -820,7 +820,7 @@
   "created_by": "099d5bf5-5f7b-444c-86ee-9e189cc1a369",
   "service_id": "488edccd-8411-4ffb-a38b-6a96c6ac28d6",
   "version_id": "27dc30c9-f7b8-4dec-973a-bd153f6797df",
-  "service_name": "Version Fixture",
+  "service_name": "Branching Fixture",
   "configuration": {
     "meta": {
       "_id": "config.meta",

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'binding_of_caller'
   spec.add_development_dependency 'brakeman'
   spec.add_development_dependency 'byebug'
+  spec.add_development_dependency 'ruby-graphviz'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rubocop', '~> 1.15.0'
   spec.add_development_dependency 'rubocop-govuk'


### PR DESCRIPTION
## Context

This PR adds a rake task that generates a diagram for any metadata which contains the flow object.

## Running the rake task

It is added to the readme. You need to install Graphviz: 

`brew install graphviz`

Then you can run with `rails app:metadata:flow` (inside of the gem).

In the mounted app (a.k.a runner) you can run only `rails metadata:flow`.

### Running in the runner

It also accepts the `SERVICE_METADATA` env var:

```
SERVICE_METADATA="my awesome metadata"  rails metadata:flow
```

## Results

![branching-fixture](https://user-images.githubusercontent.com/27509/123776845-0da4b180-d8a6-11eb-839c-5951d7e3bb4e.png)
