### PR TITLE
Branching previous page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,3 +38,6 @@ Rails/FilePath:
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: indent
+
+Rails/RequestReferer:
+  EnforcedStyle: referrer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [1.6.0] - 2021-07-01
+
+### Added
+
+- Simple branching back links
+
 ## [1.5.0] - 2021-06-28
 
 ### Added

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -28,6 +28,7 @@ module MetadataPresenter
       next_page = NextPage.new(
         service: service,
         session: session,
+        user_data: load_user_data,
         current_page_url: page_url
       ).find
 

--- a/app/controllers/metadata_presenter/change_answer_controller.rb
+++ b/app/controllers/metadata_presenter/change_answer_controller.rb
@@ -1,7 +1,7 @@
 module MetadataPresenter
   class ChangeAnswerController < EngineController
     def create
-      session[:return_to_check_you_answer] = true
+      session[:return_to_check_your_answer] = true
       redirect_to_page params[:url]
     end
   end

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -10,7 +10,7 @@ module MetadataPresenter
         service: service,
         user_data: load_user_data,
         current_page: @page,
-        referer: request.referer
+        referrer: request.referrer
       ).page
 
       if previous_page

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -13,10 +13,12 @@ module MetadataPresenter
         referer: request.referer
       ).page
 
-      @back_link ||= File.join(
-        request.script_name,
-        previous_page.url
-      ) if previous_page
+      if previous_page
+        @back_link ||= File.join(
+          request.script_name,
+          previous_page.url
+        )
+      end
     end
     helper_method :back_link
 

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -6,14 +6,17 @@ module MetadataPresenter
     default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
     def back_link
-      return if @page.blank?
-
-      previous_page = service.previous_page(
+      previous_page = PreviousPage.new(
+        service: service,
+        user_data: load_user_data,
         current_page: @page,
-        referrer: request.referer
-      )&.url
+        referer: request.referer
+      ).page
 
-      @back_link ||= File.join(request.script_name, previous_page) if previous_page
+      @back_link ||= File.join(
+        request.script_name,
+        previous_page.url
+      ) if previous_page
     end
     helper_method :back_link
 

--- a/app/models/metadata_presenter/next_page.rb
+++ b/app/models/metadata_presenter/next_page.rb
@@ -4,7 +4,7 @@ module MetadataPresenter
     attr_accessor :service, :session, :user_data, :current_page_url
 
     def find
-      return check_answers_page if return_to_check_you_answer?
+      return check_answers_page if return_to_check_your_answer?
 
       if conditions?
         evaluate_conditions
@@ -18,12 +18,12 @@ module MetadataPresenter
     private
 
     def check_answers_page
-      session[:return_to_check_you_answer] = nil
+      session[:return_to_check_your_answer] = nil
       service.pages.find { |page| page.type == 'page.checkanswers' }
     end
 
-    def return_to_check_you_answer?
-      session[:return_to_check_you_answer].present?
+    def return_to_check_your_answer?
+      session[:return_to_check_your_answer].present?
     end
 
     def conditions?

--- a/app/models/metadata_presenter/next_page.rb
+++ b/app/models/metadata_presenter/next_page.rb
@@ -1,7 +1,7 @@
 module MetadataPresenter
   class NextPage
     include ActiveModel::Model
-    attr_accessor :service, :session, :current_page_url
+    attr_accessor :service, :session, :user_data, :current_page_url
 
     def find
       return check_answers_page if return_to_check_you_answer?
@@ -36,7 +36,7 @@ module MetadataPresenter
       EvaluateConditions.new(
         service: service,
         flow: next_flow,
-        user_data: session[:user_data]
+        user_data: user_data
       ).page
     end
 

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -62,6 +62,10 @@ module MetadataPresenter
       components.select(&:upload?)
     end
 
+    def standalone?
+      type == 'page.standalone'
+    end
+
     private
 
     def to_components(node_components, collection:)

--- a/app/models/metadata_presenter/previous_page.rb
+++ b/app/models/metadata_presenter/previous_page.rb
@@ -1,0 +1,27 @@
+module MetadataPresenter
+  class PreviousPage
+    include ActiveModel::Model
+    attr_accessor :service, :user_data, :current_page, :referer
+
+    def page
+      return if current_page.blank?
+
+      if flow.present?
+        previous_page = TraversedPages.new(service, user_data).last
+
+        return previous_page if previous_page
+
+        service.start_page
+      else
+        service.previous_page(
+          current_page: current_page,
+          referrer: referer
+        )
+      end
+    end
+
+    def flow
+      service.metadata['flow']
+    end
+  end
+end

