### PR TITLE
Exit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.6.0] - 2021-10-01
+
+### Added
+
+- Exit page schemas and default metadata
+
 ## [2.5.1] - 2021-09-28
 
 ### Changed

--- a/app/views/metadata_presenter/page/exit.html.erb
+++ b/app/views/metadata_presenter/page/exit.html.erb
@@ -1,0 +1,29 @@
+<div class="fb-main-grid-wrapper" data-fb-pagetype="<%= @page.type %>">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <%= render 'metadata_presenter/attribute/section_heading' %>
+
+      <h1 class="fb-editable govuk-heading-xl"
+          data-fb-content-id="page[heading]"
+          data-fb-content-type="element">
+        <%= @page.heading %>
+      </h1>
+
+      <%= render 'metadata_presenter/attribute/lede' %>
+
+      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
+
+        <%= render partial: 'metadata_presenter/component/components',
+                   locals: {
+                     f: f,
+                     components: @page.components,
+                     tag: nil,
+                     classes: nil,
+                     input_components: @page.supported_input_components,
+                     content_components: @page.supported_content_components
+                   } %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/initializers/supported_components.rb
+++ b/config/initializers/supported_components.rb
@@ -12,6 +12,10 @@ Rails.application.config.supported_components =
       input: %w(),
       content: %w(content)
     },
+    exit: {
+      input: %w(),
+      content: %w(content)
+    },
     multiplequestions: {
       input: %w(text textarea number date radios checkboxes),
       content: %w(content)

--- a/default_metadata/page/exit.json
+++ b/default_metadata/page/exit.json
@@ -1,0 +1,9 @@
+{
+  "_id": "page.exit",
+  "_type": "page.exit",
+  "section_heading": "",
+  "heading": "Title",
+  "lede": "",
+  "components": [],
+  "url": ""
+}

--- a/fixtures/branching_7.json
+++ b/fixtures/branching_7.json
@@ -329,28 +329,20 @@
     {
       "_id": "page.g",
       "url": "page-g",
-      "body": "Page G body",
-      "lede": "",
-      "_type": "page.singlequestion",
+      "lede": "lede",
+      "_type": "page.exit",
       "_uuid": "3a584d15-6805-4a21-bc05-b61c3be47857",
       "heading": "Page G",
       "components": [
         {
-          "_id": "page-g_text_1",
-          "hint": "",
-          "name": "page-g_text_1",
-          "_type": "text",
-          "_uuid": "fa91e9cd-d935-4c15-bd92-5b6fafd81a91",
-          "label": "Page G",
-          "errors": {},
-          "collection": "components",
-          "validation": {
-            "required": true,
-            "max_length": 20,
-            "min_length": 2
-          }
+          "_id": "exit_content_1",
+          "name": "exit_content_1",
+          "_type": "content",
+          "_uuid": "9774d986-135a-4b7f-924d-7527b790e1a0",
+          "content": "This is an exit page"
         }
-      ]
+      ],
+      "section_heading": "Section heading"
     },
     {
       "_id": "page.h",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.5.1'.freeze
+  VERSION = '2.6.0'.freeze
 end

--- a/schemas/page/exit.json
+++ b/schemas/page/exit.json
@@ -1,0 +1,25 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/page/exit",
+  "_name": "page.exit",
+  "title": "Exit",
+  "description": "Display an exit page to users when they cannot proceed",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "page.exit"
+    },
+    "components": {
+      "title": "Content",
+      "description": "The form or content elements used on the page",
+      "type": "array",
+      "items": {
+        "$ref": "component.content"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.page.content"
+    }
+  ]
+}


### PR DESCRIPTION
[Trello](https://trello.com/c/f4UxmcVG/1962-be-creation-of-exit-page-templates-schemas-and-default-metadata)

### Exit pages
- Add exit page schema
- Add exit page default metadata
- Add exit page template
- Add exit page component to the support components
- Update branching 7 fixture to use exit page on 'Page G'

### 2.6.0

### Example exit page on Runner

![Screenshot 2021-10-01 at 11 14 12](https://user-images.githubusercontent.com/29227502/135605474-379a39ff-d9e8-42fc-ae73-ccd1026b1753.png)

