### PR TITLE
Multiplequestions page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+## [2.4.1] - 2021-09-09
+
+### Changed
+
+- Use multiplequestions page title even when there is only one component
+
 ## [2.4.0] - 2021-09-07
 
 ### Added

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -13,6 +13,12 @@ module MetadataPresenter
       add_extra_component
     ].freeze
     QUESTION_PAGES = %w[page.singlequestion page.multiplequestions].freeze
+    USES_HEADING = %w[
+      page.content
+      page.checkanswers
+      page.confirmation
+      page.multiplequestions
+    ].freeze
 
     def editable_attributes
       to_h.reject { |k, _| k.in?(NOT_EDITABLE) }
@@ -87,8 +93,7 @@ module MetadataPresenter
     private
 
     def heading?
-      Array(components).size != 1 ||
-        type.in?(['page.content', 'page.checkanswers', 'page.confirmation'])
+      type.in?(USES_HEADING) || Array(components).size != 1
     end
 
     def to_components(node_components, collection:)

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.4.0'.freeze
+  VERSION = '2.4.1'.freeze
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -236,6 +236,18 @@ RSpec.describe MetadataPresenter::Page do
       end
     end
 
+    context 'when multiplequestions page with single component' do
+      let(:page) do
+        page_metadata = service_metadata['pages'].find { |page| page['url'] == 'star-wars-knowledge' }
+        page_metadata['components'] = [page_metadata['components'].shift]
+        MetadataPresenter::Page.new(page_metadata)
+      end
+
+      it 'returns the page title not the component title' do
+        expect(page.title).to eq('How well do you know Star Wars?')
+      end
+    end
+
     context 'when the page is a content page' do
       let(:page) { service.find_page_by_url('how-many-lights') }
 


### PR DESCRIPTION
Multiplequestions pages can have one or more components. However the
actual title of the page is what we would like to use even when there is
only one component.

Publish 2.4.1