### PR TITLE
Remove standalone pages backlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [2.1.0] - 2021-07-27
+
+### Changed
+
+- Remove back links from standalone pages
+
 ## [2.0.2] - 2021-07-26
 
 ### Changed

--- a/app/models/metadata_presenter/previous_page.rb
+++ b/app/models/metadata_presenter/previous_page.rb
@@ -6,23 +6,10 @@ module MetadataPresenter
     def page
       return if no_current_or_referrer_pages? || service.no_back_link?(current_page)
 
-      return referrer_page if return_to_referrer?
-
       TraversedPages.new(service, user_data, current_page).last
     end
 
     private
-
-    def referrer_page
-      @referrer_page ||= service.find_page_by_url(URI(referrer).path)
-    end
-
-    def return_to_referrer?
-      return false unless current_page.standalone?
-
-      current_page.standalone? ||
-        (referrer_page && referrer_page.standalone?)
-    end
 
     def no_current_or_referrer_pages?
       current_page.blank? || referrer.nil?

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -38,14 +38,6 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     pages[pages.index(current_page) + 1] if current_page.present?
   end
 
-  def previous_page(current_page:, referrer:)
-    return if current_page.nil? || referrer.nil?
-
-    unless no_back_link?(current_page)
-      flow_page(current_page) || referrer_page(referrer)
-    end
-  end
-
   def confirmation_page
     @confirmation_page ||= pages.find do |page|
       page.type == 'page.confirmation'
@@ -57,7 +49,9 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
   end
 
   def no_back_link?(current_page)
-    current_page == start_page || current_page == confirmation_page
+    current_page == start_page ||
+      current_page == confirmation_page ||
+      current_page.standalone?
   end
 
   private

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.0.2'.freeze
+  VERSION = '2.1.0'.freeze
 end

--- a/spec/models/previous_page_spec.rb
+++ b/spec/models/previous_page_spec.rb
@@ -38,36 +38,6 @@ RSpec.describe MetadataPresenter::PreviousPage do
         end
       end
 
-      context 'when it is the standalone page' do
-        let(:current_page) { service.find_page_by_url('cookies') }
-
-        context 'when there is a referrer' do
-          context 'when is an existing page on metadata' do
-            let(:referrer) { 'http://localhost:3000/name' }
-
-            it 'returns page' do
-              expect(previous_page.page).to eq(service.find_page_by_url('name'))
-            end
-          end
-
-          context 'when is not an existing page on metadata' do
-            let(:referrer) { 'owned-site.co.uk' }
-
-            it 'returns nil' do
-              expect(previous_page.page).to be_nil
-            end
-          end
-        end
-
-        context 'when there is not a referrer' do
-          let(:referrer) {}
-
-          it 'returns nil' do
-            expect(previous_page.page).to be_nil
-          end
-        end
-      end
-
       context 'when is a confirmation page' do
         let(:current_page) { service.find_page_by_url('/confirmation') }
 
@@ -138,45 +108,6 @@ RSpec.describe MetadataPresenter::PreviousPage do
 
           it 'returns nil' do
             expect(previous_page.page).to be_nil
-          end
-        end
-
-        context 'moving from standalone page back to flow page' do
-          let(:current_page) { service.find_page_by_url('name') }
-          let(:referrer) { 'http://localhost:3000/cookies' }
-
-          it 'defaults to the previous flow page when current page is also in the flow' do
-            expect(previous_page.page.url).to eq('/')
-          end
-        end
-
-        context 'when it is the standalone page' do
-          let(:current_page) { service.find_page_by_url('cookies') }
-
-          context 'when there is a referrer' do
-            context 'when is an existing page on metadata' do
-              let(:referrer) { 'http://localhost:3000/name' }
-
-              it 'returns page' do
-                expect(previous_page.page).to eq(service.find_page_by_url('name'))
-              end
-            end
-
-            context 'when is not an existing page on metadata' do
-              let(:referrer) { 'owned-site.co.uk' }
-
-              it 'returns nil' do
-                expect(previous_page.page).to be_nil
-              end
-            end
-          end
-
-          context 'when there is not a referrer' do
-            let(:referrer) {}
-
-            it 'returns nil' do
-              expect(previous_page.page).to be_nil
-            end
           end
         end
       end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -135,61 +135,6 @@ RSpec.describe MetadataPresenter::Service do
     end
   end
 
-  describe '#previous_page' do
-    context 'when previous page exists' do
-      it 'returns the previous page' do
-        current_page = service.find_page_by_url(service_metadata['pages'][1]['url'])
-        previous_page = service.previous_page(
-          current_page: current_page,
-          referrer: 'https://example.com'
-        )
-        expect(previous_page.id).to eq(service_metadata['pages'][0]['_id'])
-      end
-    end
-
-    context 'when previous page does not exists' do
-      it 'returns nil' do
-        current_page = service.find_page_by_url(service_metadata['pages'][0]['url']) # start page
-        previous_page = service.previous_page(
-          current_page: current_page, referrer: nil
-        )
-        expect(previous_page).to be(nil)
-      end
-    end
-
-    context 'when current page is not part of the standard page flow' do
-      it 'finds the previous page by referrer' do
-        current_page = service.find_page_by_url('/cookies')
-        previous_page = service.previous_page(
-          current_page: current_page,
-          referrer: service.start_page.url
-        )
-        expect(previous_page.id).to eq(service.start_page.id)
-      end
-    end
-
-    context 'when there is no referrer page' do
-      it 'returns nil' do
-        previous_page = service.previous_page(current_page: nil, referrer: nil)
-        expect(previous_page).to be_nil
-      end
-    end
-
-    context 'when current page is confirmation page' do
-      it 'returns nil' do
-        confirmation_page = service.pages.find { |page| page.type == 'page.confirmation' }
-        # just in case the confirmation page gets removed from the fixture accidentally
-        expect(confirmation_page).to be_truthy
-
-        previous_page = service.previous_page(
-          current_page: confirmation_page,
-          referrer: nil
-        )
-        expect(previous_page).to be_nil
-      end
-    end
-  end
-
   describe '#confirmation_page' do
     it 'returns the confirmation page for the service' do
       expect(service.confirmation_page.type).to eq('page.confirmation')


### PR DESCRIPTION
We have decided to remove back links entirely from standalone pages.
Only pages in the service flow will have a back link from now on.

This does mean that we can also remove a fair amount of code and related
tests as well.