### PR TITLE
Return a page object containing a given component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 
 ## [2.1.0] - 2021-07-27
 
+### Added
+
+- Added method to the service which returns a page object containing a given component uuid
+
+## [2.1.0] - 2021-07-27
+
 ### Changed
 
 - Remove back links from standalone pages

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -54,6 +54,12 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
       current_page.standalone?
   end
 
+  def page_with_component(uuid)
+    pages.find do |page|
+      Array(page.components).any? { |component| component.uuid == uuid }
+    end
+  end
+
   private
 
   def all_pages

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -146,4 +146,13 @@ RSpec.describe MetadataPresenter::Service do
       expect(service.meta).to be_kind_of(MetadataPresenter::Meta)
     end
   end
+
+  describe '#page_with_component' do
+    let(:page) { service.find_page_by_url('do-you-like-star-wars') }
+    let(:component_uuid) { page.components.first.uuid }
+
+    it 'returns the correct page containing the component' do
+      expect(service.page_with_component(component_uuid)).to eq(page)
+    end
+  end
 end


### PR DESCRIPTION
There are times when we need to get access to a page object which
has a given component.

Add a method to the service model which receives a component uuid and
returns the page object that contains it.

Co-authored-by Natalie Seeto <natalie.seeto@digital.justice.gov.uk>