### PR TITLE
Get all service flow objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [1.7.3] - 2021-07-07
+
+### Changed
+
+- Calling flow on a service should now return all of the flow objects
+
 ## [1.7.2] - 2021-07-07
 
 ### Added

--- a/app/models/metadata_presenter/next_page.rb
+++ b/app/models/metadata_presenter/next_page.rb
@@ -49,11 +49,11 @@ module MetadataPresenter
     end
 
     def current_page_flow
-      service.flow(current_page_uuid)
+      service.flow_object(current_page_uuid)
     end
 
     def next_flow
-      service.flow(current_page_flow.default_next)
+      service.flow_object(current_page_flow.default_next)
     end
 
     def next_flow_branch_object?

--- a/app/models/metadata_presenter/previous_page.rb
+++ b/app/models/metadata_presenter/previous_page.rb
@@ -7,17 +7,13 @@ module MetadataPresenter
       # what happens when a user enters in the middle of the flow
       return if no_current_or_referrer_pages? || service.no_back_link?(current_page)
 
-      if flow.present?
+      if service.flow.present?
         return referrer_page if return_to_referrer?
 
         TraversedPages.new(service, user_data, current_page).last
       else
         service.previous_page(current_page: current_page, referrer: referrer)
       end
-    end
-
-    def flow
-      service.metadata['flow']
     end
 
     private

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -5,8 +5,8 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     end
   end
 
-  def flow(page_uuid)
-    MetadataPresenter::Flow.new(metadata.flow[page_uuid])
+  def flow_object(uuid)
+    MetadataPresenter::Flow.new(metadata.flow[uuid])
   rescue StandardError
     nil
   end

--- a/app/models/metadata_presenter/traversed_pages.rb
+++ b/app/models/metadata_presenter/traversed_pages.rb
@@ -14,10 +14,10 @@ module MetadataPresenter
     def all
       page_uuid = service.start_page.uuid
 
-      service.metadata['flow'].size.times do
+      service.flow.size.times do
         break if page_uuid == current_page.uuid
 
-        flow_object = service.flow(page_uuid)
+        flow_object = service.flow_object(page_uuid)
 
         if flow_object.branch?
           page = EvaluateConditions.new(

--- a/fixtures/no_flow_service.json
+++ b/fixtures/no_flow_service.json
@@ -1,0 +1,189 @@
+{
+  "_id": "service.base",
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "lede": "",
+      "_type": "page.start",
+      "_uuid": "cf6dc32f-502c-4215-8c27-1151a45735bb",
+      "steps": [
+        "page.name",
+        "page.email-address",
+        "page.parent-name",
+        "page.check-answers",
+        "page.confirmation"
+      ],
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.name",
+      "url": "name",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "9e1ba77f-f1e5-42f4-b090-437aa9af7f73",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "name_text_1",
+          "hint": "",
+          "name": "name_text_1",
+          "_type": "text",
+          "_uuid": "27d377a2-6828-44ca-87d1-b83ddac98284",
+          "label": "Full name",
+          "errors": {},
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 10,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.email-address",
+      "url": "email-address",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "df1ba645-f748-46d0-ad75-f34112653e37",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "email-address_text_1",
+          "hint": "",
+          "name": "email-address_text_1",
+          "_type": "text",
+          "_uuid": "f27e5788-e784-4bfd-8b21-2fab8ce95abb",
+          "label": "Email address",
+          "errors": {
+            "format": {},
+            "required": {
+              "any": "Enter an email address"
+            },
+            "max_length": {
+              "any": "%{control} is too long."
+            },
+            "min_length": {
+              "any": "%{control} is too short."
+            }
+          },
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 30,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.parent-name",
+      "url": "parent-name",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "4b8c6bf3-878a-4446-9198-48351b3e2185",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "parent-name_text_1",
+          "hint": "",
+          "name": "parent-name_text_1",
+          "_type": "text",
+          "_uuid": "5ad372fa-ed35-477f-b471-4d444f991210",
+          "label": "Parent name",
+          "errors": {},
+          "collection": "components",
+          "validation": {
+            "required": false,
+            "max_length": 10,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.check-answers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "e337070b-f636-49a3-a65c-f506675265f0",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+        {
+          "_id": "check-answers_content_2",
+          "name": "check-answers_content_2",
+          "_type": "content",
+          "_uuid": "b065ff4f-90c5-4ba2-b4ac-c984a9dd2470",
+          "content": "Take the cannoli.",
+          "collection": "components"
+        }
+      ],
+      "send_heading": "Now send your application",
+      "add_component": "content",
+      "extra_components": [
+        {
+          "_id": "check-answers_content_1",
+          "name": "check-answers_content_1",
+          "_type": "content",
+          "_uuid": "3e6ef27e-91a6-402f-8291-b7ce669e824e",
+          "content": "Check yourself before you wreck yourself.",
+          "collection": "extra_components"
+        }
+      ],
+      "add_extra_component": "content"
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "confirmation",
+      "body": "Some day I will be the most powerful Jedi ever!",
+      "lede": "",
+      "_type": "page.confirmation",
+      "_uuid": "778e364b-9a7f-4829-8eb2-510e08f156a3",
+      "heading": "Complaint sent",
+      "components": []
+    }
+  ],
+  "locale": "en",
+  "created_at": "2021-04-21T13:10:19Z",
+  "created_by": "099d5bf5-5f7b-444c-86ee-9e189cc1a369",
+  "service_id": "488edccd-8411-4ffb-a38b-6a96c6ac28d6",
+  "version_id": "27dc30c9-f7b8-4dec-973a-bd153f6797df",
+  "service_name": "Version Fixture",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  }
+}

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.7.2'.freeze
+  VERSION = '1.7.3'.freeze
 end

