### PR TITLE
Supported components, input components and content components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [2.2.0] - 2021-08-05
+
+### Changed
+
+- The methods in the page model relating to input and content components were not actually returning those objects.
+  They actually relate to supported components for a given page. Change the method names to better describe that
+- Add input_components and content_components methods which actually return objects of those types
+
+### Added
+
+- Add question_page? method on the page model. Should only be true for single question and multiple questions pages
+
 ## [2.1.0] - 2021-07-27
 
 ### Added

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -33,11 +33,11 @@ module MetadataPresenter
       to_components(metadata.extra_components, collection: :extra_components)
     end
 
-    def components_by_type(type)
-      supported_components = page_components(raw_type)[type]
+    def supported_components_by_type(type)
+      supported = supported_components(raw_type)[type]
 
       all_components.select do |component|
-        supported_components.include?(component.type)
+        supported.include?(component.type)
       end
     end
 
@@ -49,12 +49,12 @@ module MetadataPresenter
       "metadata_presenter/#{type.gsub('.', '/')}"
     end
 
-    def input_components
-      page_components(raw_type)[:input]
+    def supported_input_components
+      supported_components(raw_type)[:input]
     end
 
-    def content_components
-      page_components(raw_type)[:content]
+    def supported_content_components
+      supported_components(raw_type)[:content]
     end
 
     def upload_components
@@ -87,10 +87,10 @@ module MetadataPresenter
       end
     end
 
-    def page_components(page_type)
-      values = Rails.application.config.page_components[page_type]
+    def supported_components(page_type)
+      values = Rails.application.config.supported_components[page_type]
       if values.blank?
-        raise PageComponentsNotDefinedError, "No page components defined for #{page_type} in config initialiser"
+        raise PageComponentsNotDefinedError, "No supported components defined for #{page_type} in config initialiser"
       end
 
       values

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -34,6 +34,14 @@ module MetadataPresenter
       to_components(metadata.extra_components, collection: :extra_components)
     end
 
+    def input_components
+      all_components.reject(&:content?)
+    end
+
+    def content_components
+      all_components.select(&:content?)
+    end
+
     def supported_components_by_type(type)
       supported = supported_components(raw_type)[type]
 

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -12,6 +12,7 @@ module MetadataPresenter
       add_component
       add_extra_component
     ].freeze
+    QUESTION_PAGES = %w[page.singlequestion page.multiplequestions].freeze
 
     def editable_attributes
       to_h.reject { |k, _| k.in?(NOT_EDITABLE) }
@@ -63,6 +64,10 @@ module MetadataPresenter
 
     def standalone?
       type == 'page.standalone'
+    end
+
+    def question_page?
+      type.in?(QUESTION_PAGES)
     end
 
     def title

--- a/app/presenters/metadata_presenter/page_answers_presenter.rb
+++ b/app/presenters/metadata_presenter/page_answers_presenter.rb
@@ -10,7 +10,7 @@ module MetadataPresenter
 
     def self.map(view:, pages:, answers:)
       user_input_pages(pages).map { |page|
-        Array(page.components_by_type(:input)).map do |component|
+        Array(page.supported_components_by_type(:input)).map do |component|
           new(
             view: view,
             component: component,

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -16,8 +16,8 @@
                    components: @page.extra_components,
                    tag: nil,
                    classes: nil,
-                   input_components: @page.input_components,
-                   content_components: @page.content_components
+                   input_components: @page.supported_input_components,
+                   content_components: @page.supported_content_components
                  } %>
 
         <dl class="fb-block fb-block-answers govuk-summary-list">
@@ -80,8 +80,8 @@
                    components: @page.components,
                    tag: nil,
                    classes: nil,
-                   input_components: @page.input_components,
-                   content_components: @page.content_components
+                   input_components: @page.supported_input_components,
+                   content_components: @page.supported_content_components
                  } %>
 
         <button <%= 'disabled' if editable? %> data-prevent-double-click="true" class="fb-block fb-block-actions govuk-button" data-module="govuk-button" data-block-id="actions" data-block-type="actions">

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -29,7 +29,7 @@
              components: @page.components,
              tag: nil,
              classes: nil,
-             input_components: @page.input_components,
-             content_components: @page.content_components
+             input_components: @page.supported_input_components,
+             content_components: @page.supported_content_components
            } %>
 </div>

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -21,8 +21,8 @@
                      components: @page.components,
                      tag: nil,
                      classes: nil,
-                     input_components: @page.input_components,
-                     content_components: @page.content_components
+                     input_components: @page.supported_input_components,
+                     content_components: @page.supported_content_components
                    } %>
 
         <%= f.govuk_submit(disabled: editable?) %>

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -13,8 +13,8 @@
             components: @page.components,
             tag: :h2,
             classes: 'govuk-heading-m govuk-!-margin-top-8',
-            input_components: @page.input_components,
-            content_components: @page.content_components
+            input_components: @page.supported_input_components,
+            content_components: @page.supported_content_components
           }
         %>
 

