### PR TITLE
CYA and Confirmation page column placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.15.9] - 2022-02-09
+
+### Changed
+
+- Check Confirmation and CYA pages are in the correct column during grid placement.
+
+### Fixed
+
+- Remove excess Pointer objects in the detached grid.
+
 ## [2.15.8] - 2022-02-02
 
 ### Added

--- a/app/models/metadata_presenter/column_number.rb
+++ b/app/models/metadata_presenter/column_number.rb
@@ -25,18 +25,35 @@ module MetadataPresenter
 
     def column_number
       @column_number ||= begin
-        return latest_column if cya_or_confirmation_page?
+        return last_column if confirmation_page?
+        return latest_column if checkanswers_page?
 
         existing_column || new_column
       end
+    end
+
+    def confirmation_page?
+      service.confirmation_page&.uuid == uuid
+    end
+
+    def checkanswers_page?
+      service.checkanswers_page&.uuid == uuid
     end
 
     def latest_column
       [existing_column, new_column].compact.max
     end
 
-    def cya_or_confirmation_page?
-      [service.checkanswers_page&.uuid, service.confirmation_page&.uuid].include?(uuid)
+    def last_column
+      checkanswers_column.present? ? checkanswers_column + 1 : latest_column
+    end
+
+    def checkanswers_column
+      @checkanswers_column ||= begin
+        return if service.checkanswers_page.blank?
+
+        coordinates.uuid_column(service.checkanswers_page&.uuid)
+      end
     end
 
     def existing_column

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.15.8'.freeze
+  VERSION = '2.15.9'.freeze
 end

--- a/spec/models/column_number_spec.rb
+++ b/spec/models/column_number_spec.rb
@@ -72,15 +72,113 @@ RSpec.describe MetadataPresenter::ColumnNumber do
         end
       end
 
-      context 'when checkanswers or confirmation page' do
-        let(:new_column) { 10 }
+      context 'when checkanswers page' do
+        # branching fixture 10 CYA page
+        let(:uuid) { 'da2576f9-7ddd-4316-b24b-103708139214' }
+        let(:positions) do
+          {
+            uuid => {
+              column: 8,
+              row: 1
+            }
+          }
+        end
 
-        # branching fixture 10 CYA and Confirmation pages
-        %w[da2576f9-7ddd-4316-b24b-103708139214 a88694da-8ded-44e7-bc89-e652c1a7f46d].each do |page_uuid|
-          let(:uuid) { page_uuid }
+        context 'when existing column is less than new column' do
+          let(:new_column) { 10 }
 
-          it 'returns the greater column number' do
+          it 'returns the new column' do
             expect(column_number.number).to eq(new_column)
+          end
+        end
+
+        context 'when existing column is more than new column' do
+          let(:new_column) { 6 }
+
+          it 'returns the existing column' do
+            expect(column_number.number).to eq(8)
+          end
+        end
+
+        context 'when existing column is not present' do
+          let(:positions) do
+            {
+              uuid => {
+                column: nil,
+                row: 1
+              }
+            }
+          end
+          let(:new_column) { 8 }
+
+          it 'returns the new column' do
+            expect(column_number.number).to eq(8)
+          end
+        end
+      end
+
+      context 'when confirmation page' do
+        # branching fixture 10 Confirmation page
+        let(:uuid) { 'a88694da-8ded-44e7-bc89-e652c1a7f46d' }
+        context 'when checkanswers page is present' do
+          let(:positions) do
+            {
+              # branching fixture 10 CYA page
+              'da2576f9-7ddd-4316-b24b-103708139214' => {
+                column: 10,
+                row: 1
+              }
+            }
+          end
+          let(:new_column) { 10 }
+
+          it 'returns the last column' do
+            expect(column_number.number).to eq(11)
+          end
+        end
+
+        context 'when checkanswers page is not present' do
+          let(:positions) do
+            {
+              # branching fixture 10 Confirmation page
+              uuid => {
+                column: 8,
+                row: 1
+              }
+            }
+          end
+
+          context 'when existing column is less than new column' do
+            let(:new_column) { 10 }
+
+            it 'returns the new column' do
+              expect(column_number.number).to eq(new_column)
+            end
+          end
+
+          context 'when existing column is more than new column' do
+            let(:new_column) { 7 }
+
+            it 'returns the existing column' do
+              expect(column_number.number).to eq(8)
+            end
+          end
+
+          context 'when there is no existing column' do
+            let(:positions) do
+              {
+                # branching fixture 10 Confirmation page
+                uuid => {
+                  column: nil,
+                  row: 1
+                }
+              }
+            end
+            let(:new_column) { 6 }
+
+            it 'returns the new column' do
+              expect(column_number.number).to eq(new_column)
+            end
           end
         end
       end


### PR DESCRIPTION
[Trello](https://trello.com/c/K0G1FddV/2264-confirmation-page-sometimes-appears-before-check-your-answers-page-48-59-s-m)
### CYA and Confirmation page column placement
During grid placement, check whether a check answers page exists.
If it exists, ensure the confirmation page is in the next column.

### Bump v2.15.9

## Before
![153198480-ca23b810-6143-47e0-858e-1f8dea4cb2e1](https://user-images.githubusercontent.com/29227502/153198960-0ce55a86-a705-4627-b84a-c561293bf08e.png)

## After
![Screenshot 2022-02-09 at 12 10 24](https://user-images.githubusercontent.com/29227502/153198952-4e47854c-9c98-4c70-ac46-b59f22594462.png)