### PR TITLE
Remove lede

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [2.3.2] - 2021-08-18
+
+### Changed
+
+- Remove lede from the start page metadata
+
 ## [2.3.1] - 2021-08-16
 
 ### Added

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -3,7 +3,6 @@
     <div class="govuk-grid-column-two-thirds">
 
       <%= render 'metadata_presenter/attribute/heading' %>
-      <%= render 'metadata_presenter/attribute/lede' %>
       <%= render 'metadata_presenter/attribute/body' %>
 
       <%= form_tag(root_path, method: :post) do %>

--- a/default_metadata/page/start.json
+++ b/default_metadata/page/start.json
@@ -2,7 +2,6 @@
   "_id": "page.start",
   "_type": "page.start",
   "heading": "Service name goes here",
-  "lede": "",
   "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
   "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally.",
   "url": "/"

--- a/fixtures/branching.json
+++ b/fixtures/branching.json
@@ -364,7 +364,6 @@
       "_id": "page.start",
       "url": "/",
       "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
-      "lede": "",
       "_type": "page.start",
       "_uuid": "cf6dc32f-502c-4215-8c27-1151a45735bb",
       "heading": "Service name goes here",

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -92,7 +92,6 @@
       "_id": "page.start",
       "url": "/",
       "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
-      "lede": "",
       "_type": "page.start",
       "_uuid": "cf6dc32f-502c-4215-8c27-1151a45735bb",
       "heading": "Service name goes here",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.3.1'.freeze
+  VERSION = '2.3.2'.freeze
 end

--- a/schemas/page/start.json
+++ b/schemas/page/start.json
@@ -28,7 +28,6 @@
   ],
   "ui_category": {
     "main": [
-      "lede",
       "body",
       "before_you_start"
     ]

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe MetadataPresenter::Page do
       expect(service.pages.first.editable_attributes.keys).to include(
         :heading,
         :body,
-        :lede,
         :url
       )
     end


### PR DESCRIPTION
### Remove lede from the start page
The lede is not used in the start page so we have removed it from the `start.html.erb`, the default metadata, fixtures and the start page schema

### Bump to 2.3.2