### PR TITLE
Update flow object row based on branch spacers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.14.1] - 2021-12-20
+
+### Added
+
+- Adjust row numbers for objects to match their corresponding Spacer row from the directly previous column
+
 ## [2.14.0] - 2021-12-20
 
 ### Added

--- a/app/models/metadata_presenter/column_number.rb
+++ b/app/models/metadata_presenter/column_number.rb
@@ -9,6 +9,10 @@ module MetadataPresenter
 
     def number
       if service.flow_object(uuid).branch?
+        # Even though we are associating the column number to a specific flow object
+        # in the Coordinates model we do not use column_number + 1 as we are
+        # updating the position for the Spacers that exist for a branch which
+        # are always in the same column as the branch object itself.
         coordinates.set_branch_spacers_column(uuid, column_number)
       end
 

--- a/app/models/metadata_presenter/coordinates.rb
+++ b/app/models/metadata_presenter/coordinates.rb
@@ -39,7 +39,7 @@ module MetadataPresenter
     end
 
     def set_branch_spacers_column(branch_uuid, column)
-      branch_spacers[branch_uuid].each do |position|
+      branch_spacers[branch_uuid].each do |_, position|
         position[:column] = column
       end
     end
@@ -50,7 +50,7 @@ module MetadataPresenter
     # to draw an arrow therefore we increment the row number from the branches
     # calculated starting row
     def set_branch_spacers_row(branch_uuid, starting_row)
-      branch_spacers[branch_uuid].each.with_index(starting_row) do |position, row|
+      branch_spacers[branch_uuid].each.with_index(starting_row) do |(_, position), row|
         position[:row] = row
       end
     end
@@ -64,12 +64,14 @@ module MetadataPresenter
       service.flow.keys.index_with { |_uuid| { row: nil, column: nil } }
     end
 
-    # This also takes into account the 'or' expressions which
+    # This also takes into account the 'OR' expressions which
     # need an additional line for an arrow.
     def setup_branch_spacers
       service.branches.each.with_object({}) do |branch, hash|
         destinations = exiting_destinations_from_branch(branch)
-        hash[branch.uuid] = destinations.map { { row: nil, column: nil } }
+        hash[branch.uuid] = destinations.index_with do |_uuid|
+          { row: nil, column: nil }
+        end
       end
     end
   end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.14.0'.freeze
+  VERSION = '2.14.1'.freeze
 end

--- a/spec/models/coordinates_spec.rb
+++ b/spec/models/coordinates_spec.rb
@@ -113,20 +113,11 @@ RSpec.describe MetadataPresenter::Coordinates do
     let(:uuid) { 'a02f7073-ba5a-459d-b6b9-abe548c933a6' } # Branching Point 2
     let(:positions) { { uuid => { row: nil, column: 10 } } }
     let(:expected_branch_spacers) do
