### PR TITLE
Fix start page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+## [2.3.6] - 2021-09-01
+
+### Changed
+
+- Fix 'Before you start' section on Start page so the content is editable and retrievable.
+
 ## [2.3.5] - 2021-08-31
 
 ### Changed

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -17,7 +17,8 @@
       <% if @page.before_you_start %>
         <div class="fb-editable"
              data-fb-content-id="page[before_you_start]"
-             data-fb-content-type="content">
+             data-fb-content-type="content"
+             data-fb-default-text="<%= default_text('before_you_start') %>">
           <%= to_html(@page.before_you_start) %>
         </div>
       <%- end %>

--- a/default_text/content.json
+++ b/default_text/content.json
@@ -6,5 +6,6 @@
   "hint": "[Optional hint text]",
   "option": "Option",
   "option_hint": "[Optional hint text]",
-  "upload_hint": "Maximum file size is 7MB"
+  "upload_hint": "Maximum file size is 7MB",
+  "before_you_start": "[Optional content]"
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.3.5'.freeze
+  VERSION = '2.3.6'.freeze
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/7dRdGxot/1095-once-you-delete-section-below-start-now-button-it-cannot-be-retrieved-bug-backlog-priority-order-10)

The `before_you_start` section of the page is lost when it is deleted.
This should not happen, instead this should be an optional content component.