### PR TITLE
Add support for conditions with "OR" and "AND"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [1.7.0] - 2021-07-05
+
+### Added
+
+- Add multiple conditions (OR / AND) on multiple criterias for same condition
+
 ## [1.6.1] - 2021-07-01
 
 ### Fix

--- a/app/models/metadata_presenter/evaluate_conditions.rb
+++ b/app/models/metadata_presenter/evaluate_conditions.rb
@@ -4,24 +4,32 @@ module MetadataPresenter
     attr_accessor :service, :flow, :user_data
 
     def page
-      results = conditions.map do |condition|
-        condition.criterias.map do |criteria|
+      evaluated_page_uuid = page_uuid || flow.default_next
+
+      service.find_page_by_uuid(evaluated_page_uuid)
+    end
+
+    def page_uuid
+      @results ||= conditions.map do |condition|
+        evaluated_criterias = condition.criterias.map do |criteria|
           criteria.service = service
 
-          next unless Operator.new(
+          Operator.new(
             criteria.operator
-          ).evaluate(criteria.field_label, user_data[criteria.criteria_component.id])
+          ).evaluate(
+            criteria.field_label,
+            user_data[criteria.criteria_component.id]
+          )
+        end
 
+        if condition.condition_type == 'or' && evaluated_criterias.any?
+          condition.next
+        elsif evaluated_criterias.all?
           condition.next
         end
       end
 
-      page_uuid = results.flatten.uniq.compact
-      if page_uuid.present?
-        service.find_page_by_uuid(page_uuid.first)
-      else
-        service.find_page_by_uuid(flow.default_next)
-      end
+      @results.flatten.compact.first
     end
 
     delegate :conditions, to: :flow