-      [
-        {
-          row: nil,
-          column: 10
-        },
-        {
-          row: nil,
-          column: 10
-        },
-        {
-          row: nil,
-          column: 10
-        }
-      ]
+      {
+        '1314e473-9096-4434-8526-03a7b4b7b132' => { row: nil, column: 10 },
+        'da2576f9-7ddd-4316-b24b-103708139214' => { row: nil, column: 10 },
+        '7742dfcc-db2e-480b-9071-294fbe1769a2' => { row: nil, column: 10 }
+      }
     end
     before do
       allow_any_instance_of(MetadataPresenter::Coordinates).to receive(
@@ -144,28 +135,13 @@ RSpec.describe MetadataPresenter::Coordinates do
     let(:uuid) { '7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1' } # Branching Point 4
     let(:positions) { { uuid => { row: 0, column: 10 } } }
     let(:expected_branch_spacers) do
-      [
-        {
-          row: 0,
-          column: nil
-        },
-        {
-          row: 1,
-          column: nil
-        },
-        {
-          row: 2,
-          column: nil
-        },
-        {
-          row: 3,
-          column: nil
-        },
-        {
-          row: 4,
-          column: nil
-        }
-      ]
+      {
+        'ced77b4d-efb5-4d07-b38b-2be9e09a73df' => { row: 0, column: nil },
+        '46693db1-8995-4af0-a2d1-316140a5fb32' => { row: 1, column: nil },
+        'c01ae632-1533-4ee3-8828-a0c547200129' => { row: 2, column: nil },
+        'ad011e6b-5926-42f8-8b7c-668558850c52' => { row: 3, column: nil },
+        'da2576f9-7ddd-4316-b24b-103708139214' => { row: 4, column: nil }
+      }
     end
 
     it 'increments the row number for each consecutive branch spacer' do

--- a/spec/models/grid_spec.rb
+++ b/spec/models/grid_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe MetadataPresenter::Grid do
           let(:expected_column_7) do
             [
               MetadataPresenter::Spacer.new,
+              MetadataPresenter::Spacer.new,
               service.flow_object('be130ac1-f33d-4845-807d-89b23b90d205'), # Page K
               service.flow_object('3a584d15-6805-4a21-bc05-b61c3be47857') # Page G
             ]
@@ -127,11 +128,13 @@ RSpec.describe MetadataPresenter::Grid do
             [
               MetadataPresenter::Spacer.new,
               MetadataPresenter::Spacer.new,
+              MetadataPresenter::Spacer.new,
               service.flow_object('2c7deb33-19eb-4569-86d6-462e3d828d87') # Page L
             ]
           end
           let(:expected_column_9) do
             [
+              MetadataPresenter::Spacer.new,
               MetadataPresenter::Spacer.new,
               MetadataPresenter::Spacer.new,
               service.flow_object('d80a2225-63c3-4944-873f-504b61311a15') # Page M

--- a/spec/models/row_number_spec.rb
+++ b/spec/models/row_number_spec.rb
@@ -77,16 +77,16 @@ RSpec.describe MetadataPresenter::RowNumber do
         end
         let(:branch_spacers) do
           {
-            branching_point_5 => [
-              { row: 0, column: 6 },
-              { row: 1, column: 6 },
-              { row: 2, column: 6 }
-            ],
-            uuid => [
-              { row: nil, column: 6 },
-              { row: nil, column: 6 },
-              { row: nil, column: 6 }
-            ]
+            branching_point_5 => {
+              '007f4f35-8236-40cc-866c-cc2c27c33949' => { row: 0, column: 6 },
+              '7742dfcc-db2e-480b-9071-294fbe1769a2' => { row: 1, column: 6 },
+              'da2576f9-7ddd-4316-b24b-103708139214' => { row: 2, column: 6 }
+            },
+            uuid => {
+              '1314e473-9096-4434-8526-03a7b4b7b132' => { row: nil, column: 6 },
+              'da2576f9-7ddd-4316-b24b-103708139214' => { row: nil, column: 6 },
+              '7742dfcc-db2e-480b-9071-294fbe1769a2' => { row: nil, column: 6 }
+            }
           }
         end
 
@@ -112,13 +112,13 @@ RSpec.describe MetadataPresenter::RowNumber do
         end
         let(:branch_spacers) do
           {
-            branching_point_4 => [
-              { row: 0, column: 9 },
-              { row: 1, column: 9 },
-              { row: 2, column: 9 },
-              { row: 3, column: 9 },
-              { row: 4, column: 9 }
-            ]
+            branching_point_4 => {
+              'ced77b4d-efb5-4d07-b38b-2be9e09a73df' => { row: 0, column: 9 },
+              '46693db1-8995-4af0-a2d1-316140a5fb32' => { row: 1, column: 9 },
+              'c01ae632-1533-4ee3-8828-a0c547200129' => { row: 2, column: 9 },
+              'ad011e6b-5926-42f8-8b7c-668558850c52' => { row: 3, column: 9 },
+              'da2576f9-7ddd-4316-b24b-103708139214' => { row: 4, column: 9 }
+            }
           }
         end
 
@@ -182,25 +182,54 @@ RSpec.describe MetadataPresenter::RowNumber do
       end
       let(:branch_spacers) do
         {
-          branching_point_5 => [
-            { row: 0, column: 6 },
-            { row: 1, column: 6 },
-            { row: 2, column: 6 }
-          ],
-          branching_point_2 => [
-            { row: 3, column: 6 },
-            { row: 4, column: 6 },
-            { row: 5, column: 6 }
-          ],
-          uuid => [
-            { row: nil, column: 6 },
-            { row: nil, column: 6 }
-          ]
+          branching_point_5 => {
+            '007f4f35-8236-40cc-866c-cc2c27c33949' => { row: 0, column: 6 },
+            '7742dfcc-db2e-480b-9071-294fbe1769a2' => { row: 1, column: 6 },
+            'da2576f9-7ddd-4316-b24b-103708139214' => { row: 2, column: 6 }
+          },
+          branching_point_2 => {
+            '1314e473-9096-4434-8526-03a7b4b7b132' => { row: 3, column: 6 },
+            'da2576f9-7ddd-4316-b24b-103708139214' => { row: 4, column: 6 },
+            '7742dfcc-db2e-480b-9071-294fbe1769a2' => { row: 5, column: 6 }
+          },
+          uuid => {
+            '79c18654-7ecb-43f9-bd7f-0b09eb9c075e' => { row: nil, column: 6 },
+            'da2576f9-7ddd-4316-b24b-103708139214' => { row: nil, column: 6 }
+          }
         }
       end
 
       it 'finds the next available row leaving space for branch destinations above' do
         expect(row_number.number).to eq(6)
+      end
+    end
+
+    context 'when the object is linked to in the previous column by a branch' do
+      let(:latest_metadata) { metadata_fixture(:branching_8) }
+      let(:uuid) { 'be130ac1-f33d-4845-807d-89b23b90d205' } # Page K
+      let(:branching_point_2) { 'ffadeb22-063b-4e4f-9502-bd753c706b1d' }
+      let(:page_f) { '957e523e-663f-4cc9-9e8a-36b15bcbcaec' }
+      let(:route) { double(row: 1) }
+      let(:current_row) { 1 }
+      let(:positions) do
+        {
+          page_f => { row: 0, column: 6 }, # Page F
+          branching_point_2 => { column: 6, row: 1 },
+          uuid => { column: 7, row: nil }
+        }
+      end
+      let(:branch_spacers) do
+        {
+          branching_point_2 => {
+            page_f => { row: 0, column: 6 },
+            uuid => { row: 2, column: 7 },
+            '3a584d15-6805-4a21-bc05-b61c3be47857' => { row: 3, column: 7 }
+          }
+        }
+      end
+
+      it 'returns the row that was previously calculated for object' do
+        expect(row_number.number).to eq(2)
       end
     end
 


### PR DESCRIPTION
When a branch object row is calculated we also calculate the positions
of the required Spacer objects that have to go below it in the grid.

Now we associate those Spacers to a specific object UUID. Doing this
enables us to check whether the objects in the column following a branch
need to be moved to a higher row.

The Spacers for each branch are used to hold the text associated with
any conditional logic question and answer which dictates the visual
flow. If we did not update the row numbers then this can lead to objects
being left on rows further up the page.

Publish 2.14.1