--- a/lib/tasks/metadata_presenter_tasks.rake
+++ b/lib/tasks/metadata_presenter_tasks.rake
@@ -45,7 +45,7 @@ module MetadataPresenter
 
     def draw_nodes
       flow.each do |id, _value|
-        flow_object = service.flow(id)
+        flow_object = service.flow_object(id)
 
         if flow_object.branch?
           full_description = flow_object.conditions.map.each_with_index do |condition, _index|
@@ -65,7 +65,7 @@ module MetadataPresenter
 
     def draw_edges
       flow.each do |id, _value|
-        flow_object = service.flow(id)
+        flow_object = service.flow_object(id)
         current_node = nodes[id]
         node_next = nodes[flow_object.default_next]
 
@@ -83,7 +83,7 @@ module MetadataPresenter
     end
 
     def flow
-      metadata['flow']
+      service.flow
     end
   end
 end

--- a/spec/models/evaluate_conditions_spec.rb
+++ b/spec/models/evaluate_conditions_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MetadataPresenter::EvaluateConditions do
     subject(:page) { evaluate_conditions.page }
 
     context 'when simple if condition' do
-      let(:flow) { service.flow('09e91fd9-7a46-4840-adbc-244d545cfef7') }
+      let(:flow) { service.flow_object('09e91fd9-7a46-4840-adbc-244d545cfef7') }
 
       context 'when criterias are met' do
         let(:user_data) do
@@ -40,7 +40,7 @@ RSpec.describe MetadataPresenter::EvaluateConditions do
     end
 
     context 'when simple if/else' do
