### PR TITLE
Fixtures with flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [1.8.1] - 2021-07-09
+
+### Added
+
+- Added service and version fixtures for additional testing
+
 ## [1.8.0] - 2021-07-08
 
 ### Added

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -9,7 +9,6 @@ module MetadataPresenter
       _uuid
       _id
       _type
-      steps
       add_component
       add_extra_component
     ].freeze

--- a/default_metadata/page/start.json
+++ b/default_metadata/page/start.json
@@ -5,6 +5,5 @@
   "lede": "",
   "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
   "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally.",
-  "steps": [],
   "url": "/"
 }

--- a/default_metadata/service/base.json
+++ b/default_metadata/service/base.json
@@ -3,6 +3,7 @@
   "_type": "service.base",
   "service_name": "Service name",
   "configuration": {},
+  "flow": {},
   "pages": [],
   "standalone_pages": [],
   "locale": "en"

--- a/fixtures/branching.json
+++ b/fixtures/branching.json
@@ -367,13 +367,6 @@
       "lede": "",
       "_type": "page.start",
       "_uuid": "cf6dc32f-502c-4215-8c27-1151a45735bb",
-      "steps": [
-        "page.name",
-        "page.do-you-like-star-wars",
-        "page.star-wars-knowledge",
-        "page.check-answers",
-        "page.confirmation"
-      ],
       "heading": "Service name goes here",
       "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
     },

--- a/fixtures/no_flow_service.json
+++ b/fixtures/no_flow_service.json
@@ -155,7 +155,7 @@
   "created_by": "099d5bf5-5f7b-444c-86ee-9e189cc1a369",
   "service_id": "488edccd-8411-4ffb-a38b-6a96c6ac28d6",
   "version_id": "27dc30c9-f7b8-4dec-973a-bd153f6797df",