--- a/config/initializers/supported_components.rb
+++ b/config/initializers/supported_components.rb
@@ -1,4 +1,4 @@
-Rails.application.config.page_components =
+Rails.application.config.supported_components =
   ActiveSupport::HashWithIndifferentAccess.new({
     checkanswers: {
       input: %w(),

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.1.1'.freeze
+  VERSION = '2.2.0'.freeze
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -161,6 +161,42 @@ RSpec.describe MetadataPresenter::Page do
     end
   end
 
+  describe '#standalone?' do
+    context 'when page is a standalone page' do
+      subject(:page) { service.find_page_by_url('cookies') }
+
+      it 'returns truthy' do
+        expect(page.standalone?).to be_truthy
+      end
+    end
+
+    context 'when page is not a standalone page' do
+      subject(:page) { service.find_page_by_url('name') }
+
+      it 'returns falsey' do
+        expect(page.standalone?).to be_falsey
+      end
+    end
+  end
+
+  describe '#question_page?' do
+    context 'when page has a question' do
+      subject(:page) { service.find_page_by_url('name') }
+
+      it 'returns truthy' do
+        expect(page.question_page?).to be_truthy
+      end
+    end
+
+    context 'when page does not have any questions' do
+      subject(:page) { service.find_page_by_url('confirmation') }
+
+      it 'returns falsey' do
+        expect(page.question_page?).to be_falsey
+      end
+    end
+  end
+
   describe '#title' do
     context 'when there is one component' do
       let(:page) { service.find_page_by_url('name') }

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -50,6 +50,29 @@ RSpec.describe MetadataPresenter::Page do
     end
   end
 
+  describe '#input_components' do
+    let(:page) { service.find_page_by_url('star-wars-knowledge') }
+    let(:expected_component_ids) { %w[star-wars-knowledge_text_1 star-wars-knowledge_radios_1] }
+
+    it 'returns an array of only components that take user input' do
+      component_ids = page.input_components.map(&:id)
+      expect(component_ids).to eq(expected_component_ids)
+      expect(component_ids).not_to include('star-wars-knowledge_content_1')
+    end
+  end
+
+  describe '#content_components' do
+    let(:page) { service.find_page_by_url('star-wars-knowledge') }
+
+    it 'returns an array of only content components' do
+      component_ids = page.content_components.map(&:id)
+      expect(component_ids).to eq(%w[star-wars-knowledge_content_1])
+      %w[star-wars-knowledge_text_1 star-wars-knowledge_radios_1].each do |id|
+        expect(component_ids).not_to include(id)
+      end
+    end
+  end
+
   describe '#editable_attributes' do
     it 'does not reject editable attributes' do
       expect(service.pages.first.editable_attributes.keys).to include(

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -85,12 +85,12 @@ RSpec.describe MetadataPresenter::Page do
     end
   end
 
-  describe '#input_components' do
+  describe '#supported_input_components' do
     context 'when page has input components' do
       subject(:page) { described_class.new(_type: 'page.multiplequestions') }
 
       it 'returns the correct input components' do
-        expect(page.input_components).to match_array(%w[text textarea number date radios checkboxes])
+        expect(page.supported_input_components).to match_array(%w[text textarea number date radios checkboxes])
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.describe MetadataPresenter::Page do
       subject(:page) { described_class.new(_type: 'page.checkanswers') }
 
       it 'returns an empty array' do
-        expect(page.input_components).to be_empty
+        expect(page.supported_input_components).to be_empty
       end
     end
 
@@ -107,18 +107,18 @@ RSpec.describe MetadataPresenter::Page do
 
       it 'raises a PageComponentsNotDefinedError' do
         expect {
-          page.input_components
+          page.supported_input_components
         }.to raise_error(MetadataPresenter::PageComponentsNotDefinedError)
       end
     end
   end
 
-  describe '#content_components' do
+  describe '#supported_content_components' do
     context 'when page has content components' do
       subject(:page) { described_class.new(_type: 'page.multiplequestions') }
 
       it 'returns the correct content components' do
-        expect(page.content_components).to match_array(%w[content])
+        expect(page.supported_content_components).to match_array(%w[content])
       end
     end
 
@@ -127,7 +127,7 @@ RSpec.describe MetadataPresenter::Page do
 
       it 'raises a PageComponentsNotDefinedError' do
         expect {
-          page.content_components
+          page.supported_content_components
         }.to raise_error(MetadataPresenter::PageComponentsNotDefinedError)
       end
     end

--- a/spec/presenters/page_answers_presenter_spec.rb
+++ b/spec/presenters/page_answers_presenter_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe MetadataPresenter::PageAnswersPresenter do
         service.find_page_by_url('/star-wars-knowledge')
       end
       let(:page_answers_count) do
-        page.components_by_type(:input).size
+        page.supported_components_by_type(:input).size
       end
 
       context 'when last question' do
@@ -211,7 +211,7 @@ RSpec.describe MetadataPresenter::PageAnswersPresenter do
         service.find_page_by_url('/burgers')
       end
       let(:page_answers_count) do
-        page.components_by_type(:input).size
+        page.supported_components_by_type(:input).size
       end
       let(:index) { 0 }
 


### PR DESCRIPTION
## Supported components

The previous input_components and content_components methods did not
return actual component objects but rather just an array of the strings
relating to the supported components for a given page.

Change the name of those methods to better reflect their actual
function.

## Check if page is a question page 

There are some needs for only getting pages which are actually a
singlequestion or mulitiplequestions page so add a method to do that.

## Input and content components

This re creates the input_comonents and content_component methods to
actually return component objects of those types


## 2.2.0