### PR TITLE
Fix exit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.6.1] - 2021-10-05
+
+### Fixed
+
+- Ensure the correct titles are used for exit pages
 ## [2.6.0] - 2021-10-01
 
 ### Added

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -18,6 +18,7 @@ module MetadataPresenter
       page.checkanswers
       page.confirmation
       page.multiplequestions
+      page.exit
     ].freeze
 
     def editable_attributes

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.6.1'.freeze
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -271,5 +271,15 @@ RSpec.describe MetadataPresenter::Page do
         expect(page.title).to eq('Service name goes here')
       end
     end
+
+    context 'when page is an exit page' do
+      let(:latest_metadata) { metadata_fixture(:branching_7) }
+      let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+      let(:page) { service.find_page_by_url('page-g') }
+
+      it 'returns the correct title' do
+        expect(page.title).to eq('Page G')
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/f4UxmcVG/1962-be-creation-of-exit-page-templates-schemas-and-default-metadata)

### Exit page titles
Ensure the correct title is used for exit pages.
This is important as the title of a page is used in the flow view.

### Bump version 2.6.1