-  "service_name": "Version Fixture",
+  "service_name": "No Flow Service Fixture",
   "configuration": {
     "meta": {
       "_id": "config.meta",

--- a/fixtures/service_with_flow.json
+++ b/fixtures/service_with_flow.json
@@ -17,7 +17,6 @@
       "lede": "",
       "_type": "page.start",
       "_uuid": "86ed04ac-1727-4172-8dd2-608009f1a656",
-      "steps": [],
       "heading": "Service name goes here",
       "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
     }

--- a/fixtures/service_with_flow.json
+++ b/fixtures/service_with_flow.json
@@ -1,0 +1,87 @@
+{
+  "_id": "service.base",
+  "_type": "service.base",
+  "flow": {
+    "86ed04ac-1727-4172-8dd2-608009f1a656": {
+      "_type": "flow.page",
+      "next": {
+        "default": ""
+      }
+    }
+  },
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "lede": "",
+      "_type": "page.start",
+      "_uuid": "86ed04ac-1727-4172-8dd2-608009f1a656",
+      "steps": [],
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    }
+  ],
+  "locale": "en",
+  "created_by": "099d5bf5-5f7b-444c-86ee-9e189cc1a369",
+  "service_name": "Service With Flow Fixture",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "This online form puts a small file (known as ‘cookies’) onto your computer to collect information about how you browse the site.\r\n\r\nCookies are used to:\r\n\r\n- remember your progress\r\n- measure how you use the website so it can be updated and improved based on your needs\r\n\r\nThis online form's cookie isn't used to identify you personally.\r\n\r\nYou'll normally see a message on the site before we store a cookie on your computer.\r\n\r\nFind out more about [how to manage cookies](https://www.aboutcookies.org/).\r\n\r\n##How cookies are used on this online form\r\n\r\nWe will store a cookie to remember your progress on this computer and to expire your session after 30 minutes of inactivity or when you close your browser.\r\n\r\n| Name | Purpose | Expires |\r\n|---|---|---|\r\n| _fb_runner_session | Saves your current progress in this computer and tracks inactivity periods | After 30 minutes of inactivity or when you close your browser |",
+      "_type": "page.standalone",
+      "_uuid": "4cfdb39e-75ef-4f46-a143-e2db99bf0bf3",
+      "heading": "Cookies",
+      "components": []
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "This privacy notice explains what [insert your organisation name] means when we talk about personal data, why we ask for this information about you and what we do with it when you use this form.\r\n\r\nIt also explains how we store your data, how you can get a copy of the information we’ve collected about you and how you can complain if you think we’ve done something wrong.\r\n\r\n###Who manages this service\r\n\r\nThis form is managed by [your organisation].\r\n\r\nThe information you submit will be processed by [insert who will be processing the information and, if it’s a separate organisation, what their relationship is to you].\r\n\r\n[Insert name of organisation that acts as data controller for your form] is the data controller for the personal data collected by this form.\r\n\r\n###When we ask for personal data\r\n\r\nWhenever we ask for information about you, we promise to:\r\n\r\n- always let you know why we need it\r\n- ask for relevant personal information only\r\n- make sure we do not keep it longer than needed\r\n- keep your information safe and make sure nobody can access it unless authorised to do so\r\n- only share your data with other organisations for legitimate purposes\r\n- consider any request you make to correct or delete your personal data\r\n\r\nWe also promise to make it easy for you to:\r\n\r\n- tell us at any time if you want us to stop storing your personal data\r\n- make a complaint to the supervisory authority\r\n\r\n###The personal data we collect\r\n\r\nWe only collect personal data that you directly provide with your application.\r\n\r\nWe only collect the information we need to deliver this service to you. The personal data collected includes:\r\n\r\n- [summarise the types of personal information requested by your form]\r\n\r\nWe [use cookies](http://www.aboutcookies.org.uk/managing-cookies) to collect data that tells us about how the service is used, including:\r\n\r\n- your computer, phone or tablet’s IP address\r\n\r\n- the region or town where you are using your computer, phone or tablet\r\n\r\n- the operating system and web browser you use\r\n\r\nThis information is not used to identify you personally.\r\n\r\n###Why we collect your personal data\r\n\r\nWe collect data to [describe why you are collecting personal information]. The processing of your personal data is necessary for [explain why you require the personal information].\r\n\r\nThe legal basis for collecting and processing your personal data is [enter and explain your legal basis here, for example, that it is necessary to perform a task in the public interest or\nin the exercise of your functions as a government department].\r\n\r\nUse of the online form is voluntary. If you do not provide all the information we ask for, we may not be able to process your [insert the purpose of your form, such as claim, application or request].\r\n\r\nPlease note that transmitting information over the internet is generally not completely secure, and [your organisation] can’t guarantee the security of your data. Any data you transmit is at your own risk. [your organisation, and any other organisations involved in processing the data] have procedures and security features in place to keep your data secure once we receive it.\r\n\r\n###Sharing your personal data\r\n\r\nThe information you provide will be shared with… [name any organisations that you might share the data with and provide an explanation of why the information may be shared and what it will be used for]\r\n\r\nWe may also use your contact information to ask for feedback on using the service, but only when you have given your consent for us to do so. [delete this paragraph if not applicable]\r\n\r\nWe’ll never share your information with other organisations for marketing, market research or commercial purposes.\r\n\r\n###Keeping your personal data\r\n\r\nTo protect your personal information, any data you enter as you progress through the online form is held temporarily and securely until you submit your application, after which your application cannot be viewed or modified further online.\r\n\r\n[your organisation, and any other organisations involved in processing the data] will keep your data for [specify how long you will keep the information for and why].\r\n\r\nAll deleted data will be destroyed securely and confidentially.\r\n\r\n###How we use your personal data\r\n\r\nYour online submission will be sent from the online form to [your organisation or whichever other organisation will receive the information for processing] via encrypted email. The system does not retain a copy of your information.\r\n\r\n[select one of the following 3 paragraphs which most closely fits your circumstances and delete the other 2]\r\n\r\nYour personal data is not used in any automated decision making (a decision made solely by automated means without any human involvement) or profiling (automated processing of personal data to evaluate certain conditions about an individual).\r\n\r\nAutomated decision making (a decision made solely by automated means without any human involvement) is used for the purpose of [insert why ADM is used] and is carried out [include when in the process this is carried out]. The personal data used for this purpose includes [insert personal data types].\r\n\r\nProfiling (automated processing of personal data to evaluate certain conditions about an individual) is carried out for the purpose of [insert reason why profiling exists]. The personal data used for this purpose includes [insert personal data types].\r\n\r\n###How we store your personal data\r\n\r\n[your organisation or whichever other organisation will receive the information for processing] take data security very seriously and take every step to ensure that your data remains private and secure. All data collected by this service is stored in a secure database [kept entirely within the UK/kept outside of the UK but within the European Economic Area (EEA). - delete as appropriate]\r\n\r\nIt may sometimes be necessary to transfer personal information overseas, outside of the UK and the European Economic Area (EEA). When this is needed information may be transferred to [insert names of countries]. Any transfers made will be in full compliance with all aspects of the data protection law. [delete this paragraph if not applicable or contact your data protection team for guidance on required safeguards] \r\n\r\nYour application will only be accessible to [your organisation, and any other organisations involved in processing the data] staff who require access to process applications.\r\n\r\n###Your rights\r\n\r\nYou have a number of rights, depending on the reason for processing your information. These include:\r\n\r\n- the right to request a copy of your personal data and information about how your personal data is processed (this is known as a subject access request)\r\n- the right to have inaccuracies in your personal data corrected\r\n- the right to fill in any gaps in your personal data, including by means of a supplementary statement\r\n- the right to ask for the processing of your personal data to be restricted\r\n- the right to ask for your personal data to be deleted if there is no longer a justification for it\r\n- the right to object to automated decision making, including profiling, that has a legal or significant effect on you as an individual\r\n\r\nIf you want to see the personal data that we hold on you, you can make a subject access request. Send your request by post to:\r\n\r\nDisclosure Team  \r\nPost point 10.25  \r\n102 Petty France  \r\nLondon  \r\nSW1H 9AJ\r\n\r\nor email: data.access@justice.gov.uk\r\n\r\nFor all other rights, please write to us at:\r\n\r\n[insert your postal and email addresses]\r\n\r\n###Getting more information\r\n\r\nYou can get more details on:\r\n\r\n- agreements we have with other organisations for sharing information\r\n- when we can pass on personal information without telling you, for example, to help with the prevention or detection of crime or to produce anonymised statistics\r\n- instructions we give to staff on how to collect, use or delete your personal information\r\n- how we check that the information we have is accurate and up-to-date\r\n- how to make a complaint\r\n\r\nFor more information, please contact the [your organisation] data protection officer at:\r\n\r\n[insert the postal and email addresses of your data protection officer - for the MoJ, this is:\r\n\r\nThe Data Protection Officer  \r\nMinistry of Justice  \r\n10 South Colonnade\nCanary Wharf  \r\nLondon  \r\nE14 4PU\r\n\r\nEmail: DPO@justice.gov.uk]\r\n\r\n###Making a complaint\r\n\r\nWhen we ask you for information, we will keep to the law. If you think that your information has not been handled correctly, you can contact the [Information Commissioner](https://ico.org.uk/) for independent advice about data protection on the address below:\r\n\r\nInformation Commissioner's Office  \r\nWycliffe House  \r\nWater Lane  \r\nWilmslow  \r\nCheshire  \r\nSK9 5AF\r\n\r\nTelephone: 0303 123 1113",
+      "_type": "page.standalone",
+      "_uuid": "9fe1f0ba-de2a-4dc5-b36e-0afc5562a6f4",
+      "heading": "Privacy notice",
+      "components": []
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "This accessibility statement applies to [describe your form here - for example, the general enquiries form for the CICA]. There is a separate [accessibility statement for the main GOV.UK website](https://www.gov.uk/help/accessibility-statement).\r\n\r\n###Using this online form\r\n\r\nThis form was built using MoJ Forms, a tool developed by the Ministry of Justice, and uses components from the [GOV.UK Design System](https://design-system.service.gov.uk/).\r\n\r\n[insert your organisation here] is responsible for the content of this online form. The Ministry of Justice is responsible for its technical aspects.\r\n\r\nWe want as many people as possible to be able to use this online form. For example, that means you should be able to:\r\n\r\n- change colours, contrast levels and fonts\r\n- zoom in up to 300% without the text spilling off the screen\r\n- navigate the form using just a keyboard\r\n- navigate the form using speech recognition software\r\n- listen to the form using a screen reader (including recent versions of JAWS, NVDA and VoiceOver)\r\n\r\nWe’ve also made the text as simple as possible to understand.\r\n\r\n[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.\r\n\r\n###How accessible this form is\r\n\r\nWe know some parts of this form are not fully accessible:\r\n\r\n- pages have no skip links\r\n- the language attribute of the page has not been set in the HTML\r\n- some pages may contain empty headings\r\n- some content may be cut off or appear truncated when zooming in\r\n\r\n###Feedback and contact information\r\n\r\nIf you need information on this website in a different format:\r\n\r\n[insert your contact details for user requests here - add other channels, such as text phones or Relay UK, as required]\r\n\r\n- email: [your email address]\r\n- call: [your telephone number]\r\n- [Hours - e.g. Monday to Friday, 9am to 5pm]\r\n\r\n###Enforcement procedure\r\n\r\nThe Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the [Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).\r\n\r\n###Technical information about this online form’s accessibility\r\n\r\nWe are committed to making our online forms and services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.\r\n\r\n####Compliance status\r\n\r\nThis online form is partially compliant with the [Web Content Accessibility Guidelines version 2.1 AA standard](https://www.w3.org/TR/WCAG21/), due to the non-compliances listed below.\r\n\r\n###Non-accessible content\r\n\r\nThe content listed below is non-accessible for the following reasons.\r\n\r\n####Non compliance with the accessibility regulations\r\n\r\n1. Pages have no skip links. This issue may affect screen reader and keyboard users who use skip links to bypass repeated content such as headers and navigation menus to skip directly to the main page content.\r\n2. The language attribute of the page has not been set in the HTML. This may cause confusion to screen reader users who may not be able to identify the primary language of the page in their journey.\r\n3. Some pages may contain empty headings, including on the check answers page. As a result, screen reader users may have difficulty navigating these pages.\n4. Some content may be cut off or appear truncated when zooming in. This issue may affect low-vision users navigating the form who use reflow settings to view web pages.\r\n\r\nWe plan to fix these issues by July 2021.\r\n\r\n###Preparation of this accessibility statement\r\n\r\nThis statement was prepared on [date when it was first published]. It was last reviewed on [date when it was last reviewed].\r\n\r\nThis form was last tested on [date when you performed your basic accessibility check].\r\n\r\nIn order to test the compliance of all forms built using the MoJ Forms tool, the Ministry of Justice commissioned The Digital Accessibility Centre (DAC) to carry out a WCAG 2.1 AA level audit of a sample form. This included extensive testing by users with a wide range of disabilities. The audit was performed on 8 April 2021.\r\n\r\nIn addition, this form was tested by [insert team or organisation here]. It was tested using the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) following guidance from the Ministry of Justice and Government Digital Service (GDS).\r\n\r\n###What we’re doing to improve accessibility\r\n\r\nWe will monitor the accessibility of this website on an ongoing basis and fix any accessibility issues reported to us.",
+      "_type": "page.standalone",
+      "_uuid": "31c4e4f7-2790-41ad-935a-50f7061fb1f1",
+      "heading": "Accessibility statement",
+      "components": []
+    }
+  ]
+}

