### PR TITLE
Change your answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+## [2.4.0] - 2021-09-07
+
+### Added
+
+- Add change your answers feature
+
 ### Changed
 
 ## [2.3.6] - 2021-09-01

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -3,6 +3,7 @@ module MetadataPresenter
     before_action :check_page_exists
 
     def create
+      @previous_answers = reload_user_data.deep_dup
       @page_answers = PageAnswers.new(page, answers_params)
 
       upload_files if upload?
@@ -28,8 +29,9 @@ module MetadataPresenter
       next_page = NextPage.new(
         service: service,
         session: session,
-        user_data: load_user_data,
-        current_page_url: page_url
+        user_data: reload_user_data,
+        current_page_url: page_url,
+        previous_answers: @previous_answers
       ).find
 
       if next_page.present?

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -5,6 +5,14 @@ module MetadataPresenter
     helper MetadataPresenter::ApplicationHelper
     default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
+    def reload_user_data
+      if defined? super
+        super
+      else
+        load_user_data
+      end
+    end
+
     def back_link
       previous_page = PreviousPage.new(
         service: service,

--- a/app/models/metadata_presenter/next_page.rb
+++ b/app/models/metadata_presenter/next_page.rb
@@ -1,7 +1,7 @@
 module MetadataPresenter
   class NextPage
     include ActiveModel::Model
-    attr_accessor :service, :session, :user_data, :current_page_url
+    attr_accessor :service, :session, :user_data, :current_page_url, :previous_answers
 
     def find
       return check_answers_page if return_to_check_your_answer?
@@ -11,17 +11,53 @@ module MetadataPresenter
       else
         service.find_page_by_uuid(current_page_flow.default_next)
       end
+    ensure
+      session[:return_to_check_your_answer] = nil
     end
 
     private
 
     def check_answers_page
-      session[:return_to_check_your_answer] = nil
       service.pages.find { |page| page.type == 'page.checkanswers' }
     end
 
     def return_to_check_your_answer?
-      session[:return_to_check_your_answer].present?
+      session[:return_to_check_your_answer].present? &&
+        components_not_used_for_branching_and_answers_unchanged?
+    end
+
+    def components_not_used_for_branching_and_answers_unchanged?
+      components_not_used_for_branching? && answers_unchanged?
+    end
+
+    def components_not_used_for_branching?
+      expressions.none? { |expression| component_ids.include?(expression) }
+    end
+
+    def answers_unchanged?
+      components = current_page_components.select do |component|
+        component.uuid.in?(expressions.map(&:component))
+      end
+
+      components.all? do |component|
+        user_data[component.id] == previous_answers[component.id]
+      end
+    end
+
+    def component_ids
+      current_page_components.map(&:id)
+    end
+
+    def current_page_components
+      current_page.components
+    end
+
+    def expressions
+      collection = service.branches.map do |branch|
+        branch.conditionals.map(&:expressions)
+      end
+
+      collection.flatten
     end
 
     def conditionals?

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.3.6'.freeze
+  VERSION = '2.4.0'.freeze
 end

--- a/spec/models/next_page_spec.rb
+++ b/spec/models/next_page_spec.rb
@@ -66,10 +66,12 @@ RSpec.describe MetadataPresenter::NextPage do
       service: service,
       session: session,
       user_data: user_data,
-      current_page_url: current_page_url
+      current_page_url: current_page_url,
+      previous_answers: previous_answers
     )
   end
   let(:user_data) { {} }
+  let(:previous_answers) { nil }
 
   describe '#find' do
     subject(:result) do
@@ -78,19 +80,76 @@ RSpec.describe MetadataPresenter::NextPage do
 
     include_context 'branching flow'
 
-    context 'when user should return to check your answer' do
-      let(:session) { { return_to_check_your_answer: true } }
-      let(:current_page_url) { '' }
-
-      it 'returns check your answer page' do
-        expect(result).to eq(
-          MetadataPresenter::Page.new(_id: 'page.check-answers')
-        )
+    context 'when user wants to change their answer' do
+      let(:session) do
+        { return_to_check_your_answer: true }
       end
 
-      it 'set the session as nil' do
-        result
-        expect(session).to eq({ return_to_check_your_answer: nil })
+      context 'when there is no conditions depending on the page' do
+        let(:current_page_url) { 'name' }
+
+        it 'returns check your answer page' do
+          expect(result).to eq(
+            MetadataPresenter::Page.new(_id: 'page.check-answers')
+          )
+        end
+
+        it 'set the session as nil' do
+          result
+          expect(session).to eq({ return_to_check_your_answer: nil })
+        end
+      end
+
+      context 'when there is conditions depending on the answered page' do
+        context 'when the answer is changed' do
+          let(:previous_answers) do
+            {
+              'favourite-fruit_radios_1' => 'Apples'
+            }
+          end
+          let(:user_data) do
+            {
+              'favourite-fruit_radios_1' => 'Oranges'
+            }
+          end
+          let(:session) do
+            {
+              return_to_check_your_answer: true
+            }
+          end
+          let(:current_page_url) { 'favourite-fruit' }
+
+          it 'returns the next evaluated page (now branching has changed)' do
+            expect(result).to eq(
+              MetadataPresenter::Page.new(_id: 'page.orange-juice')
+            )
+          end
+        end
+
+        context 'when the answer is the same' do
+          let(:previous_answers) do
+            {
+              'favourite-fruit_radios_1' => 'Apples'
+            }
+          end
+          let(:user_data) do
+            {
+              'favourite-fruit_radios_1' => 'Apples'
+            }
+          end
+          let(:session) do
+            {
+              return_to_check_your_answer: true
+            }
+          end
+          let(:current_page_url) { 'favourite-fruit' }
+
+          it 'return to check your answers page' do
+            expect(result).to eq(
+              MetadataPresenter::Page.new(_id: 'page.check-answers')
+            )
+          end
+        end
       end
     end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/BmH2CAqX/1868-updated-branch-flow-cya-logic-for-branching-specific-questions)

## Change answers

This PR adds the change your answer feature.

## Explanations of what it was done

Regular question page: changing an answer on a non-branching page will jump the user back to the CYA page when they submit their updated answer.

Branching question page: changing a branching question will require the user to follow a new branch, enter information for the branch-specific question(s) and then back through the journey with all questions previously answered pre-populated for them to click through. 

Returning to a previously completed branch:  if a user then jumps back to a previous branch their answers are remembered. They can update as desired and then they traverse back through the form with all previous answers pre-populated but they are required to click back through the journey. 

Check Your Answers page: a user should only see the data related to their most recent journey e.g. if they’ve changed their answers 3x only the answers pertaining to Journey 3 should be displayed. 

Returning to a branching question page and keeping the same answer: if a user keeps the same answer on a page with branching then they should go straight back to the Check Your Answers page.