### PR TITLE
Add `contains` and `does_not_contain` operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.15.11] - 2022-02-18
+
+### Added
+
+- Add `contains` and `does_not_contain` operators.
+
 ## [2.15.10] - 2022-02-14
 
 ### Fixed

--- a/app/operators/metadata_presenter/contains_operator.rb
+++ b/app/operators/metadata_presenter/contains_operator.rb
@@ -1,0 +1,11 @@
+module MetadataPresenter
+  class ContainsOperator < BaseOperator
+    def evaluate?
+      @actual == @expected
+    end
+
+    def evaluate_collection?
+      Array(@expected).include?(@actual)
+    end
+  end
+end

--- a/app/operators/metadata_presenter/does_not_contain_operator.rb
+++ b/app/operators/metadata_presenter/does_not_contain_operator.rb
@@ -1,0 +1,11 @@
+module MetadataPresenter
+  class DoesNotContainOperator < BaseOperator
+    def evaluate?
+      @actual != @expected
+    end
+
+    def evaluate_collection?
+      Array(@expected).exclude?(@actual)
+    end
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular 'is', 'is'
+  inflect.irregular 'contains', 'contains'
 end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.15.10'.freeze
+  VERSION = '2.15.11'.freeze
 end

--- a/spec/operators/contains_operator_spec.rb
+++ b/spec/operators/contains_operator_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe MetadataPresenter::ContainsOperator do
+  subject(:operator) { described_class.new(actual, expected) }
+
+  describe '#evaluate?' do
+    context 'when equal' do
+      let(:actual) { 'foo' }
+      let(:expected) { 'foo' }
+
+      it 'returns true' do
+        expect(operator.evaluate?).to be_truthy
+      end
+    end
+
+    context 'when not equal' do
+      let(:actual) { 'foo' }
+      let(:expected) { 'bar' }
+
+      it 'returns false' do
+        expect(operator.evaluate?).to be_falsey
+      end
+    end
+  end
+
+  describe '#evaluate_collection?' do
+    context 'when contains included' do
+      let(:actual) { 'Apples' }
+      let(:expected) { %w[Apples] }
+
+      it 'returns true' do
+        expect(operator.evaluate_collection?).to be_truthy
+      end
+    end
+
+    context 'when does not contain included' do
+      context 'when other choices are selected' do
+        let(:actual) { 'Apples' }
+        let(:expected) { %w[Pears] }
+
+        it 'returns false' do
+          expect(operator.evaluate_collection?).to be_falsey
+        end
+      end
+
+      context 'when is not answered' do
+        let(:actual) { 'Apples' }
+        let(:expected) { [] }
+
+        it 'returns false' do
+          expect(operator.evaluate_collection?).to be_falsey
+        end
+      end
+
+      context 'when is nil' do
+        let(:actual) { 'Apples' }
+        let(:expected) { nil }
+
+        it 'returns false' do
+          expect(operator.evaluate_collection?).to be_falsey
+        end
+      end
+    end
+  end
+end

--- a/spec/operators/does_not_contain_operator_spec.rb
+++ b/spec/operators/does_not_contain_operator_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe MetadataPresenter::DoesNotContainOperator do
+  subject(:operator) { described_class.new(actual, expected) }
+
+  describe '#evaluate?' do
+    context 'when equal' do
+      let(:actual) { 'foo' }
+      let(:expected) { 'foo' }
+
+      it 'returns false' do
+        expect(operator.evaluate?).to be_falsey
+      end
+    end
+
+    context 'when not equal' do
+      let(:actual) { 'foo' }
+      let(:expected) { 'bar' }
+
+      it 'returns false' do
+        expect(operator.evaluate?).to be_truthy
+      end
+    end
+  end
+
+  describe '#evaluate_collection?' do
+    context 'when contains included' do
+      let(:actual) { 'Apples' }
+      let(:expected) { %w[Apples] }
+
+      it 'returns false' do
+        expect(operator.evaluate_collection?).to be_falsey
+      end
+    end
+
+    context 'when does not contain included' do
+      context 'when other choices are selected' do
+        let(:actual) { 'Apples' }
+        let(:expected) { %w[Pears] }
+
+        it 'returns true' do
+          expect(operator.evaluate_collection?).to be_truthy
+        end
+      end
+
+      context 'when is not answered' do
+        let(:actual) { 'Apples' }
+        let(:expected) { [] }
+
+        it 'returns true' do
+          expect(operator.evaluate_collection?).to be_truthy
+        end
+      end
+
+      context 'when is nil' do
+        let(:actual) { 'Apples' }
+        let(:expected) { nil }
+
+        it 'returns true' do
+          expect(operator.evaluate_collection?).to be_truthy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/5LKINamZ/2334-condition-using-a-checkbox-operator-is-incorrect-is-isnt-instead-of-contains-doesnt-contain-38-s)

### Make the contains operator work
Calling `classify` on the  `contains` operator in the `operator.rb` `klass` method, removes the 's'. Adding a rails inflector transforms the `contains` into `ContainsOperator` class to evaluate the condition.
 
### Add contains and does_not_contains operator classes
 
### Bump presenter 2.15.11