### PR TITLE
Email component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
-## [2.15.1] - 2021-01-07
+## [2.15.2] - 2022-01-10
+
+### Added
+
+- Added email component
+
+## [2.15.1] - 2022-01-07
 
 ### Added
 

--- a/app/validators/metadata_presenter/email_validator.rb
+++ b/app/validators/metadata_presenter/email_validator.rb
@@ -1,0 +1,8 @@
+module MetadataPresenter
+  class EmailValidator < BaseValidator
+    def invalid_answer?
+      regex = URI::MailTo::EMAIL_REGEXP
+      user_answer.match(regex).nil?
+    end
+  end
+end

--- a/app/views/metadata_presenter/component/_email.html.erb
+++ b/app/views/metadata_presenter/component/_email.html.erb
@@ -1,0 +1,11 @@
+<%=
+  f.govuk_email_field component.id.to_sym,
+    label: { text: input_title },
+    hint: {
+      data: { "fb-default-text" => default_text('hint') },
+      text: component.hint
+    },
+    name: "answers[#{component.name}]",
+    spellcheck: "false",
+    autocomplete: "email"
+%>

--- a/config/initializers/supported_components.rb
+++ b/config/initializers/supported_components.rb
@@ -17,11 +17,11 @@ Rails.application.config.supported_components =
       content: %w(content)
     },
     multiplequestions: {
-      input: %w(text textarea number date radios checkboxes),
+      input: %w(text textarea number date radios checkboxes email),
       content: %w(content)
     },
     singlequestion: {
-      input: %w(text textarea number date radios checkboxes upload),
+      input: %w(text textarea number date radios checkboxes email upload),
       content: %w()
      }
   })

--- a/default_metadata/component/email.json
+++ b/default_metadata/component/email.json
@@ -1,0 +1,12 @@
+{
+  "_id": "component.email",
+  "_type": "email",
+  "errors": {},
+  "label": "Question",
+  "hint": "",
+  "name": "component-name",
+  "validation": {
+    "email": true,
+    "required": true
+  }
+}

--- a/default_metadata/string/error.email.json
+++ b/default_metadata/string/error.email.json
@@ -2,5 +2,5 @@
   "_id": "error.email",
   "_type": "string.error",
   "description": "Input (email) is not a valid email",
-  "value": "Enter a valid email for %{control}"
+  "value": "Enter an email address in the correct format, like name@example.com"
 }

--- a/default_metadata/string/error.email.json
+++ b/default_metadata/string/error.email.json
@@ -1,0 +1,6 @@
+{
+  "_id": "error.email",
+  "_type": "string.error",
+  "description": "Input (email) is not a valid email",
+  "value": "Enter a valid email for %{control}"
+}

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -65,6 +65,12 @@
     "80420693-d6f2-4fce-a860-777ca774a6f5": {
       "_type": "flow.page",
       "next": {
+        "default": "adcb61c3-52b1-479b-be51-1bb610876d54"
+      }
+    },
+    "adcb61c3-52b1-479b-be51-1bb610876d54" : {
+      "_type": "flow.page",
+      "next": {
         "default": "2ef7d11e-0307-49e9-9fe2-345dc528dd66"
       }
     },
@@ -502,6 +508,31 @@
       ],
       "add_component": "content",
       "section_heading": "Chain of Command"
+    },
+    {
+      "_id": "page.email",
+      "url": "email",
+      "body": "Body section",
+      "_type": "page.singlequestion",
+      "_uuid": "adcb61c3-52b1-479b-be51-1bb610876d54",
+      "heading": "Email",
+      "components": [
+        {
+          "_id": "email-address_email_1",
+          "hint": "",
+          "name": "email-address_email_1",
+          "_type": "email",
+          "_uuid": "482cb2d0-fda7-4e5c-9591-96dcb546e181",
+          "label": "Email address",
+          "errors": {},
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "email": true,
+            "max_length": 256
+          }
+        }
+      ]
     },
     {
       "_id": "page.dog-picture",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.15.1'.freeze
+  VERSION = '2.15.2'.freeze
 end

--- a/schemas/component/email.json
+++ b/schemas/component/email.json
@@ -1,0 +1,23 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/email",
+  "_name": "component.email",
+  "title": "Email",
+  "description": "Let users enter an email address",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "email"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "http://gov.uk/schema/v1.0.0/definition/field"
+    },
+    {
+      "$ref": "http://gov.uk/schema/v1.0.0/definition/widthclass/input"
+    }
+  ],
+  "validation": {
+    "format": "email"
+  }
+}

