### PR TITLE
Update default heading for email component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.15.4] - 2022-01-13
+
+### Changed
+
+- Change order of components on multiple question page
+- Change default heading for email component
+
 ## [2.15.3] - 2022-01-12
 
 ### Added

--- a/config/initializers/supported_components.rb
+++ b/config/initializers/supported_components.rb
@@ -17,7 +17,7 @@ Rails.application.config.supported_components =
       content: %w(content)
     },
     multiplequestions: {
-      input: %w(text textarea number date radios checkboxes email),
+      input: %w(text textarea email number date radios checkboxes),
       content: %w(content)
     },
     singlequestion: {

--- a/default_metadata/component/email.json
+++ b/default_metadata/component/email.json
@@ -2,7 +2,7 @@
   "_id": "component.email",
   "_type": "email",
   "errors": {},
-  "label": "Question",
+  "label": "Email address question",
   "hint": "",
   "name": "component-name",
   "validation": {

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.15.3'.freeze
+  VERSION = '2.15.4'.freeze
 end


### PR DESCRIPTION
Following testing the team have decided to change the default heading from
Question to Email address question.
This is to avoid confusion in the event a user adds a text and email component
on a multiple question page.

Also, re-arrange the order of components on a multiple question page so the
text based components are grouped.

![Screenshot 2022-01-13 at 09 42 49](https://user-images.githubusercontent.com/29227502/149305937-3d3e3012-9027-4319-97a4-f4a3a59f469b.png)
