### PR TITLE
Disable bold labels on radios components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.15.13] - 2022-03-22
+
+### Changed
+
+- Changed weight of radio buttons component labels.
+
 ## [2.15.12] - 2022-03-17
 
 ### Added

--- a/app/views/metadata_presenter/component/_radios.html.erb
+++ b/app/views/metadata_presenter/component/_radios.html.erb
@@ -8,5 +8,6 @@
     hint: {
       data: { "fb-default-text" => default_text('hint') },
       text: component.hint
-    }
+    },
+    bold_labels: false
 %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.15.12'.freeze
+  VERSION = '2.15.13'.freeze
 end


### PR DESCRIPTION
This PR explicitly sets the value of `bold_labels` to `false` for `govuk_collection_radio_buttons` components.  