--- a/schemas/component/text.json
+++ b/schemas/component/text.json
@@ -14,9 +14,6 @@
       "$ref": "definition.field"
     },
     {
-      "$ref": "validations#/definitions/string_bundle"
-    },
-    {
       "$ref": "definition.width_class.input"
     }
   ]

--- a/schemas/component/textarea.json
+++ b/schemas/component/textarea.json
@@ -46,9 +46,6 @@
       "$ref": "definition.field"
     },
     {
-      "$ref": "validations#/definitions/string_bundle"
-    },
-    {
       "$ref": "definition.width_class.input"
     }
   ]

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe MetadataPresenter::Page do
       subject(:page) { described_class.new(_type: 'page.multiplequestions') }
 
       it 'returns the correct input components' do
-        expect(page.supported_input_components).to match_array(%w[text textarea number date radios checkboxes])
+        expect(page.supported_input_components).to match_array(%w[text textarea number date radios checkboxes email])
       end
     end
 

--- a/spec/models/traversed_pages_spec.rb
+++ b/spec/models/traversed_pages_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe MetadataPresenter::TraversedPages do
             'burgers',
             'star-wars-knowledge',
             'how-many-lights',
+            'email',
             'dog-picture'
           ]
         )

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe MetadataPresenter::EmailValidator do
+  subject(:validator) do
+    described_class.new(page_answers: page_answers, component: component)
+  end
+  let(:component) { page.components.first }
+  let(:page_answers) { MetadataPresenter::PageAnswers.new(page, answers) }
+
+  describe '#valid?' do
+    let(:page) { service.find_page_by_url('/email') }
+
+    before do
+      validator.valid?
+    end
+
+    context 'when is a valid email' do
+      %w[
+        hi@gmail.com
+        empress.wu@digital.justice.gov.uk
+        Hedy.Lamarr@justice.gov.uk
+        email@subdomain.example.com
+        ching+shih@example.com
+        email@123.123.123.123
+        email@[123.123.123.123]
+        "email"@example.com
+        1234567890@example.com
+        LucyHicksAnderson@example-one.com
+        _______@example.com
+        email@example.name
+        gabriela-brimmer@outlook.com
+        dede_mirabal@hotmail.com
+        firstname+lastname@example.com
+      ].each do |valid_answer|
+        let(:answers) { { 'email-address_email_1' => valid_answer } }
+
+        it "returns valid for '#{valid_answer}'" do
+          expect(validator).to be_valid
+        end
+      end
+    end
+
+    context 'when is not a valid email' do
+      [
+        "'hello@gmail.com'",
+        'first.last@sub.do,com',
+        'first.last',
+        'gabriela.brimmer@-xample.com',
+        '"first"last"@gmail.org',
+        'plainaddress',
+        '#@%^%#$@#$@#.com',
+        '@example.com',
+        'Joe Smith <email@example.com>',
+        'email.example.com',
+        'email@example@example.com',
+        'あいうえお@example.com',
+        'email@example.com (Joe Smith)',
+        'email@-example.com',
+        'email@example..com',
+        'empress wu@outlook.com'
+      ].each do |invalid_answer|
+        let(:answers) { { 'email-address_email_1' => invalid_answer } }
+        let(:page) { service.find_page_by_url('/email') }
+
+        it "returns invalid for '#{invalid_answer}'" do
+          expect(validator).to_not be_valid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/IIQG92SM/2173-preview-email-component-and-interacting-with-email-component-in-the-runner)
### Add schema for email component
 
### Add default metadata for email component

### Add template and fixture for email component 
- Add template
- Add ability to choose email component in multi question pages

### Add validation for email component

### Update tests for fixture change and supported components
 
### Bump 2.15.2

### Remove unused schema property


## Example of validation message
![Screenshot 2022-01-11 at 11 43 17](https://user-images.githubusercontent.com/29227502/148936770-66922753-62bb-436f-82dd-94d70d4761c2.png)