-      let(:flow) { service.flow('ffadeb22-063b-4e4f-9502-bd753c706b1d') }
+      let(:flow) { service.flow_object('ffadeb22-063b-4e4f-9502-bd753c706b1d') }
       context 'when apple criteria is met' do
         let(:user_data) do
           {
@@ -78,7 +78,7 @@ RSpec.describe MetadataPresenter::EvaluateConditions do
       end
 
       context 'when the question is a checkbox component' do
-        let(:flow) { service.flow('618b7537-b42b-4551-ae7d-053afa4d9ca9') }
+        let(:flow) { service.flow_object('618b7537-b42b-4551-ae7d-053afa4d9ca9') }
 
         context 'when beef cheese and tomato condition "is" met' do
           let(:user_data) do
@@ -108,7 +108,7 @@ RSpec.describe MetadataPresenter::EvaluateConditions do
 
     context 'when the question is optional' do
       context 'for single answer questions' do
-        let(:flow) { service.flow('ffadeb22-063b-4e4f-9502-bd753c706b1d') }
+        let(:flow) { service.flow_object('ffadeb22-063b-4e4f-9502-bd753c706b1d') }
         let(:user_data) { { 'favourite-fruit_radios_1' => '' } }
 
         it 'returns the page uuid for the default page' do
@@ -117,7 +117,7 @@ RSpec.describe MetadataPresenter::EvaluateConditions do
       end
 
       context 'for multiple answer (checkboxes) questions' do
-        let(:flow) { service.flow('ffadeb22-063b-4e4f-9502-bd753c706b1d') }
+        let(:flow) { service.flow_object('ffadeb22-063b-4e4f-9502-bd753c706b1d') }
         let(:user_data) { { 'burgers_checkboxes_1' => [] } }
 
         it 'returns the page uuid for the default page' do
@@ -127,7 +127,7 @@ RSpec.describe MetadataPresenter::EvaluateConditions do
     end
 
     context 'when multiple conditions' do
-      let(:flow) { service.flow('84a347fc-8d4b-486a-9996-6a86fa9544c5') }
+      let(:flow) { service.flow_object('84a347fc-8d4b-486a-9996-6a86fa9544c5') }
 
       context 'when multiple criterias with "OR" statement' do
         context 'when the conditions are met' do

--- a/spec/models/flow_spec.rb
+++ b/spec/models/flow_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe MetadataPresenter::Flow do
     metadata_fixture(:branching)
   end
   subject(:flow) do
-    service.flow('cf6dc32f-502c-4215-8c27-1151a45735bb')
+    service.flow_object('cf6dc32f-502c-4215-8c27-1151a45735bb')
   end
 
   describe '#branch?' do
     context 'when the type is branch' do
       subject(:flow) do
-        service.flow('09e91fd9-7a46-4840-adbc-244d545cfef7')
+        service.flow_object('09e91fd9-7a46-4840-adbc-244d545cfef7')
       end
 
       it 'returns true' do
@@ -19,7 +19,7 @@ RSpec.describe MetadataPresenter::Flow do
 
     context 'when the type is not a branch' do
       subject(:flow) do
-        service.flow('cf6dc32f-502c-4215-8c27-1151a45735bb')
+        service.flow_object('cf6dc32f-502c-4215-8c27-1151a45735bb')
       end
 
       it 'returns false' do
@@ -38,7 +38,7 @@ RSpec.describe MetadataPresenter::Flow do
     end
 
     context 'when there is no next flow' do
-      subject(:flow) { service.flow('778e364b-9a7f-4829-8eb2-510e08f156a3') }
+      subject(:flow) { service.flow_object('778e364b-9a7f-4829-8eb2-510e08f156a3') }
 
       it 'returns nothing' do
         expect(flow.default_next).to eq('')
@@ -48,7 +48,7 @@ RSpec.describe MetadataPresenter::Flow do
 
   describe '#conditions' do
     context 'when there are conditions' do
-      subject(:flow) { service.flow('09e91fd9-7a46-4840-adbc-244d545cfef7') }
+      subject(:flow) { service.flow_object('09e91fd9-7a46-4840-adbc-244d545cfef7') }
 
       it 'returns conditions' do
         expect(flow.conditions).to eq(


### PR DESCRIPTION
The previous flow method expected a uuid as an argument. It returns a
flow object which matches the provided uuid. It is not always a page
uuid but could also be a branch uuid so rename it to just uuid.

calling `flow` on a service should return all of the flow objects so
rename the current method to `flow_object` as that returns a single
object. This should allow the current implementation to simply return
all the flow objects for a service should they exist.