### PR TITLE
Create base flow schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [1.7.5] - 2021-07-08
+
+### Added
+
+- Base flow object schema to cater for dynamic UUID properties
+
+### Changed
+
+- Remove '_id' property from flow objects default metadata
+- Fallback to using '_type' as the key for default metadata that does not have a '_id' property
+
 ## [1.7.4] - 2021-07-08
 
 ### Added

--- a/config/initializers/default_metadata.rb
+++ b/config/initializers/default_metadata.rb
@@ -6,8 +6,11 @@ Rails.logger.info('Loading default metadata')
 default_metadata = Dir.glob("#{Rails.application.config.default_metadata_directory}/*/**")
 default_metadata.each do |metadata_file|
   metadata = JSON.parse(File.read(metadata_file))
-  Rails.logger.info(metadata['_id'])
-  Rails.application.config.default_metadata[metadata['_id']] = metadata
+
+  key = metadata['_id'] || metadata['_type']
+  Rails.logger.info(key)
+
+  Rails.application.config.default_metadata[key] = metadata
 end
 
 Rails.logger.info(

--- a/default_metadata/flow/branch.json
+++ b/default_metadata/flow/branch.json
@@ -1,5 +1,4 @@
 {
-  "_id": "flow.branch",
   "_type": "flow.branch",
   "next": {
     "default": "",

--- a/default_metadata/flow/page.json
+++ b/default_metadata/flow/page.json
@@ -1,5 +1,4 @@
 {
-  "_id": "flow.page",
   "_type": "flow.page",
   "next": {
     "default": ""

--- a/fixtures/no_flow_service.json
+++ b/fixtures/no_flow_service.json
@@ -185,5 +185,6 @@
       "_id": "config.service",
       "_type": "config.service"
     }
-  }
+  },
+  "standalone_pages": []
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.7.4'.freeze
+  VERSION = '1.7.5'.freeze
 end

--- a/schemas/flow/base.json
+++ b/schemas/flow/base.json
@@ -1,0 +1,24 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/flow/base",
+  "_name": "flow.base",
+  "title": "Base flow object",
+  "description": "Base flow object containing page or branch objects",
+  "type": "object",
+  "patternProperties": {
+    "type": "object",
+    "^S_": {
+      "type": "string"
+    },
+    "properties": {
+      "anyOf": [
+        {
+          "$ref": "flow.page"
+        },
+        {
+          "$ref": "flow.branch"
+        }
+      ]
+    },
+    "additionalProperties": false
+  }
+}

--- a/schemas/service/base.json
+++ b/schemas/service/base.json
@@ -33,17 +33,7 @@
       "$ref": "configuration"
     },
     "flow": {
-      "type": "object",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "flow.page"
-          },
-          {
-            "$ref": "flow.branch"
-          }
-        ]
-      }
+      "$ref": "flow.base"
     },
     "pages": {
       "type": "array",


### PR DESCRIPTION
The service flow object uses UUIDs as the string property for either a
page object or a branch object. These UUIDs are obviously dynamic so
this schema has to allow for that as well.

Adding a base schema which makes use of the `patternProperties` to allow
for dynamic uuid string keys.

Some metadata objects do not have an '_id' property. In those instances
fallback to using the '_type' property when loading the metadata on
startup.