--- a/fixtures/branching.json
+++ b/fixtures/branching.json
@@ -169,7 +169,7 @@
     "618b7537-b42b-4551-ae7d-053afa4d9ca9": {
       "_type": "branch",
       "next": {
-        "default": "e337070b-f636-49a3-a65c-f506675265f0",
+        "default": "dc7454f9-4186-48d7-b055-684d57bbcdc7",
         "conditions": [
           {
             "condition_type": "if",
@@ -201,10 +201,72 @@
     "bc666714-c0a2-4674-afe5-faff2e20d847": {
       "_type": "page",
       "next": {
-        "default": "e337070b-f636-49a3-a65c-f506675265f0"
+        "default": "dc7454f9-4186-48d7-b055-684d57bbcdc7"
       }
     },
     "e2887f44-5e8d-4dc0-b1de-496ab6039430": {
+      "_type": "page",
+      "next": {
+        "default": "dc7454f9-4186-48d7-b055-684d57bbcdc7"
+      }
+    },
+    "dc7454f9-4186-48d7-b055-684d57bbcdc7": {
+      "_type": "page",
+      "next": {
+        "default": "84a347fc-8d4b-486a-9996-6a86fa9544c5"
+      }
+    },
+    "84a347fc-8d4b-486a-9996-6a86fa9544c5": {
+      "_type": "branch",
+      "next": {
+        "default": "e337070b-f636-49a3-a65c-f506675265f0",
+        "conditions": [
+          {
+            "condition_type": "or",
+            "next": "2cc66e51-2c14-4023-86bf-ded49887cdb2",
+            "criterias": [
+              {
+                "operator": "is",
+                "page": "dc7454f9-4186-48d7-b055-684d57bbcdc7",
+                "component": "5ca01e56-94de-4c33-b5fc-74697e5b95cc",
+                "field": "bd14bf31-427e-4267-9926-a18c167fe604"
+              },
+              {
+                "operator": "is",
+                "page": "dc7454f9-4186-48d7-b055-684d57bbcdc7",
+                "component": "5ca01e56-94de-4c33-b5fc-74697e5b95cc",
+                "field": "eb720ef7-bcaf-4c73-8972-6fc80dca6245"
+              }
+            ]
+          },
+          {
+            "condition_type": "and",
+            "next": "f6c51f88-7be8-4cb7-bbfc-6c905727a051",
+            "criterias": [
+              {
+                "operator": "is",
+                "page": "68fbb180-9a2a-48f6-9da6-545e28b8d35a",
+                "component": "ac41be35-914e-4b22-8683-f5477716b7d4",
+                "field": "c5571937-9388-4411-b5fa-34ddf9bc4ca0"
+              },
+              {
+                "operator": "is",
+                "page": "dc7454f9-4186-48d7-b055-684d57bbcdc7",
+                "component": "5ca01e56-94de-4c33-b5fc-74697e5b95cc",
+                "field": "0c4192eb-1441-4f10-b00a-0f03b756269e"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "2cc66e51-2c14-4023-86bf-ded49887cdb2": {
+      "_type": "page",
+      "next": {
+        "default": "e337070b-f636-49a3-a65c-f506675265f0"
+      }
+    },
+    "f6c51f88-7be8-4cb7-bbfc-6c905727a051": {
       "_type": "page",
       "next": {
         "default": "e337070b-f636-49a3-a65c-f506675265f0"
@@ -769,6 +831,108 @@
           "_type": "content",
           "_uuid": "49ff5c79-2e63-45fe-bbf7-de0bd061b909",
           "content": "Cruella ain't got nothing on Cluckeralla"
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.marvel-series",
+      "url": "marvel-series",
+      "_type": "page.singlequestion",
+      "_uuid": "dc7454f9-4186-48d7-b055-684d57bbcdc7",
+      "components": [
+        {
+          "_id": "marvel-series_radios_1",
+          "hint": "",
+          "name": "marvel-series_radios_1",
+          "_type": "radios",
+          "_uuid": "5ca01e56-94de-4c33-b5fc-74697e5b95cc",
+          "items": [
+            {
+              "_id": "marvel-series_radios_1_item_1",
+              "hint": "",
+              "_type": "radio",
+              "_uuid": "0c4192eb-1441-4f10-b00a-0f03b756269e",
+              "label": "WandaVision"
+            },
+            {
+              "_id": "marvel-series_radios_1_item_2",
+              "hint": "",
+              "_type": "radio",
+              "_uuid": "bd14bf31-427e-4267-9926-a18c167fe604",
+              "label": "The Falcon and the Winter Soldier"
+            },
+            {
+              "_id": "marvel-series_radios_1_item_2",
+              "hint": "",
+              "_type": "radio",
+              "_uuid": "eb720ef7-bcaf-4c73-8972-6fc80dca6245",
+              "label": "Loki"
+            },
+            {
+              "_id": "marvel-series_radios_1_item_3",
+              "hint": "",
+              "_type": "radio",
+              "_uuid": "d762e328-18dc-4861-bca8-d104609b8299",
+              "label": "Hawkeye"
+            }
+          ],
+          "errors": {},
+          "legend": "What is the best marvel series?",
+          "validation": {
+            "required": true
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.marvel-quotes",
+      "url": "marvel-quotes",
+      "body": "Marvel quotes",
+      "lede": "",
+      "_type": "page.content",
+      "_uuid": "2cc66e51-2c14-4023-86bf-ded49887cdb2",
+      "heading": "Loki",
+      "components": [
+        {
+          "_id": "marvel-quotes_content_1",
+          "name": "marvel-quotes_content_1",
+          "_type": "content",
+          "_uuid": "5cede2fa-5001-4d6a-965c-30addc3c4496",
+          "content": "I am Loki of Asgard, and I am burdened with glorious purpose."
+        },
+        {
+          "_id": "marvel-quotes_content_2",
+          "name": "marvel-quotes_content_2",
+          "_type": "content",
+          "_uuid": "816b6afd-4649-455a-b10d-62cb5acb4584",
+          "content": "So Who Are You Fighting Now ... Gandalf?"
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.other-quotes",
+      "url": "other-quotes",
+      "body": "Other quotes",
+      "lede": "",
+      "_type": "page.content",
+      "_uuid": "f6c51f88-7be8-4cb7-bbfc-6c905727a051",
+      "heading": "Other quotes",
+      "components": [
+        {
+          "_id": "other-quotes_content_1",
+          "name": "other-quotes_content_1",
+          "_type": "content",
+          "_uuid": "2535a867-deab-457b-91aa-c006e3c73d63",
+          "content": "- How we doing? - Same as always... - That bad, huh?"
+        },
+        {
+          "_id": "other-quotes_content_2",
+          "name": "other-quotes_content_2",
+          "_type": "content",
+          "_uuid": "816b6afd-4649-455a-b10d-62cb5acb4584",
+          "content": "Are you using your night vision, Vision?"
         }
       ],
       "section_heading": ""

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.6.1'.freeze
+  VERSION = '1.7.0'.freeze
 end

--- a/spec/models/evaluate_conditions_spec.rb
+++ b/spec/models/evaluate_conditions_spec.rb
@@ -125,5 +125,70 @@ RSpec.describe MetadataPresenter::EvaluateConditions do
         end
       end
     end
+
+    context 'when multiple conditions' do
+      let(:flow) { service.flow('84a347fc-8d4b-486a-9996-6a86fa9544c5') }
+
+      context 'when multiple criterias with "OR" statement' do
+        context 'when the conditions are met' do
+          context 'when choosing one option' do
+            let(:user_data) do
+              { 'marvel-series_radios_1' => 'Loki' }
+            end
+
+            it 'returns the page that evaluates the condition' do
+              expect(page).to eq(service.find_page_by_url('marvel-quotes'))
+            end
+          end
+
+          context 'when choosing another option from the condition' do
+            let(:user_data) do
+              { 'marvel-series_radios_1' => 'The Falcon and the Winter Soldier' }
+            end
+
+            it 'returns the page that evaluates the condition' do
+              expect(page).to eq(service.find_page_by_url('marvel-quotes'))
+            end
+          end
+        end
+
+        context 'when the conditions are not met' do
+          let(:user_data) do
+            { 'marvel-series_radios_1' => 'Other' }
+          end
+
+          it 'returns the page that evaluates the condition' do
+            expect(page).to eq(service.find_page_by_url('check-answers'))
+          end
+        end
+      end
+
+      context 'when multiple criterias with "AND" statement' do
+        context 'when the conditions are met' do
+          let(:user_data) do
+            {
+              'do-you-like-star-wars_radios_1' => 'Only on weekends',
+              'marvel-series_radios_1' => 'WandaVision'
+            }
+          end
+
+          it 'returns the page that evaluates the condition' do
+            expect(page).to eq(service.find_page_by_url('other-quotes'))
+          end
+        end
+
+        context 'when the conditions are not met' do
+          context 'when one criteria is met but not the other' do
+            let(:user_data) do
+              { 'marvel-series_radios_1' => 'WandaVision' }
+            end
+
+            it 'returns the page default' do
+              expect(page).to eq(service.find_page_by_url('check-answers'))
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

So all conditions can be mapped through criteria using "OR" and "AND".

So we can have a condition object with many criteria object and having the condition_type managing the page to be evaluated.
