### PR TITLE
End of route pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+### Added
+## [2.7.0] - 2021-10-08
+
+- Add methods to check if the page is the last page in a route.
+- This helps determine whether we allow adding of pages or branches,
+or changes of destination from these pages.
+
+### Added
 ## [2.7.0] - 2021-10-07
 
 - Add MetadataPresenter::Service#conditionals that returns *all* conditionals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 ### Added
-## [2.7.0] - 2021-10-08
+## [2.7.1] - 2021-10-08
 
 - Add methods to check if the page is the last page in a route.
 - This helps determine whether we allow adding of pages or branches,

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -20,6 +20,11 @@ module MetadataPresenter
       page.multiplequestions
       page.exit
     ].freeze
+    END_OF_ROUTE_PAGES = %w[
+      page.checkanswers
+      page.confirmation
+      page.exit
+    ].freeze
 
     def editable_attributes
       to_h.reject { |k, _| k.in?(NOT_EDITABLE) }
@@ -89,6 +94,10 @@ module MetadataPresenter
       return heading if heading?
 
       components.first.humanised_title
+    end
+
+    def end_of_route?
+      type.in?(END_OF_ROUTE_PAGES)
     end
 
     private

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.7.0'.freeze
+  VERSION = '2.7.1'.freeze
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -282,4 +282,22 @@ RSpec.describe MetadataPresenter::Page do
       end
     end
   end
+
+  describe '#end_of_route?' do
+    context 'when the page is not the end of the route' do
+      let(:page) { service.find_page_by_url('how-many-lights') }
+
+      it 'returns falsey' do
+        expect(page.end_of_route?).to be_falsey
+      end
+    end
+
+    context 'when the page is the end of the route' do
+      let(:page) { service.find_page_by_url('confirmation') }
+
+      it 'returns truthy' do
+        expect(page.end_of_route?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/TdlTyeGt/1979-bug-remove-add-branching-option-from-exit-confirmation-and-check-your-answer-pages)

### Add end of route pages
Add method to determine pages that are at the end of a route.
This will help determine whether a user can add a page, add a branch or change a destination from these pages.

### Bump version 2.7.1