--- a/app/models/metadata_presenter/previous_page.rb
+++ b/app/models/metadata_presenter/previous_page.rb
@@ -4,19 +4,35 @@ module MetadataPresenter
     attr_accessor :service, :user_data, :current_page, :referer
 
     def page
-      return if current_page.blank? || service.no_back_link?(current_page)
+      # what happens when a user enters in the middle of the flow
+      return if no_current_or_referrer_pages? || service.no_back_link?(current_page)
 
       if flow.present?
-        previous_page = TraversedPages.new(service, user_data, current_page).last
+        return referer_page if return_to_referer?
 
-        return previous_page if previous_page
+        TraversedPages.new(service, user_data, current_page).last
       else
-        service.previous_page(current_page: current_page)
+        service.previous_page(current_page: current_page, referer: referer)
       end
     end
 
     def flow
       service.metadata['flow']
+    end
+
+    private
+
+    def referer_page
+      @referer_page ||= service.find_page_by_url(URI(referer).path)
+    end
+
+    def return_to_referer?
+      current_page.standalone? ||
+        (referer_page && referer_page.standalone?)
+    end
+
+    def no_current_or_referer_pages?
+      current_page.blank? || referer.nil?
     end
   end
 end

--- a/app/models/metadata_presenter/previous_page.rb
+++ b/app/models/metadata_presenter/previous_page.rb
@@ -4,14 +4,12 @@ module MetadataPresenter
     attr_accessor :service, :user_data, :current_page, :referer
 
     def page
-      return if current_page.blank?
+      return if current_page.blank? || current_page == service.start_page
 
       if flow.present?
-        previous_page = TraversedPages.new(service, user_data).last
+        previous_page = TraversedPages.new(service, user_data, current_page).last
 
         return previous_page if previous_page
