### PR TITLE
Expose previous destination uuids

### DIFF
--- a/app/models/metadata_presenter/coordinates.rb
+++ b/app/models/metadata_presenter/coordinates.rb
@@ -61,7 +61,9 @@ module MetadataPresenter
     attr_writer :positions, :branch_spacers
 
     def setup_positions
-      service.flow.keys.index_with { |_uuid| { row: nil, column: nil } }
+      service.flow.keys.index_with do |_uuid|
+        { row: nil, column: nil, previous_flow_uuid: nil, conditional_uuid: nil }
+      end
     end
 
     # This also takes into account the 'OR' expressions which

--- a/app/models/metadata_presenter/route.rb
+++ b/app/models/metadata_presenter/route.rb
@@ -1,21 +1,27 @@
 module MetadataPresenter
   class Route
     attr_reader :traverse_from
-    attr_accessor :flow_uuids, :routes, :row, :column
+    attr_accessor :flow_uuids, :routes, :row, :column, :previous_flow_uuid,
+                  :conditional_uuid, :previous_uuids
 
-    def initialize(service:, traverse_from:, row: 0, column: 0)
+    def initialize(service:, traverse_from:, row: 0, column: 0,
+                   previous_flow_uuid: nil, conditional_uuid: nil)
       @service = service
       @traverse_from = traverse_from
       @row = row
       @column = column
+      @previous_flow_uuid = previous_flow_uuid
+      @conditional_uuid = conditional_uuid
+      @previous_uuids = setup_previous_uuids
       @routes = []
       @flow_uuids = []
     end
 
     def traverse
       @flow_uuid = traverse_from
-
       index = column
