### PR TITLE
Branching pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [2.0.1] - 2021-07-23
+
+### Added
+
+- Add title method to page to return the question, heading or component legend or label
+- Begin to support branching with radio and checkbox components
+
 ## [2.0.0] - 2021-07-13
 
 ### Changed

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -13,6 +13,12 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
     end
   end
 
+  SUPPORTS_BRANCHING = %w[radios checkboxes].freeze
+
+  def supports_branching?
+    type.in?(SUPPORTS_BRANCHING)
+  end
+
   def content?
     type == 'content'
   end

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -65,7 +65,18 @@ module MetadataPresenter
       type == 'page.standalone'
     end
 
+    def title
+      return heading if heading?
+
+      components.first.humanised_title
+    end
+
     private
+
+    def heading?
+      Array(components).size != 1 ||
+        type.in?(['page.content', 'page.checkanswers', 'page.confirmation'])
+    end
 
     def to_components(node_components, collection:)
       node_components&.map do |component|

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -91,4 +91,30 @@ RSpec.describe MetadataPresenter::Component do
       end
     end
   end
+
+  describe '#supports_branching?' do
+    context 'when is radio' do
+      let(:attributes) { { '_type' => 'radios' } }
+
+      it 'returns true' do
+        expect(component.supports_branching?).to be_truthy
+      end
+    end
+
+    context 'when is checkbox' do
+      let(:attributes) { { '_type' => 'checkboxes' } }
+
+      it 'returns true' do
+        expect(component.supports_branching?).to be_truthy
+      end
+    end
+
+    context 'when is file upload' do
+      let(:attributes) { { '_type' => 'upload' } }
+
+      it 'returns false' do
+        expect(component.supports_branching?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe MetadataPresenter::Page do
 
   describe '#title' do
     context 'when there is one component' do
-      let(:page){ service.find_page_by_url('name') }
+      let(:page) { service.find_page_by_url('name') }
 
       it 'returns the correct title' do
         expect(page.title).to eq('Full name')

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -160,4 +160,46 @@ RSpec.describe MetadataPresenter::Page do
       ).to eq(page.components.first)
     end
   end
+
+  describe '#title' do
+    context 'when there is one component' do
+      let(:page){ service.find_page_by_url('name') }
+
+      it 'returns the correct title' do
+        expect(page.title).to eq('Full name')
+      end
+    end
+
+    context 'when there is more than one component' do
+      let(:page) { service.find_page_by_url('star-wars-knowledge') }
+
+      it 'returns the correct title' do
+        expect(page.title).to eq('How well do you know Star Wars?')
+      end
+    end
+
+    context 'when the page is a content page' do
+      let(:page) { service.find_page_by_url('how-many-lights') }
+
+      it 'returns the correct title' do
+        expect(page.title).to eq('Tell me how many lights you see')
+      end
+    end
+
+    context 'when is check your answers' do
+      let(:page) { service.find_page_by_url('check-answers') }
+
+      it 'returns the correct title' do
+        expect(page.title).to eq('Check your answers')
+      end
+    end
+
+    context 'when there are no components' do
+      let(:page) { service.find_page_by_url('/') }
+
+      it 'returns the correct title' do
+        expect(page.title).to eq('Service name goes here')
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Add title method to pages. This is for returning either the page heading, the question or the component label or legend
- Start adding support for branching. In this case radio and checkbox components

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>