### PR TITLE
Fix spacing on check your answers page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [2.3.5] - 2021-08-31
+
+### Changed
+
+- Fix spacing on 'Check your answers' page
+
 ## [2.3.4] - 2021-08-24
 
 ### Changed

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -67,7 +67,7 @@
         <% end %>
 
         <% if @page.send_body.present? %>
-          <div class="fb-send-body fb-editable"
+          <div class="fb-send-body fb-editable govuk-body"
                data-fb-content-type="content"
                data-fb-content-id="page[send_body]">
             <%= @page.send_body %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.3.4'.freeze
+  VERSION = '2.3.5'.freeze
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/fpVp6foD/1861-spacing-looks-off-on-check-answers-page-bug-backlog-priority-score-5)

### Before
![Screenshot 2021-08-31 at 12 35 20](https://user-images.githubusercontent.com/29227502/131495643-2ece58f2-2da7-467a-93b6-5e9c1b5bdb79.png)

### After
![Screenshot 2021-08-31 at 12 28 41](https://user-images.githubusercontent.com/29227502/131495657-2903692b-41b4-4d43-9ee3-f8d3d5d39b72.png)
