### PR TITLE
Update version fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.15.6] - 2022-01-14
+
+### Changed
+
+- Replace text component with email component in version fixture.
+
 ## [2.15.5] - 2022-01-14
 
 ### Fixed

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -11,10 +11,10 @@
     "9e1ba77f-f1e5-42f4-b090-437aa9af7f73": {
       "_type": "flow.page",
       "next": {
-        "default": "df1ba645-f748-46d0-ad75-f34112653e37"
+        "default": "adcb61c3-52b1-479b-be51-1bb610876d54"
       }
     },
-    "df1ba645-f748-46d0-ad75-f34112653e37": {
+    "adcb61c3-52b1-479b-be51-1bb610876d54": {
       "_type": "flow.page",
       "next": {
         "default": "4b8c6bf3-878a-4446-9198-48351b3e2185"
@@ -63,12 +63,6 @@
       }
     },
     "80420693-d6f2-4fce-a860-777ca774a6f5": {
-      "_type": "flow.page",
-      "next": {
-        "default": "adcb61c3-52b1-479b-be51-1bb610876d54"
-      }
-    },
-    "adcb61c3-52b1-479b-be51-1bb610876d54" : {
       "_type": "flow.page",
       "next": {
         "default": "2ef7d11e-0307-49e9-9fe2-345dc528dd66"
@@ -133,35 +127,23 @@
       "_id": "page.email-address",
       "url": "email-address",
       "body": "Body section",
-      "lede": "",
       "_type": "page.singlequestion",
-      "_uuid": "df1ba645-f748-46d0-ad75-f34112653e37",
+      "_uuid": "adcb61c3-52b1-479b-be51-1bb610876d54",
       "heading": "Question",
       "components": [
         {
-          "_id": "email-address_text_1",
+          "_id": "email-address_email_1",
           "hint": "",
-          "name": "email-address_text_1",
-          "_type": "text",
-          "_uuid": "f27e5788-e784-4bfd-8b21-2fab8ce95abb",
+          "name": "email-address_email_1",
+          "_type": "email",
+          "_uuid": "482cb2d0-fda7-4e5c-9591-96dcb546e181",
           "label": "Email address",
-          "errors": {
-            "format": {},
-            "required": {
-              "any": "Enter an email address"
-            },
-            "max_length": {
-              "any": "%{control} is too long."
-            },
-            "min_length": {
-              "any": "%{control} is too short."
-            }
-          },
+          "errors": {},
           "collection": "components",
           "validation": {
             "required": true,
-            "max_length": 30,
-            "min_length": 2
+            "email": true,
+            "max_length": 256
           }
         }
       ]
@@ -182,7 +164,18 @@
           "_type": "text",
           "_uuid": "5ad372fa-ed35-477f-b471-4d444f991210",
           "label": "Parent name",
-          "errors": {},
+          "errors": {
+            "format": {},
+            "required": {
+              "any": "Enter a parent name"
+            },
+            "max_length": {
+              "any": "%{control} is too long."
+            },
+            "min_length": {
+              "any": "%{control} is too short."
+            }
+          },
           "collection": "components",
           "validation": {
             "required": false,
@@ -508,31 +501,6 @@
       ],
       "add_component": "content",
       "section_heading": "Chain of Command"
-    },
-    {
-      "_id": "page.email",
-      "url": "email",
-      "body": "Body section",
-      "_type": "page.singlequestion",
-      "_uuid": "adcb61c3-52b1-479b-be51-1bb610876d54",
-      "heading": "Email",
-      "components": [
-        {
-          "_id": "email-address_email_1",
-          "hint": "",
-          "name": "email-address_email_1",
-          "_type": "email",
-          "_uuid": "482cb2d0-fda7-4e5c-9591-96dcb546e181",
-          "label": "Email address",
-          "errors": {},
-          "collection": "components",
-          "validation": {
-            "required": true,
-            "email": true,
-            "max_length": 256
-          }
-        }
-      ]
     },
     {
       "_id": "page.dog-picture",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.15.5'.freeze
+  VERSION = '2.15.6'.freeze
 end

--- a/spec/models/traversed_pages_spec.rb
+++ b/spec/models/traversed_pages_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe MetadataPresenter::TraversedPages do
             'burgers',
             'star-wars-knowledge',
             'how-many-lights',
-            'email',
             'dog-picture'
           ]
         )

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MetadataPresenter::EmailValidator do
   let(:page_answers) { MetadataPresenter::PageAnswers.new(page, answers) }
 
   describe '#valid?' do
-    let(:page) { service.find_page_by_url('/email') }
+    let(:page) { service.find_page_by_url('/email-address') }
 
     before do
       validator.valid?
@@ -58,7 +58,7 @@ RSpec.describe MetadataPresenter::EmailValidator do
         'empress wu@outlook.com'
       ].each do |invalid_answer|
         let(:answers) { { 'email-address_email_1' => invalid_answer } }
-        let(:page) { service.find_page_by_url('/email') }
+        let(:page) { service.find_page_by_url('/email-address') }
 
         it "returns invalid for '#{invalid_answer}'" do
           expect(validator).to_not be_valid

--- a/spec/validators/max_length_validator_spec.rb
+++ b/spec/validators/max_length_validator_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe MetadataPresenter::MaxLengthValidator do
       end
 
       context 'when there is a custom error message' do
-        let(:page) { service.find_page_by_url('/email-address') }
+        let(:page) { service.find_page_by_url('/parent-name') }
         let(:answers) do
-          { 'email-address_text_1' => 'gandalf.mithrandir1239@middleearth.gov.uk' }
+          { 'parent-name_text_1' => 'Albus Percival Wulfric Brian Dumbledore' }
         end
 
         it 'uses the custom error message' do
           expect(page_answers.errors.full_messages).to eq(
-            ['Email address is too long.']
+            ['Parent name is too long.']
           )
         end
       end

--- a/spec/validators/min_length_validator_spec.rb
+++ b/spec/validators/min_length_validator_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe MetadataPresenter::MinLengthValidator do
       end
 
       context 'when there is a custom error message' do
-        let(:page) { service.find_page_by_url('/email-address') }
+        let(:page) { service.find_page_by_url('/parent-name') }
         let(:answers) do
-          { 'email-address_text_1' => 'g' }
+          { 'parent-name_text_1' => 'g' }
         end
 
         it 'uses the custom error message' do
           expect(page_answers.errors.full_messages).to eq(
-            ['Email address is too short.']
+            ['Parent name is too short.']
           )
         end
       end

--- a/spec/validators/required_validator_spec.rb
+++ b/spec/validators/required_validator_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe MetadataPresenter::RequiredValidator do
 
       context 'when there is custom error message' do
         context 'when there is "any"' do
-          let(:page) { service.find_page_by_url('/email-address') }
-          let(:answers) { { 'email-address_text_1' => '' } }
+          let(:page) { service.find_page_by_url('/parent-name') }
+          let(:answers) { { 'parent-name_text_1' => '' } }
 
           it 'be invalid' do
             expect(validator).to_not be_valid
@@ -37,7 +37,7 @@ RSpec.describe MetadataPresenter::RequiredValidator do
 
           it 'set default error message on page' do
             expect(page_answers.errors.full_messages).to eq(
-              ['Enter an email address']
+              ['Enter a parent name']
             )
           end
         end


### PR DESCRIPTION
Replace existing email (text) component with an actual email component.
The old email component had custom validations for error messages, these have been moved to the `parent-name` component and specs have been updated to reflect this.

### 2.15.6