### PR TITLE
Expression memoization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-## [2.3.2] - 2021-08-20
+## [2.3.4] - 2021-08-24
+
+### Changed
+
+- Memoize the Page and Component inside Expression objects
+
+## [2.3.3] - 2021-08-20
 
 ### Added
 

--- a/app/models/metadata_presenter/expression.rb
+++ b/app/models/metadata_presenter/expression.rb
@@ -7,11 +7,11 @@ module MetadataPresenter
     end
 
     def expression_page
-      service.find_page_by_uuid(page)
+      @expression_page ||= service.find_page_by_uuid(page)
     end
 
     def expression_component
-      expression_page.find_component_by_uuid(component)
+      @expression_component ||= expression_page.find_component_by_uuid(component)
     end
 
     def expression_field

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.3.3'.freeze
+  VERSION = '2.3.4'.freeze
 end


### PR DESCRIPTION
This is a small performance related change. There is no need to go and
keep looking up the Page object and the Component object once they have
been found previously.

There are times when we make several calls to find the item and label
for a given expression so this should save a few micro seconds of lookup
time.