### PR TITLE
Update branching fixture name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.5.1] - 2021-09-28
+
+### Changed
+
+- Do not build the ordered flow twice
+
+### Fixed
+
+-  Update the Branching fixture names for 7 and 8
+
 ## [2.5.0] - 2021-09-28
 
 ### Added

--- a/app/models/metadata_presenter/grid.rb
+++ b/app/models/metadata_presenter/grid.rb
@@ -14,21 +14,21 @@ module MetadataPresenter
     ROW_ZERO = 0
 
     def build
+      return @ordered unless @ordered.empty?
+
       @ordered = make_grid
       add_columns
       add_rows
       add_by_coordinates
-      trim_spacers
       insert_expression_spacers
+      trim_spacers
 
       @ordered
     end
 
     def ordered_flow
-      @ordered_flow ||= begin
-        flow = @ordered.empty? ? build.flatten : @ordered.flatten
-        flow.reject { |obj| obj.is_a?(MetadataPresenter::Spacer) }
-      end
+      @ordered_flow ||=
+        build.flatten.reject { |obj| obj.is_a?(MetadataPresenter::Spacer) }
     end
 
     def ordered_pages

--- a/fixtures/branching_7.json
+++ b/fixtures/branching_7.json
@@ -148,7 +148,7 @@
       "body": "Start page body",
       "_type": "page.start",
       "_uuid": "cf6dc32f-502c-4215-8c27-1151a45735bb",
-      "heading": "Branching Fixture 4",
+      "heading": "Branching Fixture 7",
       "before_you_start": "Start page before you start"
     },
     {
@@ -559,7 +559,7 @@
   "created_by": "099d5bf5-5f7b-444c-86ee-9e189cc1a369",
   "service_id": "ea3bfb09-fc6d-4464-b025-9d6aadafc593",
   "version_id": "429a8039-75b3-42b8-84dc-230fb371c71d",
-  "service_name": "Branching Fixture 4",
+  "service_name": "Branching Fixture 7",
   "configuration": {
     "meta": {
       "_id": "config.meta",

--- a/fixtures/branching_8.json
+++ b/fixtures/branching_8.json
@@ -142,7 +142,7 @@
       "body": "Start page body",
       "_type": "page.start",
       "_uuid": "cf6dc32f-502c-4215-8c27-1151a45735bb",
-      "heading": "Branching Fixture 4",
+      "heading": "Branching Fixture 8",
       "before_you_start": "Start page before you start"
     },
     {
@@ -497,7 +497,7 @@
   "created_by": "099d5bf5-5f7b-444c-86ee-9e189cc1a369",
   "service_id": "ea3bfb09-fc6d-4464-b025-9d6aadafc593",
   "version_id": "429a8039-75b3-42b8-84dc-230fb371c71d",
-  "service_name": "Branching Fixture 4",
+  "service_name": "Branching Fixture 8",
   "configuration": {
     "meta": {
       "_id": "config.meta",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.5.1'.freeze
 end


### PR DESCRIPTION
## Return the ordered flow if it has already been built

There is no need to try and build the flow again. In fact if it does
attempt to do so it can potentially break the flow.

## Correctly name the branching fixtures

## 2.5.1