### PR TITLE
Add responsive meta viewport tag and version bump

### DIFF
--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -4,7 +4,8 @@
     <title><%= service.service_name %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_pack_url('media/images/favicon.ico') %>" type="image/x-icon" />
   <link rel="mask-icon" href="<%= asset_pack_url('media/images/govuk-mask-icon.svg') %>" color="blue">
   <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-180x180.png') %>">

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.16.0'.freeze
+  VERSION = '2.16.1'.freeze
 end


### PR DESCRIPTION
This adds the correct `viewport` meta tag from the design system so that the interface displays correctly on devices.

<img width="942" alt="image" src="https://user-images.githubusercontent.com/595564/162456075-a82f5da8-f47f-4b40-985f-e3f64ee9425d.png">

Before:
<img width="408" alt="image" src="https://user-images.githubusercontent.com/595564/162458869-47af1f99-d23b-4210-8538-42d8c9263efc.png">


After:
<img width="403" alt="image" src="https://user-images.githubusercontent.com/595564/162458459-b7bae7e8-5b80-4d28-b16b-bdea6481cad4.png">
