### PR TITLE
Surface flow object UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-## [2.2.0] - 2021-08-05
+## [2.3.1] - 2021-08-16
+
+### Added
+
+- Add flow_objects method to the service which returns all the service flow as MetadataPresenter::Flow objects
+
+### Changed
+
+- Surface the page uuid for the related flow object
+
+## [2.3.0] - 2021-08-09
 
 ### Added
 

--- a/app/models/metadata_presenter/flow.rb
+++ b/app/models/metadata_presenter/flow.rb
@@ -1,5 +1,13 @@
 module MetadataPresenter
   class Flow < MetadataPresenter::Metadata
+    attr_reader :uuid
+
+    def initialize(uuid, flow)
+      @uuid = uuid
+
+      super(flow)
+    end
+
     def branch?
       type == 'flow.branch'
     end

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -5,11 +5,12 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     end
   end
 
+  def flow_objects
+    flow.map { |uuid, flow| MetadataPresenter::Flow.new(uuid, flow) }
+  end
+
   def branches
-    collection = flow.map do |uuid, flow|
-      MetadataPresenter::Flow.new(uuid, flow)
-    end
-    collection.select { |flow| flow.type == 'flow.branch' }
+    flow_objects.select { |flow| flow.type == 'flow.branch' }
   end
 
   def flow_object(uuid)

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -6,14 +6,14 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
   end
 
   def branches
-    collection = flow.map do |_, flow|
-      MetadataPresenter::Flow.new(flow)
+    collection = flow.map do |uuid, flow|
+      MetadataPresenter::Flow.new(uuid, flow)
     end
     collection.select { |flow| flow.type == 'flow.branch' }
   end
 
   def flow_object(uuid)
-    MetadataPresenter::Flow.new(metadata.flow[uuid])
+    MetadataPresenter::Flow.new(uuid, metadata.flow[uuid])
   rescue StandardError
     nil
   end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.3.1'.freeze
 end

--- a/spec/models/flow_spec.rb
+++ b/spec/models/flow_spec.rb
@@ -2,8 +2,13 @@ RSpec.describe MetadataPresenter::Flow do
   let(:service_metadata) do
     metadata_fixture(:branching)
   end
-  subject(:flow) do
-    service.flow_object('cf6dc32f-502c-4215-8c27-1151a45735bb')
+  let(:uuid) { 'cf6dc32f-502c-4215-8c27-1151a45735bb' }
+  subject(:flow) { service.flow_object(uuid) }
+
+  describe '#uuid' do
+    it 'should return the uuid for a flow object' do
+      expect(flow.uuid).to eq(uuid)
+    end
   end
 
   describe '#branch?' do

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -46,8 +46,15 @@ RSpec.describe MetadataPresenter::Service do
     it 'returns an array of Flow objects' do
       expect(service.branches.size).to be > 1
       service.branches.each do |flow|
-        expect(flow).to be_kind_of(MetadataPresenter::Flow)
         expect(flow.type).to eq('flow.branch')
+      end
+    end
+  end
+
+  describe '#flow_objects' do
+    it 'returns the service flow as Flow objects' do
+      service.branches.each do |flow|
+        expect(flow).to be_kind_of(MetadataPresenter::Flow)
       end
     end
   end


### PR DESCRIPTION
## Surface flow object uuid

The MetadataPresenter::Flow object has no knowledge of the page uuid
that it is related to. This can be a useful thing to surface on the flow
object.

Initialize the flow object with the uuid which is used as the key for
the object in the service flow hash.

## Return service flow as Flow objects

This adds a method which may prove helpful when working on the future
pages flow.

Previously we were only returning branches as MetadataPresenter::Flow
objects. `flow_objects` returns all flow objects, including branches.

## Publish 2.3.1