--- a/fixtures/version_with_flow.json
+++ b/fixtures/version_with_flow.json
@@ -95,21 +95,6 @@
       "lede": "",
       "_type": "page.start",
       "_uuid": "cf6dc32f-502c-4215-8c27-1151a45735bb",
-      "steps": [
-        "page.name",
-        "page.email-address",
-        "page.parent-name",
-        "page.your-age",
-        "page.family-hobbies",
-        "page.do-you-like-star-wars",
-        "page.holiday",
-        "page.burgers",
-        "page.star-wars-knowledge",
-        "page.how-many-lights",
-        "page.dog-picture",
-        "page.check-answers",
-        "page.confirmation"
-      ],
       "heading": "Service name goes here",
       "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
     },

--- a/fixtures/version_with_flow.json
+++ b/fixtures/version_with_flow.json
@@ -1,0 +1,694 @@
+{
+  "_id": "service.base",
+  "_type": "service.base",
+  "flow": {
+    "cf6dc32f-502c-4215-8c27-1151a45735bb": {
+      "_type": "flow.page",
+      "next": {
+        "default": "9e1ba77f-f1e5-42f4-b090-437aa9af7f73"
+      }
+    },
+    "9e1ba77f-f1e5-42f4-b090-437aa9af7f73": {
+      "_type": "flow.page",
+      "next": {
+        "default": "df1ba645-f748-46d0-ad75-f34112653e37"
+      }
+    },
+    "df1ba645-f748-46d0-ad75-f34112653e37": {
+      "_type": "flow.page",
+      "next": {
+        "default": "4b8c6bf3-878a-4446-9198-48351b3e2185"
+      }
+    },
+    "4b8c6bf3-878a-4446-9198-48351b3e2185": {
+      "_type": "flow.page",
+      "next": {
+        "default": "54ccc6cd-60c0-4749-947b-a97af1bc0aa2"
+      }
+    },
+    "54ccc6cd-60c0-4749-947b-a97af1bc0aa2": {
+      "_type": "flow.page",
+      "next": {
+        "default": "b8335af2-6642-4e2f-8192-0dd12279eec7"
+      }
+    },
+    "b8335af2-6642-4e2f-8192-0dd12279eec7": {
+      "_type": "flow.page",
+      "next": {
+        "default": "68fbb180-9a2a-48f6-9da6-545e28b8d35a"
+      }
+    },
+    "68fbb180-9a2a-48f6-9da6-545e28b8d35a": {
+      "_type": "flow.page",
+      "next": {
+        "default": "7806cd64-0c05-450e-ba6f-2325c8b22d46"
+      }
+    },
+    "7806cd64-0c05-450e-ba6f-2325c8b22d46": {
+      "_type": "flow.page",
+      "next": {
+        "default": "0c022e95-0748-4dda-8ba5-12fd1d2f596b"
+      }
+    },
+    "0c022e95-0748-4dda-8ba5-12fd1d2f596b": {
+      "_type": "flow.page",
+      "next": {
+        "default": "e8708909-922e-4eaf-87a5-096f7a713fcb"
+      }
+    },
+    "e8708909-922e-4eaf-87a5-096f7a713fcb": {
+      "_type": "flow.page",
+      "next": {
+        "default": "80420693-d6f2-4fce-a860-777ca774a6f5"
+      }
+    },
+    "80420693-d6f2-4fce-a860-777ca774a6f5": {
+      "_type": "flow.page",
+      "next": {
+        "default": "2ef7d11e-0307-49e9-9fe2-345dc528dd66"
+      }
+    },
+    "2ef7d11e-0307-49e9-9fe2-345dc528dd66": {
+      "_type": "flow.page",
+      "next": {
+        "default": "e337070b-f636-49a3-a65c-f506675265f0"
+      }
+    },
+    "e337070b-f636-49a3-a65c-f506675265f0": {
+      "_type": "flow.page",
+      "next": {
+        "default": "778e364b-9a7f-4829-8eb2-510e08f156a3"
+      }
+    },
+    "778e364b-9a7f-4829-8eb2-510e08f156a3": {
+      "_type": "flow.page",
+      "next": {
+        "default": ""
+      }
+    }
+  },
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "lede": "",
+      "_type": "page.start",
+      "_uuid": "cf6dc32f-502c-4215-8c27-1151a45735bb",
+      "steps": [
+        "page.name",
+        "page.email-address",
+        "page.parent-name",
+        "page.your-age",
+        "page.family-hobbies",
+        "page.do-you-like-star-wars",
+        "page.holiday",
+        "page.burgers",
+        "page.star-wars-knowledge",
+        "page.how-many-lights",
+        "page.dog-picture",
+        "page.check-answers",
+        "page.confirmation"
+      ],
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.name",
+      "url": "name",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "9e1ba77f-f1e5-42f4-b090-437aa9af7f73",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "name_text_1",
+          "hint": "",
+          "name": "name_text_1",
+          "_type": "text",
+          "_uuid": "27d377a2-6828-44ca-87d1-b83ddac98284",
+          "label": "Full name",
+          "errors": {},
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 10,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.email-address",
+      "url": "email-address",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "df1ba645-f748-46d0-ad75-f34112653e37",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "email-address_text_1",
+          "hint": "",
+          "name": "email-address_text_1",
+          "_type": "text",
+          "_uuid": "f27e5788-e784-4bfd-8b21-2fab8ce95abb",
+          "label": "Email address",
+          "errors": {
+            "format": {},
+            "required": {
+              "any": "Enter an email address"
+            },
+            "max_length": {
+              "any": "%{control} is too long."
+            },
+            "min_length": {
+              "any": "%{control} is too short."
+            }
+          },
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 30,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.parent-name",
+      "url": "parent-name",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "4b8c6bf3-878a-4446-9198-48351b3e2185",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "parent-name_text_1",
+          "hint": "",
+          "name": "parent-name_text_1",
+          "_type": "text",
+          "_uuid": "5ad372fa-ed35-477f-b471-4d444f991210",
+          "label": "Parent name",
+          "errors": {},
+          "collection": "components",
+          "validation": {
+            "required": false,
+            "max_length": 10,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.your-age",
+      "url": "your-age",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "54ccc6cd-60c0-4749-947b-a97af1bc0aa2",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "your-age_number_1",
+          "hint": "",
+          "name": "your-age_number_1",
+          "_type": "number",
+          "_uuid": "b3014ef8-546a-4a35-9669-c5c1667e86d7",
+          "label": "Your age",
+          "errors": {},
+          "collection": "components",
+          "validation": {
+            "number": true,
+            "required": true
+          },
+          "width_class_input": "10"
+        }
+      ]
+    },
+    {
+      "_id": "page.family-hobbies",
+      "url": "family-hobbies",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "b8335af2-6642-4e2f-8192-0dd12279eec7",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "family-hobbies_textarea_1",
+          "hint": "",
+          "name": "family-hobbies_textarea_1",
+          "rows": 5,
+          "_type": "textarea",
+          "_uuid": "9bf39533-dbd2-45ed-b2b8-9b29bf5fe9e8",
+          "label": "Family Hobbies",
+          "errors": {},
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.do-you-like-star-wars",
+      "url": "do-you-like-star-wars",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "68fbb180-9a2a-48f6-9da6-545e28b8d35a",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "do-you-like-star-wars_radios_1",
+          "hint": "",
+          "name": "do-you-like-star-wars_radios_1",
+          "_type": "radios",
+          "_uuid": "ac41be35-914e-4b22-8683-f5477716b7d4",
+          "items": [
+            {
+              "_id": "do-you-like-star-wars_radios_1_item_1",
+              "hint": "",
+              "name": "do-you-like-star-wars_radios_1",
+              "_type": "radio",
+              "_uuid": "c5571937-9388-4411-b5fa-34ddf9bc4ca0",
+              "label": "Only on weekends",
+              "value": "value-1",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "do-you-like-star-wars_radios_1_item_2",
+              "hint": "",
+              "name": "do-you-like-star-wars_radios_1",
+              "_type": "radio",
+              "_uuid": "67160ff1-6f7c-43a8-8bf6-49b3d5f450f6",
+              "label": "Hell no!",
+              "value": "value-2",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {},
+          "legend": "Do you like Star Wars?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.holiday",
+      "url": "holiday",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "7806cd64-0c05-450e-ba6f-2325c8b22d46",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "holiday_date_1",
+          "hint": "",
+          "name": "holiday_date_1",
+          "_type": "date",
+          "_uuid": "f16b7e7b-fbfa-4e41-a413-ee7eaf6063a6",
+          "errors": {},
+          "legend": "What is the day that you like to take holidays?",
+          "date_type": "day-month-year",
+          "collection": "components",
+          "validation": {
+            "date": true,
+            "required": true
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.burgers",
+      "url": "burgers",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "0c022e95-0748-4dda-8ba5-12fd1d2f596b",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "burgers_checkboxes_1",
+          "hint": "",
+          "name": "burgers_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "4c409737-80bb-48c7-afa7-6e9360b65004",
+          "items": [
+            {
+              "_id": "burgers_checkboxes_1_item_1",
+              "hint": "",
+              "name": "burgers_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "3251098f-c8e0-4ac5-a637-95fd2e1c4dc4",
+              "label": "Beef, cheese, tomato",
+              "value": "value-1",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "burgers_checkboxes_1_item_2",
+              "hint": "",
+              "name": "burgers_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "a0717bbd-0b9f-47a0-bf2b-2a9d208e1168",
+              "label": "Chicken, cheese, tomato",
+              "value": "value-2",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "burgers_checkboxes_1_item_3",
+              "hint": "",
+              "name": "burgers_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "4c409737-80bb-48c7-afa7-6e9360b65004",
+              "label": "Mozzarella, cheddar, feta",
+              "value": "value-3",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {},
+          "legend": "What would you like on your burger?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.star-wars-knowledge",
+      "url": "star-wars-knowledge",
+      "_type": "page.multiplequestions",
+      "_uuid": "e8708909-922e-4eaf-87a5-096f7a713fcb",
+      "heading": "How well do you know Star Wars?",
+      "components": [
+        {
+          "_id": "star-wars-knowledge_text_1",
+          "hint": "",
+          "name": "star-wars-knowledge_text_1",
+          "_type": "text",
+          "_uuid": "fda1e5a1-ed5f-49c9-a943-dc930a520984",
+          "label": "What was the name of the band playing in Jabba's palace?",
+          "errors": {},
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "_id": "star-wars-knowledge_content_1",
+          "name": "star-wars-knowledge_content_1",
+          "_type": "content",
+          "_uuid": "82444d3d-dab6-44c4-a147-e2650326c9eb",
+          "content": "Stay on target",
+          "collection": "components"
+        },
+        {
+          "_id": "star-wars-knowledge_radios_1",
+          "hint": "",
+          "name": "star-wars-knowledge_radios_1",
+          "_type": "radios",
+          "_uuid": "51efe2ca-fc47-4584-8129-e91589a46b9e",
+          "items": [
+            {
+              "_id": "star-wars-knowledge_radios_1_item_1",
+              "hint": "",
+              "name": "star-wars-knowledge_radios_1",
+              "_type": "radio",
+              "_uuid": "1b6c5734-04bf-49fa-928a-2e9bbbb09f8c",
+              "label": "Harry Potter",
+              "value": "value-1",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "star-wars-knowledge_radios_1_item_2",
+              "hint": "",
+              "name": "star-wars-knowledge_radios_1",
+              "_type": "radio",
+              "_uuid": "693edfd9-883b-4a6f-95b4-202849395d3d",
+              "label": "Din Jarrin",
+              "value": "value-2",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "star-wars-knowledge_radios_1_item_3",
+              "hint": "",
+              "name": "star-wars-knowledge_radios_1",
+              "_type": "radio",
+              "_uuid": "7bbd84ab-b7c9-49ec-be76-a94c460acac4",
+              "label": "Tony Stark",
+              "value": "value-3",
+              "errors": {},
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {},
+          "legend": "What is The Mandalorian's real name?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "add_component": "radios",
+      "section_heading": "That's no moon"
+    },
+    {
+      "_id": "page.how-many-lights",
+      "url": "how-many-lights",
+      "body": "here are four lights!",
+      "lede": "",
+      "_type": "page.content",
+      "_uuid": "80420693-d6f2-4fce-a860-777ca774a6f5",
+      "heading": "Tell me how many lights you see",
+      "components": [
+        {
+          "_id": "how-many-lights_content_1",
+          "name": "how-many-lights_content_1",
+          "_type": "content",
+          "_uuid": "e3a47cb3-407b-4d7a-950e-da2526ce77ab",
+          "content": "What lights?",
+          "collection": "components"
+        }
+      ],
+      "add_component": "content",
+      "section_heading": "Chain of Command"
+    },
+    {
+      "_id": "page.dog-picture",
+      "url": "dog-picture",
+      "_type": "page.singlequestion",
+      "_uuid": "2ef7d11e-0307-49e9-9fe2-345dc528dd66",
+      "heading": "Question",
+      "components": [
+        {
+          "_id":  "dog-picture_upload_1",
+          "name": "dog-picture_upload_1",
+          "_type": "upload",
+          "_uuid": "f056a76e-ec3f-47ae-b625-1bba92220ad1",
+          "hint": "",
+          "legend": "Upload your best dog photo",
+          "max_files": 1,
+          "validation": {
+            "required": true,
+            "accept": [
+              "audio/*",
+              "image/bmp",
+              "text/csv",
+              "application/vnd.ms-excel",
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+              "application/vnd.ms-excel.sheet.macroEnabled.12",
+              "application/vnd.ms-excel.template.macroEnabled.12",
+              "application/vnd.ms-excel.addin.macroEnabled.12",
+              "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+              "image/gif",
+              "image/*",
+              "application/x-iwork-pages-sffpages",
+              "image/jpeg",
+              "application/pdf",
+              "text/plain",
+              "image/png",
+              "application/vnd.ms-powerpoint",
+              "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+              "application/vnd.openxmlformats-officedocument.presentationml.template",
+              "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+              "application/vnd.ms-powerpoint.addin.macroEnabled.12",
+              "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
+              "application/vnd.ms-powerpoint.template.macroEnabled.12",
+              "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
+              "text/rtf",
+              "excel",
+              "csv",
+              "image/svg+xml",
+              "pdf",
+              "word",
+              "rtf",
+              "plaintext",
+              "image/tiff",
+              "video/*",
+              "application/msword",
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+              "application/vnd.ms-word.document.macroEnabled.12",
+              "application/vnd.ms-word.template.macroEnabled.12"
+            ],
+            "max_size": 7340032,
+            "virus_scan": true
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.check-answers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "e337070b-f636-49a3-a65c-f506675265f0",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+        {
+          "_id": "check-answers_content_2",
+          "name": "check-answers_content_2",
+          "_type": "content",
+          "_uuid": "b065ff4f-90c5-4ba2-b4ac-c984a9dd2470",
+          "content": "Take the cannoli.",
+          "collection": "components"
+        }
+      ],
+      "send_heading": "Now send your application",
+      "add_component": "content",
+      "extra_components": [
+        {
+          "_id": "check-answers_content_1",
+          "name": "check-answers_content_1",
+          "_type": "content",
+          "_uuid": "3e6ef27e-91a6-402f-8291-b7ce669e824e",
+          "content": "Check yourself before you wreck yourself.",
+          "collection": "extra_components"
+        }
+      ],
+      "add_extra_component": "content"
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "confirmation",
+      "body": "Some day I will be the most powerful Jedi ever!",
+      "lede": "",
+      "_type": "page.confirmation",
+      "_uuid": "778e364b-9a7f-4829-8eb2-510e08f156a3",
+      "heading": "Complaint sent",
+      "components": []
+    }
+  ],
+  "locale": "en",
+  "created_at": "2021-04-21T13:10:19Z",
+  "created_by": "099d5bf5-5f7b-444c-86ee-9e189cc1a369",
+  "service_id": "488edccd-8411-4ffb-a38b-6a96c6ac28d6",
+  "version_id": "27dc30c9-f7b8-4dec-973a-bd153f6797df",
+  "service_name": "Version With Flow Fixture",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "This online form puts a small file (known as ‘cookies’) onto your computer to collect information about how you browse the site.\r\n\r\nCookies are used to:\r\n\r\n- remember your progress\r\n- measure how you use the website so it can be updated and improved based on your needs\r\n\r\nThis online form's cookie isn't used to identify you personally.\r\n\r\nYou'll normally see a message on the site before we store a cookie on your computer.\r\n\r\nFind out more about [how to manage cookies](https://www.aboutcookies.org/).\r\n\r\n##How cookies are used on this online form\r\n\r\nWe will store a cookie to remember your progress on this computer and to expire your session after 30 minutes of inactivity or when you close your browser.\r\n\r\n- name: _fb_runner_session\r\n- purpose: saves your current progress in this computer and tracks inactivity periods\r\n- expires: after 30 minutes of inactivity or when you close your browser",
+      "_type": "page.standalone",
+      "_uuid": "fd52e7c0-03f7-4001-ae7e-f2e4142b0ccc",
+      "heading": "Cookies",
+      "components": []
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "This privacy notice explains what [insert your organisation name] means when we talk about personal data, why we ask for this information about you and what we do with it when you use this form.\r\n\r\nIt also explains how we store your data, how you can get a copy of the information we’ve collected about you and how you can complain if you think we’ve done something wrong.\r\n\r\n###Who manages this service\r\n\r\nThis form is managed by [your organisation].\r\n\r\nThe information you submit will be processed by [insert who will be processing the information and, if it’s a separate organisation, what their relationship is to you].\r\n\r\n[Insert name of organisation that acts as data controller for your form] is the data controller for the personal data collected by this form.\r\n\r\n###When we ask for personal data\r\n\r\nWhenever we ask for information about you, we promise to:\r\n\r\n- always let you know why we need it\r\n- ask for relevant personal information only\r\n- make sure we do not keep it longer than needed\r\n- keep your information safe and make sure nobody can access it unless authorised to do so\r\n- only share your data with other organisations for legitimate purposes\r\n- consider any request you make to correct or delete your personal data\r\n\r\nWe also promise to make it easy for you to:\r\n\r\n- tell us at any time if you want us to stop storing your personal data\r\n- make a complaint to the supervisory authority\r\n\r\n###The personal data we collect\r\n\r\nWe only collect personal data that you directly provide with your application.\r\n\r\nWe only collect the information we need to deliver this service to you. The personal data collected includes:\r\n\r\n- [summarise the types of personal information requested by your form]\r\n\r\nWe [use cookies](http://www.aboutcookies.org.uk/managing-cookies) to collect data that tells us about how the service is used, including:\r\n\r\n- your computer, phone or tablet’s IP address\r\n\r\n- the region or town where you are using your computer, phone or tablet\r\n\r\n- the operating system and web browser you use\r\n\r\nThis information is not used to identify you personally.\r\n\r\n###Why we collect your personal data\r\n\r\nWe collect data to [describe why you are collecting personal information]. The processing of your personal data is necessary for [explain why you require the personal information].\r\n\r\nThe legal basis for collecting and processing your personal data is [enter and explain your legal basis here, for example, that it is necessary to perform a task in the public interest or\nin the exercise of your functions as a government department].\r\n\r\nUse of the online form is voluntary. If you do not provide all the information we ask for, we may not be able to process your [insert the purpose of your form, such as claim, application or request].\r\n\r\nPlease note that transmitting information over the internet is generally not completely secure, and [your organisation] can’t guarantee the security of your data. Any data you transmit is at your own risk. [your organisation, and any other organisations involved in processing the data] have procedures and security features in place to keep your data secure once we receive it.\r\n\r\n###Sharing your personal data\r\n\r\nThe information you provide will be shared with… [name any organisations that you might share the data with and provide an explanation of why the information may be shared and what it will be used for]\r\n\r\nWe may also use your contact information to ask for feedback on using the service, but only when you have given your consent for us to do so. [delete this paragraph if not applicable]\r\n\r\nWe’ll never share your information with other organisations for marketing, market research or commercial purposes.\r\n\r\n###Keeping your personal data\r\n\r\nTo protect your personal information, any data you enter as you progress through the online form is held temporarily and securely until you submit your application, after which your application cannot be viewed or modified further online.\r\n\r\n[your organisation, and any other organisations involved in processing the data] will keep your data for [specify how long you will keep the information for and why].\r\n\r\nAll deleted data will be destroyed securely and confidentially.\r\n\r\n###How we use your personal data\r\n\r\nYour online submission will be sent from the online form to [your organisation or whichever other organisation will receive the information for processing] via encrypted email. The system does not retain a copy of your information.\r\n\r\n[select one of the following 3 paragraphs which most closely fits your circumstances and delete the other 2]\r\n\r\nYour personal data is not used in any automated decision making (a decision made solely by automated means without any human involvement) or profiling (automated processing of personal data to evaluate certain conditions about an individual).\r\n\r\nAutomated decision making (a decision made solely by automated means without any human involvement) is used for the purpose of [insert why ADM is used] and is carried out [include when in the process this is carried out]. The personal data used for this purpose includes [insert personal data types].\r\n\r\nProfiling (automated processing of personal data to evaluate certain conditions about an individual) is carried out for the purpose of [insert reason why profiling exists]. The personal data used for this purpose includes [insert personal data types].\r\n\r\n###How we store your personal data\r\n\r\n[your organisation or whichever other organisation will receive the information for processing] take data security very seriously and take every step to ensure that your data remains private and secure. All data collected by this service is stored in a secure database [kept entirely within the UK/kept outside of the UK but within the European Economic Area (EEA). - delete as appropriate]\r\n\r\nIt may sometimes be necessary to transfer personal information overseas, outside of the UK and the European Economic Area (EEA). When this is needed information may be transferred to [insert names of countries]. Any transfers made will be in full compliance with all aspects of the data protection law. [delete this paragraph if not applicable or contact your data protection team for guidance on required safeguards] \r\n\r\nYour application will only be accessible to [your organisation, and any other organisations involved in processing the data] staff who require access to process applications.\r\n\r\n###Your rights\r\n\r\nYou have a number of rights, depending on the reason for processing your information. These include:\r\n\r\n- the right to request a copy of your personal data and information about how your personal data is processed (this is known as a subject access request)\r\n- the right to have inaccuracies in your personal data corrected\r\n- the right to fill in any gaps in your personal data, including by means of a supplementary statement\r\n- the right to ask for the processing of your personal data to be restricted\r\n- the right to ask for your personal data to be deleted if there is no longer a justification for it\r\n- the right to object to automated decision making, including profiling, that has a legal or significant effect on you as an individual\r\n\r\nIf you want to see the personal data that we hold on you, you can make a subject access request. Send your request by post to:\r\n\r\nDisclosure Team  \r\nPost point 10.25  \r\n102 Petty France  \r\nLondon  \r\nSW1H 9AJ\r\n\r\nor email: data.access@justice.gov.uk\r\n\r\nFor all other rights, please write to us at:\r\n\r\n[insert your postal and email addresses]\r\n\r\n###Getting more information\r\n\r\nYou can get more details on:\r\n\r\n- agreements we have with other organisations for sharing information\r\n- when we can pass on personal information without telling you, for example, to help with the prevention or detection of crime or to produce anonymised statistics\r\n- instructions we give to staff on how to collect, use or delete your personal information\r\n- how we check that the information we have is accurate and up-to-date\r\n- how to make a complaint\r\n\r\nFor more information, please contact the [your organisation] data protection officer at:\r\n\r\n[insert the postal and email addresses of your data protection officer - for the MoJ, this is:\r\n\r\nThe Data Protection Officer  \r\nMinistry of Justice  \r\n10 South Colonnade\nCanary Wharf  \r\nLondon  \r\nE14 4PU\r\n\r\nEmail: DPO@justice.gov.uk]\r\n\r\n###Making a complaint\r\n\r\nWhen we ask you for information, we will keep to the law. If you think that your information has not been handled correctly, you can contact the [Information Commissioner](https://ico.org.uk/) for independent advice about data protection on the address below:\r\n\r\nInformation Commissioner's Office  \r\nWycliffe House  \r\nWater Lane  \r\nWilmslow  \r\nCheshire  \r\nSK9 5AF\r\n\r\nTelephone: 0303 123 1113",
+      "_type": "page.standalone",
+      "_uuid": "4b86fe8c-7723-4cce-9378-7b2510279e04",
+      "heading": "Privacy notice",
+      "components": []
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "This accessibility statement applies to [describe your form here - for example, the general enquiries form for the CICA]. There is a separate [accessibility statement for the main GOV.UK website](https://www.gov.uk/help/accessibility-statement).\r\n\r\n###Using this online form\r\n\r\nThis form was built using MoJ Forms, a tool developed by the Ministry of Justice, and uses components from the [GOV.UK Design System](https://design-system.service.gov.uk/).\r\n\r\n[insert your organisation here] is responsible for the content of this online form. The Ministry of Justice is responsible for its technical aspects.\r\n\r\nWe want as many people as possible to be able to use this online form. For example, that means you should be able to:\r\n\r\n- change colours, contrast levels and fonts\r\n- zoom in up to 300% without the text spilling off the screen\r\n- navigate the form using just a keyboard\r\n- navigate the form using speech recognition software\r\n- listen to the form using a screen reader (including recent versions of JAWS, NVDA and VoiceOver)\r\n\r\nWe’ve also made the text as simple as possible to understand.\r\n\r\n[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.\r\n\r\n###Feedback and contact information\r\n\r\nIf you need information on this website in a different format:\r\n\r\n[insert your contact details for user requests here - add other channels, such as text phones or Relay UK, as required]\r\n\r\n- email: [your email address]\r\n- call: [your telephone number]\r\n- [Hours - e.g. Monday to Friday, 9am to 5pm]\r\n\r\nWe'll consider your request and get back to you in [add your SLA - e.g. a week or 5 working days].\r\n\r\n###Reporting accessibility problems with this form\r\n\r\nWe’re always looking to improve the accessibility of this form. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact:\r\n\r\n[insert your contact details for user feedback here - add other channels, such as text phones or Relay UK, as required]\r\n\r\n- email: [your email address]\r\n- call: [your telephone number]\r\n- [Hours - e.g. Monday to Friday, 9am to 5pm]\r\n\r\n###Enforcement procedure\r\n\r\nThe Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the [Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).\r\n\r\n###Technical information about this online form’s accessibility\r\n\r\nWe are committed to making our online forms and services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.\r\n\r\n####Compliance status\r\n\r\nThis online form is fully compliant with the [Web Content Accessibility Guidelines version 2.1 AA standard](https://www.w3.org/TR/WCAG21/)\r\n\r\n###Preparation of this accessibility statement\r\n\r\nThis statement was prepared on [date when it was first published]. It was last reviewed on [date when it was last reviewed].\r\n\r\nThis form was last tested on [date when you performed your basic accessibility check].\r\n\r\nIn order to test the compliance of all forms built using the MoJ Forms tool, the Ministry of Justice commissioned The Digital Accessibility Centre (DAC) to carry out a WCAG 2.1 AA level audit of a sample form. This included extensive testing by users with a wide range of disabilities. The audit was performed on 8 April 2021. The audit highlighted a number of non-compliance issues which were fixed on 11 May 2021.\r\n\r\nIn addition, this form was tested by [insert team or organisation here]. It was tested using the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) following guidance from the Ministry of Justice and the Government Digital Service (GDS).\r\n\r\n###What we’re doing to improve accessibility\r\n\r\nWe will monitor the accessibility of this website on an ongoing basis and fix any accessibility issues reported to us.",
+      "_type": "page.standalone",
+      "_uuid": "c439c7fd-f411-4e11-8598-4023934bac93",
+      "heading": "Accessibility statement",
+      "components": []
+    }
+  ]
+}

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '1.8.0'.freeze
+  VERSION = '1.8.1'.freeze
 end

--- a/schemas/definition/page.form.json
+++ b/schemas/definition/page.form.json
@@ -44,40 +44,6 @@
         "content"
       ]
     },
-    "steps_heading": {
-      "title": "Steps heading",
-      "description": "Name of section to use on step pages (if any)",
-      "type": "string",
-      "category": [
-        "content"
-      ]
-    },
-    "steps": {
-      "title": "Steps",
-      "description": "The ‘child’ pages that follow from this ‘parent’ page",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "enable_steps": {
-      "title": "Enable steps",
-      "description": "Allow current page to have steps",
-      "type": "boolean"
-    },
-    "show_steps": {
-      "title": "Steps visibility",
-      "category": [
-        "logic"
-      ],
-      "description": "Whether to show or hide the page’s steps",
-      "oneOf": [
-        {
-          "$ref": "definition.conditional.boolean"
-        }
-      ],
-      "default": true
-    },
     "nextPage": {
       "$ref": "definition.next_page"
     }

--- a/schemas/page/start.json
+++ b/schemas/page/start.json
@@ -15,9 +15,6 @@
       "title": "Before you start",
       "description": "A body of text that goes after the Start button"
     },
-    "enable_steps": {
-      "const": true
-    },
     "components": {
       "accepts": [
         "content"
@@ -37,7 +34,6 @@
     ]
   },
   "required": [
-    "heading",
-    "steps"
+    "heading"
   ]
 }


### PR DESCRIPTION
## Add flow object to default service metadata

All new services should have a flow object

## Add service and version fixtures with flow objects

These are direct copies of the current service and version fixtures but with additional flow objects. 

Keep the old ones as well so as not to break other tests currently. Eventually all tests should use the fixtures which include service flow objects

## Remove steps from start page default metadata

The Steps array is not used so we do not need to create it at all

## Change title of No Flow Service Fixture

## Publish 1.8.1