-
-        service.start_page
       else
         service.previous_page(
           current_page: current_page,

--- a/app/models/metadata_presenter/previous_page.rb
+++ b/app/models/metadata_presenter/previous_page.rb
@@ -4,17 +4,14 @@ module MetadataPresenter
     attr_accessor :service, :user_data, :current_page, :referer
 
     def page
-      return if current_page.blank? || current_page == service.start_page
+      return if current_page.blank? || service.no_back_link?(current_page)
 
       if flow.present?
         previous_page = TraversedPages.new(service, user_data, current_page).last
 
         return previous_page if previous_page
       else
-        service.previous_page(
-          current_page: current_page,
-          referrer: referer
-        )
+        service.previous_page(current_page: current_page)
       end
     end
 

--- a/app/models/metadata_presenter/previous_page.rb
+++ b/app/models/metadata_presenter/previous_page.rb
@@ -1,18 +1,18 @@
 module MetadataPresenter
   class PreviousPage
     include ActiveModel::Model
-    attr_accessor :service, :user_data, :current_page, :referer
+    attr_accessor :service, :user_data, :current_page, :referrer
 
     def page
       # what happens when a user enters in the middle of the flow
       return if no_current_or_referrer_pages? || service.no_back_link?(current_page)
 
       if flow.present?
-        return referer_page if return_to_referer?
+        return referrer_page if return_to_referrer?
 
         TraversedPages.new(service, user_data, current_page).last
       else
-        service.previous_page(current_page: current_page, referer: referer)
+        service.previous_page(current_page: current_page, referrer: referrer)
       end
     end
 
@@ -22,17 +22,17 @@ module MetadataPresenter
 
     private
 
-    def referer_page
-      @referer_page ||= service.find_page_by_url(URI(referer).path)
+    def referrer_page
+      @referrer_page ||= service.find_page_by_url(URI(referrer).path)
     end
 
-    def return_to_referer?
+    def return_to_referrer?
       current_page.standalone? ||
-        (referer_page && referer_page.standalone?)
+        (referrer_page && referrer_page.standalone?)
     end
 
-    def no_current_or_referer_pages?
-      current_page.blank? || referer.nil?
+    def no_current_or_referrer_pages?
+      current_page.blank? || referrer.nil?
     end
   end
 end

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -38,12 +38,11 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     pages[pages.index(current_page) + 1] if current_page.present?
   end
 
-  def previous_page(current_page:, referer:)
-    return if current_page.nil? || referer.nil?
+  def previous_page(current_page:, referrer:)
+    return if current_page.nil? || referrer.nil?
 
     unless no_back_link?(current_page)
-      flow_page(current_page) ||
-        find_page_by_url(URI(referer).path)
+      flow_page(current_page) || referrer_page(referrer)
     end
   end
 

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -38,9 +38,9 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     pages[pages.index(current_page) + 1] if current_page.present?
   end
 
-  def previous_page(current_page:, referrer:)
+  def previous_page(current_page:)
     unless no_back_link?(current_page)
-      flow_page(current_page) || referrer_page(referrer)
+      flow_page(current_page)
     end
   end
 
@@ -54,23 +54,19 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     MetadataPresenter::Meta.new(configuration['meta'])
   end
 
+  def no_back_link?(current_page)
+    current_page == start_page || current_page == confirmation_page
+  end
+
   private
 
   def all_pages
     @all_pages ||= pages + standalone_pages
   end
 
-  def no_back_link?(current_page)
-    current_page == start_page || current_page == confirmation_page
-  end
-
   def flow_page(current_page)
     page_index = pages.index(current_page)
     pages[page_index - 1] if page_index.present?
-  end
-
-  def referrer_page(referrer)
-    find_page_by_url(URI(referrer).path) if referrer
   end
 
   def strip_slash(url)

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -38,9 +38,12 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     pages[pages.index(current_page) + 1] if current_page.present?
   end
 
-  def previous_page(current_page:)
+  def previous_page(current_page:, referer:)
+    return if current_page.nil? || referer.nil?
+
     unless no_back_link?(current_page)
-      flow_page(current_page)
+      flow_page(current_page) ||
+        find_page_by_url(URI(referer).path)
     end
   end
 
@@ -67,6 +70,10 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
   def flow_page(current_page)
     page_index = pages.index(current_page)
     pages[page_index - 1] if page_index.present?
+  end
+
+  def referrer_page(referrer)
+    find_page_by_url(URI(referrer).path) if referrer
   end
 
   def strip_slash(url)

--- a/app/models/metadata_presenter/traversed_pages.rb
+++ b/app/models/metadata_presenter/traversed_pages.rb
@@ -1,0 +1,44 @@
+module MetadataPresenter
+  class TraversedPages
+    attr_reader :service, :user_data, :current_page
+
+    def initialize(service, user_data, current_page)
+      @service = service
+      @user_data = user_data
+      @pages = [service.start_page]
+      @current_page = current_page
+    end
+
+    def last
+      all.last
+    end
+
+    def all
+      next_page_uuid = service.start_page.uuid
+
+      until next_page_uuid == current_page.uuid do
+        flow_object = service.flow(next_page_uuid)
+
+        if flow_object.branch?
+          page = EvaluateConditions.new(
+            service: service,
+            flow: flow_object,
+            user_data: user_data
+          ).page
+          # check if user answer exists
+          # check if it is a content page
+          # check for optional questions
+          # check for multiple questions with content components only
+          next_page_uuid = page.uuid
+        else
+          next_page_uuid = flow_object.default_next
+          page = service.find_page_by_uuid(next_page_uuid)
+        end
+
+        @pages.push(page) if page && page.uuid != current_page.uuid
+      end
+
+      @pages
+    end
+  end
+end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.5.0'.freeze
+  VERSION = '1.6.0'.freeze
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
   describe '#back_link' do
     before do
       allow(controller.request).to receive(:script_name).and_return(script_name)
-      allow(controller.request).to receive(:referer).and_return(referer)
+      allow(controller.request).to receive(:referrer).and_return(referrer)
     end
 
     context 'when in preview' do
@@ -16,7 +16,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
 
       context 'when there is a page' do
         let(:page) { MetadataPresenter::Page.new(service.pages.second) }
-        let(:referer) { 'http://localhost:3000/services/1/preview' }
+        let(:referrer) { 'http://localhost:3000/services/1/preview' }
 
         it 'returns the previous page' do
           expect(controller.back_link).to eq('/services/1/preview/')
@@ -25,7 +25,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
 
       context 'when there is no page' do
         let(:page) { MetadataPresenter::Page.new(service.pages.first) }
-        let(:referer) { nil }
+        let(:referrer) { nil }
 
         it 'returns nil' do
           expect(controller.back_link).to be_nil
@@ -38,7 +38,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
 
       context 'when there is a page' do
         let(:page) { MetadataPresenter::Page.new(service.pages.second) }
-        let(:referer) { '/' }
+        let(:referrer) { '/' }
 
         before do
           controller.instance_variable_set(:@page, page)
@@ -50,7 +50,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
       end
 
       context 'when there is no page' do
-        let(:referer) { nil }
+        let(:referrer) { nil }
 
         it 'returns nil' do
           expect(controller.back_link).to be_nil

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
   describe '#back_link' do
     before do
       allow(controller.request).to receive(:script_name).and_return(script_name)
+      allow(controller.request).to receive(:referer).and_return(referer)
     end
 
     context 'when in preview' do
@@ -15,6 +16,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
 
       context 'when there is a page' do
         let(:page) { MetadataPresenter::Page.new(service.pages.second) }
+        let(:referer) { 'http://localhost:3000/services/1/preview' }
 
         it 'returns the previous page' do
           expect(controller.back_link).to eq('/services/1/preview/')
@@ -23,6 +25,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
 
       context 'when there is no page' do
         let(:page) { MetadataPresenter::Page.new(service.pages.first) }
+        let(:referer) { nil }
 
         it 'returns nil' do
           expect(controller.back_link).to be_nil
@@ -35,6 +38,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
 
       context 'when there is a page' do
         let(:page) { MetadataPresenter::Page.new(service.pages.second) }
+        let(:referer) { '/' }
 
         before do
           controller.instance_variable_set(:@page, page)
@@ -46,6 +50,8 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
       end
 
       context 'when there is no page' do
+        let(:referer) { nil }
+
         it 'returns nil' do
           expect(controller.back_link).to be_nil
         end

--- a/spec/models/next_page_spec.rb
+++ b/spec/models/next_page_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe MetadataPresenter::NextPage do
     include_context 'branching flow'
 
     context 'when user should return to check your answer' do
-      let(:session) { { return_to_check_you_answer: true } }
+      let(:session) { { return_to_check_your_answer: true } }
       let(:current_page_url) { '' }
 
       it 'returns check your answer page' do
@@ -90,13 +90,13 @@ RSpec.describe MetadataPresenter::NextPage do
 
       it 'set the session as nil' do
         result
-        expect(session).to eq({ return_to_check_you_answer: nil })
+        expect(session).to eq({ return_to_check_your_answer: nil })
       end
     end
 
     context 'when there is a next page' do
       let(:service_metadata) { metadata_fixture(:version) }
-      let(:session) { { return_to_check_you_answer: nil } }
+      let(:session) { { return_to_check_your_answer: nil } }
       let(:current_page_url) { '/name' }
 
       it 'returns next page in sequence' do

--- a/spec/models/next_page_spec.rb
+++ b/spec/models/next_page_spec.rb
@@ -2,10 +2,10 @@ RSpec.shared_context 'branching flow' do
   let(:service_metadata) do
     metadata_fixture(:branching)
   end
+  let(:session) { {} }
 
   context 'when first page' do
     let(:current_page_url) { '/' }
-    let(:session) { {} }
 
     it 'returns first page' do
       expect(result).to eq(
@@ -16,11 +16,9 @@ RSpec.shared_context 'branching flow' do
 
   context 'when last page inside the branch' do
     let(:current_page_url) { 'apple-juice' }
-    let(:session) do
+    let(:user_data) do
       {
-        user_data: {
-          'apple-juice_radios_1' => 'Yes'
-        }
+        'apple-juice_radios_1' => 'Yes'
       }
     end
 
@@ -33,12 +31,10 @@ RSpec.shared_context 'branching flow' do
 
   context 'when radio is selected' do
     let(:current_page_url) { 'do-you-like-star-wars' }
-    let(:session) do
+    let(:user_data) do
       {
-        user_data: {
-          'name_text_1' => 'Din Djarin',
-          'do-you-like-star-wars_radios_1' => branching_answer
-        }
+        'name_text_1' => 'Din Djarin',
+        'do-you-like-star-wars_radios_1' => branching_answer
       }
     end
 
@@ -69,9 +65,11 @@ RSpec.describe MetadataPresenter::NextPage do
     described_class.new(
       service: service,
       session: session,
+      user_data: user_data,
       current_page_url: current_page_url
     )
   end
+  let(:user_data) { {} }
 
   describe '#find' do
     subject(:result) do

--- a/spec/models/previous_page_spec.rb
+++ b/spec/models/previous_page_spec.rb
@@ -1,0 +1,104 @@
+RSpec.describe MetadataPresenter::PreviousPage do
+  subject(:previous_page) do
+    described_class.new(
+      service: service,
+      user_data: user_data,
+      current_page: current_page,
+      referer: referer
+    )
+  end
+  let(:user_data) { {} }
+  let(:referer) { '' }
+
+  describe '#page' do
+    context 'when using the old flow' do
+      let(:service_metadata) do
+        metadata_fixture(:version)
+      end
+
+      context 'when is a start page' do
+        let(:current_page) { service.find_page_by_url('/') }
+
+        it 'returns nil' do
+          expect(previous_page.page).to be_nil
+        end
+      end
+
+      context 'when it is the first page' do
+        let(:current_page) { service.find_page_by_url('/name') }
+
+        it 'returns the start page' do
+          expect(previous_page.page).to eq(service.start_page)
+        end
+      end
+
+      context 'when it is the second page' do
+        let(:current_page) { service.find_page_by_url('/email-address') }
+
+        it 'returns the first page' do
+          expect(previous_page.page.url).to eq('name')
+        end
+      end
+    end
+
+    context 'when using the new branching flow' do
+      let(:service_metadata) do
+        metadata_fixture(:branching)
+      end
+
+      context 'when navigating the branch' do
+        let(:user_data) do
+          {
+            'name_text_1' => 'Rocket',
+            'do-you-like-star-wars_radios_1' => 'Hell no!',
+            'favourite-fruit_radios_1' => 'Apples',
+            'apple-juice_radios_1' => 'Yes',
+            'favourite-band_radios_1' => 'Rolling Stones',
+            'music-app_radios_1' => 'Spotify',
+            'best-formbuilder_radios_1' => 'MoJ'
+          }
+        end
+
+        context 'when on start page' do
+          let(:current_page) { service.find_page_by_url('/') }
+
+          it 'returns nil' do
+            expect(previous_page.page).to be_nil
+          end
+        end
+
+        context 'when on first page' do
+          let(:current_page) { service.find_page_by_url('/name') }
+
+          it 'returns start page' do
+            expect(previous_page.page).to eq(service.start_page)
+          end
+        end
+
+        context 'when on page without branching previously' do
+          let(:current_page) { service.find_page_by_url('do-you-like-star-wars') }
+
+          it 'returns to the first page' do
+            expect(previous_page.page.url).to eq('name')
+          end
+        end
+
+        context 'when on page where it jump a branch previously' do
+          let(:current_page) { service.find_page_by_url('favourite-fruit') }
+
+          it 'returns to page before branch' do
+            expect(previous_page.page.url).to eq('do-you-like-star-wars')
+          end
+        end
+
+        context 'when on page where previously user were inside a branch' do
+          let(:current_page) { service.find_page_by_url('favourite-band') }
+
+          it 'returns to page inside the branch' do
+            expect(previous_page.page.url).to eq('apple-juice')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/previous_page_spec.rb
+++ b/spec/models/previous_page_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe MetadataPresenter::PreviousPage do
 
   describe '#page' do
     context 'when using the old flow' do
-      let(:service_metadata) do
-        metadata_fixture(:version)
-      end
+      let(:service_metadata) { metadata_fixture(:version) }
 
       context 'when is a start page' do
         let(:current_page) { service.find_page_by_url('/') }
@@ -39,12 +37,48 @@ RSpec.describe MetadataPresenter::PreviousPage do
           expect(previous_page.page.url).to eq('name')
         end
       end
+
+      context 'when it is the standalone page' do
+        let(:current_page) { service.find_page_by_url('cookies') }
+
+        context 'when there is a referer' do
+          context 'when is an existing page on metadata' do
+            let(:referer) { 'http://localhost:3000/name' }
+
+            it 'returns page' do
+              expect(previous_page.page).to eq(service.find_page_by_url('name'))
+            end
+          end
+
+          context 'when is not an existing page on metadata' do
+            let(:referer) { 'owned-site.co.uk' }
+
+            it 'returns nil' do
+              expect(previous_page.page).to be_nil
+            end
+          end
+        end
+
+        context 'when there is not a referer' do
+          let(:referer) { }
+
+          it 'returns nil' do
+            expect(previous_page.page).to be_nil
+          end
+        end
+      end
+
+      context 'when is a confirmation page' do
+        let(:current_page) { service.find_page_by_url('/confirmation') }
+
+        it 'returns nil' do
+          expect(previous_page.page).to be_nil
+        end
+      end
     end
 
     context 'when using the new branching flow' do
-      let(:service_metadata) do
-        metadata_fixture(:branching)
-      end
+      let(:service_metadata) { metadata_fixture(:branching) }
 
       context 'when navigating the branch' do
         let(:user_data) do
@@ -96,6 +130,44 @@ RSpec.describe MetadataPresenter::PreviousPage do
 
           it 'returns to page inside the branch' do
             expect(previous_page.page.url).to eq('apple-juice')
+          end
+        end
+
+        context 'when is a confirmation page' do
+          let(:current_page) { service.find_page_by_url('confirmation') }
+
+          it 'returns nil' do
+            expect(previous_page.page).to be_nil
+          end
+        end
+
+        context 'when it is the standalone page' do
+          let(:current_page) { service.find_page_by_url('cookies') }
+
+          context 'when there is a referer' do
+            context 'when is an existing page on metadata' do
+              let(:referer) { 'http://localhost:3000/name' }
+
+              it 'returns page' do
+                expect(previous_page.page).to eq(service.find_page_by_url('name'))
+              end
+            end
+
+            context 'when is not an existing page on metadata' do
+              let(:referer) { 'owned-site.co.uk' }
+
+              it 'returns nil' do
+                expect(previous_page.page).to be_nil
+              end
+            end
+          end
+
+          context 'when there is not a referer' do
+            let(:referer) { }
+
+            it 'returns nil' do
+              expect(previous_page.page).to be_nil
+            end
           end
         end
       end

--- a/spec/models/previous_page_spec.rb
+++ b/spec/models/previous_page_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe MetadataPresenter::PreviousPage do
       service: service,
       user_data: user_data,
       current_page: current_page,
-      referer: referer
+      referrer: referrer
     )
   end
   let(:user_data) { {} }
-  let(:referer) { '' }
+  let(:referrer) { '' }
 
   describe '#page' do
     context 'when using the old flow' do
@@ -41,9 +41,9 @@ RSpec.describe MetadataPresenter::PreviousPage do
       context 'when it is the standalone page' do
         let(:current_page) { service.find_page_by_url('cookies') }
 
-        context 'when there is a referer' do
+        context 'when there is a referrer' do
           context 'when is an existing page on metadata' do
-            let(:referer) { 'http://localhost:3000/name' }
+            let(:referrer) { 'http://localhost:3000/name' }
 
             it 'returns page' do
               expect(previous_page.page).to eq(service.find_page_by_url('name'))
@@ -51,7 +51,7 @@ RSpec.describe MetadataPresenter::PreviousPage do
           end
 
           context 'when is not an existing page on metadata' do
-            let(:referer) { 'owned-site.co.uk' }
+            let(:referrer) { 'owned-site.co.uk' }
 
             it 'returns nil' do
               expect(previous_page.page).to be_nil
@@ -141,9 +141,9 @@ RSpec.describe MetadataPresenter::PreviousPage do
           end
         end
 
-        context 'when the referer is a standalone page' do
+        context 'when the referrer is a standalone page' do
           let(:current_page) { service.find_page_by_url('name') }
-          let(:referer) { 'http://localhost:3000/cookies' }
+          let(:referrer) { 'http://localhost:3000/cookies' }
 
           it 'returns the standalone page' do
             expect(previous_page.page.url).to eq('cookies')
@@ -153,9 +153,9 @@ RSpec.describe MetadataPresenter::PreviousPage do
         context 'when it is the standalone page' do
           let(:current_page) { service.find_page_by_url('cookies') }
 
-          context 'when there is a referer' do
+          context 'when there is a referrer' do
             context 'when is an existing page on metadata' do
-              let(:referer) { 'http://localhost:3000/name' }
+              let(:referrer) { 'http://localhost:3000/name' }
 
               it 'returns page' do
                 expect(previous_page.page).to eq(service.find_page_by_url('name'))
@@ -163,7 +163,7 @@ RSpec.describe MetadataPresenter::PreviousPage do
             end
 
             context 'when is not an existing page on metadata' do
-              let(:referer) { 'owned-site.co.uk' }
+              let(:referrer) { 'owned-site.co.uk' }
 
               it 'returns nil' do
                 expect(previous_page.page).to be_nil

--- a/spec/models/previous_page_spec.rb
+++ b/spec/models/previous_page_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe MetadataPresenter::PreviousPage do
           end
         end
 
-        context 'when there is not a referer' do
-          let(:referer) { }
+        context 'when there is not a referrer' do
+          let(:referrer) {}
 
           it 'returns nil' do
             expect(previous_page.page).to be_nil
@@ -141,6 +141,15 @@ RSpec.describe MetadataPresenter::PreviousPage do
           end
         end
 
+        context 'when the referer is a standalone page' do
+          let(:current_page) { service.find_page_by_url('name') }
+          let(:referer) { 'http://localhost:3000/cookies' }
+
+          it 'returns the standalone page' do
+            expect(previous_page.page.url).to eq('cookies')
+          end
+        end
+
         context 'when it is the standalone page' do
           let(:current_page) { service.find_page_by_url('cookies') }
 
@@ -162,8 +171,8 @@ RSpec.describe MetadataPresenter::PreviousPage do
             end
           end
 
-          context 'when there is not a referer' do
-            let(:referer) { }
+          context 'when there is not a referrer' do
+            let(:referrer) {}
 
             it 'returns nil' do
               expect(previous_page.page).to be_nil

--- a/spec/models/traversed_pages_spec.rb
+++ b/spec/models/traversed_pages_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe MetadataPresenter::TraversedPages do
       let(:user_data) do
         {
           'name_text_1' => 'Rocket',
-          'do-you-like-star-wars_radios_1' => 'Hell no!',
+          'do-you-like-star-wars_radios_1' => 'Hell no!'
         }
       end
 

--- a/spec/models/traversed_pages_spec.rb
+++ b/spec/models/traversed_pages_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe MetadataPresenter::TraversedPages do
+  subject(:traversed_pages) do
+    described_class.new(
+      service, user_data, current_page
+    )
+  end
+  let(:service_metadata) { metadata_fixture(:branching) }
+
+  describe '#all' do
+    subject(:all) do
+      traversed_pages.all
+    end
+
+    context 'when navigating only on main branch' do
+      let(:current_page) { service.find_page_by_url('favourite-fruit') }
+
+      let(:user_data) do
+        {
+          'name_text_1' => 'Rocket',
+          'do-you-like-star-wars_radios_1' => 'Hell no!',
+        }
+      end
+
+      it 'returns all pages traversed and answered' do
+        expect(all.map(&:url)).to eq(
+          [
+            '/',
+            'name',
+            'do-you-like-star-wars'
+          ]
+        )
+      end
+    end
+
+    context 'when navigating only on branches' do
+      let(:current_page) { service.find_page_by_url('burgers') }
+
+      let(:user_data) do
+        {
+          'name_text_1' => 'Rocket',
+          'do-you-like-star-wars_radios_1' => 'Hell no!',
+          'favourite-fruit_radios_1' => 'Apples',
+          'apple-juice_radios_1' => 'Yes',
+          'favourite-band_radios_1' => 'Rolling Stones',
+          'music-app_radios_1' => 'Spotify',
+          'best-formbuilder_radios_1' => 'MoJ'
+        }
+      end
+
+      it 'returns all pages traversed and answered' do
+        expect(all.map(&:url)).to eq(
+          [
+            '/',
+            'name',
+            'do-you-like-star-wars',
+            'favourite-fruit',
+            'apple-juice',
+            'favourite-band',
+            'music-app',
+            'best-formbuilder'
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
     end
 
     it 'sets the session to return to check your answer page' do
-      expect(session[:return_to_check_you_answer]).to be_truthy
+      expect(session[:return_to_check_your_answer]).to be_truthy
     end
 
     it 'redirect to the url' do


### PR DESCRIPTION
[Trello card](https://trello.com/c/95zZQwKB/1642-epic-change-backlinks-behaviour-in-the-form)

## Context

This PR adds the backlink feature for navigating on branches.

It evaluates all pages that the user traversed into. This could be used in the check answers page too.

