### PR TITLE
Check detached submitting pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.15.1] - 2021-01-07
+
+### Added
+
+- Added a page warning model to check whether the submitting pages will detached from the main flow
+
 ## [2.15.0] - 2021-12-30
 
 ### Changed

--- a/app/models/metadata_presenter/grid.rb
+++ b/app/models/metadata_presenter/grid.rb
@@ -19,7 +19,7 @@ module MetadataPresenter
 
   class Grid
     include BranchDestinations
-    attr_reader :start_from
+    attr_reader :service, :start_from
 
     def initialize(service, start_from: nil, main_flow: [])
       @service = service
@@ -73,7 +73,7 @@ module MetadataPresenter
 
     private
 
-    attr_reader :service, :main_flow
+    attr_reader :main_flow
     attr_accessor :ordered, :traversed, :routes, :coordinates
 
     def route_from_start

--- a/app/models/metadata_presenter/grid.rb
+++ b/app/models/metadata_presenter/grid.rb
@@ -67,6 +67,10 @@ module MetadataPresenter
       ordered_pages.map(&:uuid)
     end
 
+    def show_warning?
+      checkanswers_warning.show_warning? || confirmation_warning.show_warning?
+    end
+
     private
 
     attr_reader :service, :main_flow
@@ -277,46 +281,21 @@ module MetadataPresenter
     # Include a warning if a service does not have a CYA or Confirmation page in the
     # main flow. The warning should always be in the first row, last column.
     def insert_warning
-      if cya_and_confirmation_pages_not_in_service? ||
-          cya_and_confirmation_pages_detached?
-        @ordered.append([MetadataPresenter::Warning.new])
-      end
+      @ordered.append([MetadataPresenter::Warning.new]) if show_warning?
     end
 
-    def cya_and_confirmation_pages_not_in_service?
-      (checkanswers_not_in_service? && confirmation_not_in_service?) ||
-        checkanswers_not_in_service? ||
-        confirmation_not_in_service?
+    def checkanswers_warning
+      MetadataPresenter::PageWarning.new(
+        page: service.checkanswers_page,
+        main_flow_uuids: flow_uuids
+      )
     end
 
-    def checkanswers_not_in_service?
-      service.checkanswers_page.blank?
-    end
-
-    def confirmation_not_in_service?
-      service.confirmation_page.blank?
-    end
-
-    def cya_and_confirmation_pages_detached?
-      (checkanswers_detached? && confirmation_detached?) ||
-        checkanswers_detached? ||
-        confirmation_detached?
-    end
-
-    def checkanswers_detached?
-      if service.checkanswers_page.present?
-        uuid = service.checkanswers_page.uuid
-        position = coordinates.positions[uuid]
-        detached?(position)
-      end
-    end
-
-    def confirmation_detached?
-      if service.confirmation_page.present?
-        uuid = service.confirmation_page.uuid
-        position = coordinates.positions[uuid]
-        detached?(position)
-      end
+    def confirmation_warning
+      MetadataPresenter::PageWarning.new(
+        page: service.confirmation_page,
+        main_flow_uuids: flow_uuids
+      )
     end
 
     # Any destinations exiting the branch that have not already been traversed.

--- a/app/models/metadata_presenter/page_warning.rb
+++ b/app/models/metadata_presenter/page_warning.rb
@@ -1,0 +1,24 @@
+module MetadataPresenter
+  class PageWarning
+    def initialize(page:, main_flow_uuids:)
+      @page = page
+      @main_flow_uuids = main_flow_uuids
+    end
+
+    def show_warning?
+      missing? || detached?
+    end
+
+    def missing?
+      page.blank?
+    end
+
+    def detached?
+      main_flow_uuids.exclude?(page&.uuid)
+    end
+
+    private
+
+    attr_reader :page, :main_flow_uuids
+  end
+end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.15.0'.freeze
+  VERSION = '2.15.1'.freeze
 end

--- a/spec/models/page_warning_spec.rb
+++ b/spec/models/page_warning_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe MetadataPresenter::PageWarning do
+  subject(:page_warning) do
+    described_class.new(page: page, main_flow_uuids: main_flow_uuids)
+  end
+
+  describe '#show_warning?' do
+    let(:page) { double(uuid: 'some-uuid') }
+    let(:main_flow_uuids) { %w[some-uuid] }
+
+    context 'when page is presenter in the service' do
+      it 'should return false' do
+        expect(page_warning.show_warning?).to be_falsey
+      end
+    end
+
+    context 'when page is missing from service' do
+      let(:page) { nil }
+
+      it 'should return true' do
+        expect(page_warning.show_warning?).to be_truthy
+      end
+    end
+
+    context 'when page is in the main flow' do
+      it 'should return false' do
+        expect(page_warning.show_warning?).to be_falsey
+      end
+    end
+
+    context 'when page is not in the main flow' do
+      let(:main_flow_uuids) { %w[some-other-page-uuid] }
+
+      it 'should return true' do
+        expect(page_warning.show_warning?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
Whenever a change to the metadata of a service affects the checkanswers
or confirmation pages we need to check whether they have been detached
from the main flow. If so then we are most likely going to show a
warning message to the user that they will be unable to submit their
form.

We also have to surface the Service object inside the Grid model because
the Editor will need to compare grids for two different types of services; pre
and post user changes.

Publish 2.15.1

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>