### PR TITLE
Don't require ruby graphviz in runtime, only when run rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [1.6.1] - 2021-07-01
+
+### Fix
+
+- Do not require ruby graphviz in runtime, only when you run the diagram rake
+    task
+
 ## [1.6.0] - 2021-07-01
 
 ### Added

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.6.0'.freeze
+  VERSION = '1.6.1'.freeze
 end

--- a/lib/tasks/metadata_presenter_tasks.rake
+++ b/lib/tasks/metadata_presenter_tasks.rake
@@ -5,6 +5,7 @@ namespace :metadata do
 
   desc 'Represent the flow objects in human readable form'
   task flow: :environment do
+    require 'ruby-graphviz'
     metadata = ENV['SERVICE_METADATA'] || metadata_fixture('branching')
     service = MetadataPresenter::Service.new(metadata)
 
@@ -15,8 +16,6 @@ namespace :metadata do
     system("open #{graph.filename}")
   end
 end
-
-require 'ruby-graphviz'
 
 module MetadataPresenter
   class Graph


### PR DESCRIPTION
## Context 

Needs to fix the require ruby graphviz because the runner/editor/metadata-api doesn't require it.

The rake task will run only locally.