### PR TITLE
Add ability to check if a page is a multiple question page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.15.12] - 2022-03-17
+
+### Added
+
+- Add ability to check if page is a multiple question page.
+
 ## [2.15.11] - 2022-02-18
 
 ### Added

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -100,6 +100,10 @@ module MetadataPresenter
       type.in?(END_OF_ROUTE_PAGES)
     end
 
+    def multiple_questions?
+      type == 'page.multiplequestions'
+    end
+
     private
 
     def heading?

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.15.11'.freeze
+  VERSION = '2.15.12'.freeze
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -300,4 +300,22 @@ RSpec.describe MetadataPresenter::Page do
       end
     end
   end
+
+  describe '#multiple_questions?' do
+    context 'when page is a multiple question page' do
+      subject(:page) { service.find_page_by_url('star-wars-knowledge') }
+
+      it 'returns truthy' do
+        expect(page.multiple_questions?).to be_truthy
+      end
+    end
+
+    context 'when page is not a multiple questions page' do
+      subject(:page) { service.find_page_by_url('name') }
+
+      it 'returns falsey' do
+        expect(page.multiple_questions?).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
Relates to [Trello](https://trello.com/c/JY7GLf37/2343-in-branching-screen-condition-question-does-not-use-optgroup-to-group-q-from-multi-q-pages-67-m)

- Add ability to check if a page is a multiple question page
- Bump presenter 2.15.12
