### PR TITLE
Service name validation revisited

### DIFF
--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -38,7 +38,7 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
   end
 
   def service_slug
-    service_name.parameterize
+    service_name.gsub(/['’]/, '').parameterize
   end
 
   def find_page_by_url(url)

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.11.0'.freeze
+  VERSION = '2.12.0'.freeze
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe MetadataPresenter::Service do
         'grogu' => 'grogu',
         'Darth Vader' => 'darth-vader',
         'emperor-palpatine' => 'emperor-palpatine',
-        'princess Leia' => 'princess-leia'
+        'princess Leia' => 'princess-leia',
+        "Darth Vader Children's" => 'darth-vader-childrens',
+        'Darth Vader Children’s' => 'darth-vader-childrens'
       }
     end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/gEognZYS/2133-allow-special-characters-like-apostrophe-in-the-form-name)

## Context

We need to accept service names with single quotes/apostrophe so adding specs to make sure the slugs are generated as expected