### PR TITLE
Add utility methods to the service object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.7.0] - 2021-10-07
+
+- Add MetadataPresenter::Service#conditionals that returns *all* conditionals
+in the metadata
+- Add MetadataPresenter::Service#expressions that returns *all* expressions
 
 ## [2.6.2] - 2021-10-05
 

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -13,6 +13,14 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     flow_objects.select { |flow| flow.type == 'flow.branch' }
   end
 
+  def expressions
+    conditionals.map(&:expressions).flatten
+  end
+
+  def conditionals
+    branches.map(&:conditionals).flatten
+  end
+
   def flow_object(uuid)
     MetadataPresenter::Flow.new(uuid, metadata.flow[uuid])
   rescue StandardError

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.6.2'.freeze
+  VERSION = '2.7.0'.freeze
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -59,6 +59,30 @@ RSpec.describe MetadataPresenter::Service do
     end
   end
 
+  describe '#expressions' do
+    let(:service_metadata) { metadata_fixture(:branching_2) }
+
+    it 'returns all expressions in the flow' do
+      expect(service.expressions.size).to be(3)
+
+      service.expressions.each do |expression|
+        expect(expression).to be_kind_of(MetadataPresenter::Expression)
+      end
+    end
+  end
+
+  describe '#conditionals' do
+    let(:service_metadata) { metadata_fixture(:branching_3) }
+
+    it 'returns all conditionals in the flow' do
+      expect(service.conditionals.size).to be(2)
+
+      service.conditionals.each do |conditional|
+        expect(conditional).to be_kind_of(MetadataPresenter::Conditional)
+      end
+    end
+  end
+
   describe '#find_page_by_url' do
     subject(:page) { service.find_page_by_url(path) }
 


### PR DESCRIPTION
There will be times that we need to check all conditionals in the form
or we need to check all expressions in the form (like when we
delete pages we should check if there is any conditional for that page,
etc).

This commit adds those methods to dry up in the other places where its
used.

This will DRY these two classes: 
https://github.com/ministryofjustice/fb-editor/compare/pages/delete-modals?expand=1#diff-372384c3fb21598b080049c5c230e03d77c460f09f74b936f0e7ba5a4bc07f6fR62
https://github.com/ministryofjustice/fb-editor/compare/pages/delete-modals?expand=1#diff-24b3e2ad830a5eab925146282286b2746d6e2f65c3b1617b092ade3e8786759bR17