+      previous_uuid = previous_flow_uuid || ''
+
       until @flow_uuid.blank?
         if index > service.flow.size
           ActiveSupport::Notifications.instrument(
@@ -29,36 +35,27 @@ module MetadataPresenter
         flow_object = service.flow_object(@flow_uuid)
 
         if flow_object.branch?
-          destinations = destination_uuids(flow_object)
+          destinations = branch_destinations(flow_object)
           # Take the first conditional destination and follow that until the end
           # of the route.
-          @flow_uuid = destinations.shift
+          first_conditional = destinations.shift
+          set_first_conditional_previous_flow(flow_object.uuid, first_conditional)
+          create_destination_routes(
+            previous_flow_uuid: flow_object.uuid,
+            destinations: destinations,
+            row: row,
+            column: index
+          )
 
-          # The remaining conditional destinations and the branch's default next
-          # (otherwise) will be the starting point for a new Route object to be
-          # traversed.
-          # The default behaviour is that the next destination will be on the row
-          # below this current route's row. This can be changed under certain
-          # conditions in the Grid model.
-          # Each of the destinations need to be placed in the column after the
-          # current column.
-          row_number = row + 1
-          column_number = index + 1
-          destinations.each do |uuid|
-            @routes.push(
-              MetadataPresenter::Route.new(
-                service: service,
-                traverse_from: uuid,
-                row: row_number,
-                column: column_number
-              )
-            )
-            row_number += 1
-          end
+          @flow_uuid = first_conditional[:next]
         else
           @flow_uuid = flow_object.default_next
         end
 
+        unless previous_uuids.key?(flow_object.uuid)
+          set_previous_flow(uuid: flow_object.uuid, previous_flow_uuid: previous_uuid)
+        end
+        previous_uuid = flow_object.uuid
         index += 1
       end
 
@@ -69,8 +66,64 @@ module MetadataPresenter
 
     attr_reader :service
 
-    def destination_uuids(flow_object)
-      flow_object.conditionals.map(&:next).push(flow_object.default_next)
+    def branch_destinations(flow_object)
+      conditionals = flow_object.conditionals.map do |conditional|
+        { next: conditional.next, conditional_uuid: conditional.uuid }
+      end
+
+      conditionals.push({ next: flow_object.default_next })
+      conditionals
+    end
+
+    def set_first_conditional_previous_flow(previous_flow_uuid, first_conditional)
+      set_previous_flow(
+        uuid: first_conditional[:next],
+        previous_flow_uuid: previous_flow_uuid,
+        conditional_uuid: first_conditional[:conditional_uuid]
+      )
+    end
+
+    def set_previous_flow(uuid:, previous_flow_uuid:, conditional_uuid: nil)
+      previous_uuids[uuid] = {
+        previous_flow_uuid: previous_flow_uuid,
+        conditional_uuid: conditional_uuid
+      }
+    end
+
+    # The remaining conditional destinations and the branch's default next
+    # (otherwise) will be the starting point for a new Route object to be
+    # traversed.
+    # The default behaviour is that the next destination will be on the row
+    # below this current route's row. This can be changed under certain
+    # conditions in the Grid model.
+    # Each of the destinations need to be placed in the column after the
+    # current column.
+    def create_destination_routes(previous_flow_uuid:, destinations:, row:, column:)
+      row_number = row + 1
+      column_number = column + 1
+      destinations.each do |destination|
+        @routes.push(
+          MetadataPresenter::Route.new(
+            service: service,
+            traverse_from: destination[:next],
+            previous_flow_uuid: previous_flow_uuid,
+            conditional_uuid: destination[:conditional_uuid],
+            row: row_number,
+            column: column_number
+          )
+        )
+        row_number += 1
+      end
+    end
+
+    def setup_previous_uuids
+      Hash[
+        traverse_from,
+        {
+          previous_flow_uuid: previous_flow_uuid,
+          conditional_uuid: conditional_uuid
+        }
+      ]
     end
   end
 end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.15.13'.freeze
+  VERSION = '2.16.0'.freeze
 end

--- a/spec/models/coordinates_spec.rb
+++ b/spec/models/coordinates_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MetadataPresenter::Coordinates do
   describe 'initialising the positions' do
     let(:latest_metadata) do
       {
-        "_id": "service.base",
+        "_id": 'service.base',
         "flow": {
           "some-uuid": {},
           "another-uuid": {}

--- a/spec/models/coordinates_spec.rb
+++ b/spec/models/coordinates_spec.rb
@@ -4,6 +4,38 @@ RSpec.describe MetadataPresenter::Coordinates do
   let(:service) { MetadataPresenter::Service.new(latest_metadata) }
   let(:uuid) { 'ad011e6b-5926-42f8-8b7c-668558850c52' } # Page N
 
+  describe 'initialising the positions' do
+    let(:latest_metadata) do
+      {
+        "_id": "service.base",
+        "flow": {
+          "some-uuid": {},
+          "another-uuid": {}
+        }
+      }
+    end
+    let(:expected_positions) do
+      {
+        'some-uuid': {
+          row: nil,
+          column: nil,
+          previous_flow_uuid: nil,
+          conditional_uuid: nil
+        },
+        'another-uuid': {
+          row: nil,
+          column: nil,
+          previous_flow_uuid: nil,
+          conditional_uuid: nil
+        }
+      }
+    end
+
+    it 'sets up the positions object' do
+      expect(coordinates.positions).to eq(expected_positions)
+    end
+  end
+
   describe 'initialising the branch spacers' do
     context 'when branching point does not have OR conditions' do
       let(:branch_uuid) { '7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1' } # branching point 4
@@ -160,10 +192,10 @@ RSpec.describe MetadataPresenter::Coordinates do
       allow_any_instance_of(MetadataPresenter::Coordinates).to receive(
         :setup_positions
       ).and_return(positions)
+    end
 
-      it 'returns all the positions objects for a given column' do
-        expect(coordinates.positions_in_column(10)).to eq(expected_column)
-      end
+    it 'returns all the positions objects for a given column' do
+      expect(coordinates.positions_in_column(10)).to eq(expected_column)
     end
   end
 


### PR DESCRIPTION
This adds previous flow uuids on the route model for any objects that it
traverses. It will also add a conditional uuid should that be
applicable.

For any given route object, any branches that are part of that
particular route, the first conditional will be traversed as normal and
the previous flow uuid and conditional uuid set for that object.

Each additional branch destination and default next for that branch get
their own route object which will traverse that path and set previous
flow uuids and conditional uuids accordingly.

The route model exposes the previous flow uuid and conditional uuid for
each flow object that is traversed for any given route.

These now need to be set for any given grid, main flow or detached.
Similar rules apply for when flow objects are placed on the grid; the
first flow object takes precedence over any preceding objects. This is
to say that only the first object that is placed on the grid will have
the ability to be moved as the previous flow uuid and optional
conditional uuid will not be overwritten by any following objects.

Also:

### Additional Route object tests for column and row incrementation

The first destination of a branch is traversed by the parent route
object. Each subsequent destination and the branch default next is done
by separate route objects.

Each of these route objects is initialised with an incrementing column
and row number.

### Additional test for setup of positions object in Coordinates model

The Coordinates model initialises with a positions object which caters
for row, column, previous flow uuid and potential conditional uuid if
the object in question is a branch destination.

### Publish 2.16.0