### PR TITLE
Set confirmation page column coordinate to after the CYA page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.16.2] - 2022-04-21
+
+### Changed
+
+- Change method to ensure the confirmation page column coordinate is larger than the CYA page coordinate.
+
 ## [2.15.13] - 2022-03-22
 
 ### Changed

--- a/app/models/metadata_presenter/grid.rb
+++ b/app/models/metadata_presenter/grid.rb
@@ -214,7 +214,13 @@ module MetadataPresenter
         position = coordinates.positions[uuid]
         next if detached?(position)
 
-        column = position[:column]
+        # Update confirmation page column co-ordinate
+        column = if confirmation_and_cya_pages_present? && service.confirmation_page.uuid == uuid
+                   coordinates.positions[service.checkanswers_page.uuid][:column] + 1
+                 else
+                   position[:column]
+                 end
+
         row = position[:row]
         insert_spacer(column, row) if occupied?(column, row, uuid)
         @ordered[column][row] = get_flow_object(uuid)
@@ -223,6 +229,12 @@ module MetadataPresenter
 
     def detached?(position)
       position[:row].nil? || position[:column].nil?
+    end
+
+    def confirmation_and_cya_pages_present?
+      service.confirmation_page.present? &&
+        service.checkanswers_page.present? &&
+        coordinates.positions[service.checkanswers_page.uuid][:column].present?
     end
 
     def occupied?(column, row, uuid)

--- a/fixtures/branching_12.json
+++ b/fixtures/branching_12.json
@@ -1,0 +1,361 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "173457d8-6273-47df-88b4-61adcfca5ac8": {
+      "next": {
+        "default": "48b0bcd1-7ab1-424f-8250-9a1f0beed2f7"
+      },
+      "_type": "flow.page"
+    },
+    "25e888b0-5c48-441e-a69d-c6a4913315a9": {
+      "next": {
+        "default": "173457d8-6273-47df-88b4-61adcfca5ac8"
+      },
+      "_type": "flow.page"
+    },
+    "25ee48a1-bdb8-414d-aba6-ea7be572e9f1": {
+      "next": {
+        "default": "173457d8-6273-47df-88b4-61adcfca5ac8"
+      },
+      "_type": "flow.page"
+    },
+    "48b0bcd1-7ab1-424f-8250-9a1f0beed2f7": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "7f56f813-a7f0-488a-a8bc-7a53193d74c5": {
+      "next": {
+        "default": "82e1d5af-f033-4af2-841d-e72c6d64b3db",
+        "conditionals": [
+          {
+            "next": "25ee48a1-bdb8-414d-aba6-ea7be572e9f1",
+            "_type": "if",
+            "_uuid": "7dcf2f23-27ed-4c0b-934b-cbd1afdc4c4f",
+            "expressions": [
+              {
+                "page": "82e1d5af-f033-4af2-841d-e72c6d64b3db",
+                "field": "edb2e110-5f20-4753-82e4-f61cbc537a20",
+                "operator": "is",
+                "component": "a3ffd706-9bec-4edc-9f0c-b74369279226"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 3"
+    },
+    "82e1d5af-f033-4af2-841d-e72c6d64b3db": {
+      "next": {
+        "default": "a40c74b7-467d-471b-b81a-92c09a3a2dc2"
+      },
+      "_type": "flow.page"
+    },
+    "a40c74b7-467d-471b-b81a-92c09a3a2dc2": {
+      "next": {
+        "default": "d3072958-10f7-4293-ba02-bcc7dd53cd89",
+        "conditionals": [
+          {
+            "next": "173457d8-6273-47df-88b4-61adcfca5ac8",
+            "_type": "if",
+            "_uuid": "b8e58cb1-3951-4615-b9a0-6079bcb95dd5",
+            "expressions": [
+              {
+                "page": "82e1d5af-f033-4af2-841d-e72c6d64b3db",
+                "field": "edb2e110-5f20-4753-82e4-f61cbc537a20",
+                "operator": "is",
+                "component": "a3ffd706-9bec-4edc-9f0c-b74369279226"
+              }
+            ]
+          },
+          {
+            "next": "25e888b0-5c48-441e-a69d-c6a4913315a9",
+            "_type": "if",
+            "_uuid": "73c6b39d-a917-4d89-b4c2-3ea656cd36cb",
+            "expressions": [
+              {
+                "page": "82e1d5af-f033-4af2-841d-e72c6d64b3db",
+                "field": "b95dcfba-24cd-4e35-949b-0e551e7009e7",
+                "operator": "is",
+                "component": "a3ffd706-9bec-4edc-9f0c-b74369279226"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 1"
+    },
+    "d3072958-10f7-4293-ba02-bcc7dd53cd89": {
+      "next": {
+        "default": "7f56f813-a7f0-488a-a8bc-7a53193d74c5"
+      },
+      "_type": "flow.page"
+    },
+    "e1944e0c-ddbd-468e-818c-ada3a30d50e7": {
+      "next": {
+        "default": "25ee48a1-bdb8-414d-aba6-ea7be572e9f1",
+        "conditionals": [
+          {
+            "next": "25ee48a1-bdb8-414d-aba6-ea7be572e9f1",
+            "_type": "if",
+            "_uuid": "e667a067-afd5-4578-83aa-fee4a6d621e6",
+            "expressions": [
+              {
+                "page": "82e1d5af-f033-4af2-841d-e72c6d64b3db",
+                "field": "edb2e110-5f20-4753-82e4-f61cbc537a20",
+                "operator": "is",
+                "component": "a3ffd706-9bec-4edc-9f0c-b74369279226"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 2"
+    },
+    "f320a561-31e5-4547-aa20-ddeec07d10f4": {
+      "next": {
+        "default": "82e1d5af-f033-4af2-841d-e72c6d64b3db"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n- do something\r\n- update your name, address or other details\r\n- do something else\r\n\r\n<!-- -->\r\n\r\n<!-- -->\r\n\r\nRegistering takes around 5 minutes.",
+      "lede": "",
+      "_type": "page.start",
+      "_uuid": "f320a561-31e5-4547-aa20-ddeec07d10f4",
+      "heading": "A new service",
+      "before_you_start": "### Before you start\r\n\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally.\r\n\r\n"
+    },
+    {
+      "_id": "page.multi",
+      "url": "multi",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "82e1d5af-f033-4af2-841d-e72c6d64b3db",
+      "heading": "Question",
+      "components": [
+        {
+          "_id": "multi_radios_1",
+          "hint": "We need to know before we can process your application. 2",
+          "name": "multi_radios_1",
+          "_type": "radios",
+          "_uuid": "a3ffd706-9bec-4edc-9f0c-b74369279226",
+          "items": [
+            {
+              "_id": "multi_radios_1_item_1",
+              "hint": "",
+              "name": "multi_radios_1",
+              "_type": "radio",
+              "_uuid": "edb2e110-5f20-4753-82e4-f61cbc537a20",
+              "label": "No",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "multi_radios_1_item_2",
+              "hint": "",
+              "name": "multi_radios_1",
+              "_type": "radio",
+              "_uuid": "b95dcfba-24cd-4e35-949b-0e551e7009e7",
+              "label": "Yes",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page A",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.slider",
+      "url": "slider",
+      "body": "",
+      "lede": "",
+      "_type": "page.content",
+      "_uuid": "d3072958-10f7-4293-ba02-bcc7dd53cd89",
+      "heading": "Page B",
+      "components": [
+
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.email",
+      "url": "email",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "25ee48a1-bdb8-414d-aba6-ea7be572e9f1",
+      "heading": "",
+      "components": [
+        {
+          "_id": "email_email_1",
+          "hint": "",
+          "name": "email_email_1",
+          "_type": "email",
+          "_uuid": "d6a942d0-5134-488c-9192-8dcfc0a039be",
+          "label": "Email",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "email": true,
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.multi2",
+      "url": "multi2",
+      "_type": "page.multiplequestions",
+      "_uuid": "25e888b0-5c48-441e-a69d-c6a4913315a9",
+      "heading": "Multi 2",
+      "components": [
+        {
+          "_id": "multi2_email_1",
+          "hint": "",
+          "name": "multi2_email_1",
+          "_type": "email",
+          "_uuid": "dbd9ec7b-20b2-4b2d-8481-abd608fe1e75",
+          "label": "What's you email address?",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "email": true,
+            "required": true
+          }
+        }
+      ],
+      "add_component": "email",
+      "section_heading": ""
+    },
+    {
+      "_id": "page.cya",
+      "url": "cya",
+      "_type": "page.checkanswers",
+      "_uuid": "173457d8-6273-47df-88b4-61adcfca5ac8",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.conf",
+      "url": "conf",
+      "_type": "page.confirmation",
+      "_uuid": "48b0bcd1-7ab1-424f-8250-9a1f0beed2f7",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_at": "2022-04-21T14:59:57Z",
+  "created_by": "f0f9f2e2-239e-4e44-989d-6eacfabb69d7",
+  "service_id": "288d3b07-f20d-4a52-98c3-ccb3a0f56dc4",
+  "version_id": "59819d43-22c1-4e15-bb31-b4ee3eea877f",
+  "service_name": "Branching 12",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "This online form puts a small file (known as ‘cookies’) onto your computer to collect information about how you browse the site.\r\n\r\nCookies are used to:\r\n\r\n- remember your progress\r\n- measure how you use the website so it can be updated and improved based on your needs\r\n\r\nThis online form's cookie isn't used to identify you personally.\r\n\r\nYou'll normally see a message on the site before we store a cookie on your computer.\r\n\r\nFind out more about [how to manage cookies](https://www.aboutcookies.org/).\r\n\r\n##How cookies are used on this online form\r\n\r\nWe will store a cookie to remember your progress on this computer and to expire your session after 30 minutes of inactivity or when you close your browser.\r\n\r\n- name: _fb_runner_session\r\n- purpose: saves your current progress in this computer and tracks inactivity periods\r\n- expires: after 30 minutes of inactivity or when you close your browser",
+      "_type": "page.standalone",
+      "_uuid": "a5d8f4b5-2d73-4432-aa51-b36812d6a2ff",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "This privacy notice explains what [insert your organisation name] means when we talk about personal data, why we ask for this information about you and what we do with it when you use this form.\r\n\r\nIt also explains how we store your data, how you can get a copy of the information we’ve collected about you and how you can complain if you think we’ve done something wrong.\r\n\r\n###Who manages this service\r\n\r\nThis form is managed by [your organisation].\r\n\r\nThe information you submit will be processed by [insert who will be processing the information and, if it’s a separate organisation, what their relationship is to you].\r\n\r\n[Insert name of organisation that acts as data controller for your form] is the data controller for the personal data collected by this form.\r\n\r\n###When we ask for personal data\r\n\r\nWhenever we ask for information about you, we promise to:\r\n\r\n- always let you know why we need it\r\n- ask for relevant personal information only\r\n- make sure we do not keep it longer than needed\r\n- keep your information safe and make sure nobody can access it unless authorised to do so\r\n- only share your data with other organisations for legitimate purposes\r\n- consider any request you make to correct or delete your personal data\r\n\r\nWe also promise to make it easy for you to:\r\n\r\n- tell us at any time if you want us to stop storing your personal data\r\n- make a complaint to the supervisory authority\r\n\r\n###The personal data we collect\r\n\r\nWe only collect personal data that you directly provide with your application.\r\n\r\nWe only collect the information we need to deliver this service to you. The personal data collected includes:\r\n\r\n- [summarise the types of personal information requested by your form]\r\n\r\nWe [use cookies](http://www.aboutcookies.org.uk/managing-cookies) to collect data that tells us about how the service is used, including:\r\n\r\n- your computer, phone or tablet’s IP address\r\n\r\n- the region or town where you are using your computer, phone or tablet\r\n\r\n- the operating system and web browser you use\r\n\r\nThis information is not used to identify you personally.\r\n\r\n###Why we collect your personal data\r\n\r\nWe collect data to [describe why you are collecting personal information]. The processing of your personal data is necessary for [explain why you require the personal information].\r\n\r\nThe legal basis for collecting and processing your personal data is [enter and explain your legal basis here, for example, that it is necessary to perform a task in the public interest or\nin the exercise of your functions as a government department].\r\n\r\nUse of the online form is voluntary. If you do not provide all the information we ask for, we may not be able to process your [insert the purpose of your form, such as claim, application or request].\r\n\r\nPlease note that transmitting information over the internet is generally not completely secure, and [your organisation] can’t guarantee the security of your data. Any data you transmit is at your own risk. [your organisation, and any other organisations involved in processing the data] have procedures and security features in place to keep your data secure once we receive it.\r\n\r\n###Sharing your personal data\r\n\r\nThe information you provide will be shared with… [name any organisations that you might share the data with and provide an explanation of why the information may be shared and what it will be used for]\r\n\r\nWe may also use your contact information to ask for feedback on using the service, but only when you have given your consent for us to do so. [delete this paragraph if not applicable]\r\n\r\nWe’ll never share your information with other organisations for marketing, market research or commercial purposes.\r\n\r\n###Keeping your personal data\r\n\r\nTo protect your personal information, any data you enter as you progress through the online form is held temporarily and securely until you submit your application, after which your application cannot be viewed or modified further online.\r\n\r\n[your organisation, and any other organisations involved in processing the data] will keep your data for [specify how long you will keep the information for and why].\r\n\r\nAll deleted data will be destroyed securely and confidentially.\r\n\r\n###How we use your personal data\r\n\r\nYour online submission will be sent from the online form to [your organisation or whichever other organisation will receive the information for processing] via encrypted email. The system does not retain a copy of your information.\r\n\r\n[select one of the following 3 paragraphs which most closely fits your circumstances and delete the other 2]\r\n\r\nYour personal data is not used in any automated decision making (a decision made solely by automated means without any human involvement) or profiling (automated processing of personal data to evaluate certain conditions about an individual).\r\n\r\nAutomated decision making (a decision made solely by automated means without any human involvement) is used for the purpose of [insert why ADM is used] and is carried out [include when in the process this is carried out]. The personal data used for this purpose includes [insert personal data types].\r\n\r\nProfiling (automated processing of personal data to evaluate certain conditions about an individual) is carried out for the purpose of [insert reason why profiling exists]. The personal data used for this purpose includes [insert personal data types].\r\n\r\n###How we store your personal data\r\n\r\n[your organisation or whichever other organisation will receive the information for processing] take data security very seriously and take every step to ensure that your data remains private and secure. All data collected by this service is stored in a secure database [kept entirely within the UK/kept outside of the UK but within the European Economic Area (EEA). - delete as appropriate]\r\n\r\nIt may sometimes be necessary to transfer personal information overseas, outside of the UK and the European Economic Area (EEA). When this is needed information may be transferred to [insert names of countries]. Any transfers made will be in full compliance with all aspects of the data protection law. [delete this paragraph if not applicable or contact your data protection team for guidance on required safeguards] \r\n\r\nYour application will only be accessible to [your organisation, and any other organisations involved in processing the data] staff who require access to process applications.\r\n\r\n###Your rights\r\n\r\nYou have a number of rights, depending on the reason for processing your information. These include:\r\n\r\n- the right to request a copy of your personal data and information about how your personal data is processed (this is known as a subject access request)\r\n- the right to have inaccuracies in your personal data corrected\r\n- the right to fill in any gaps in your personal data, including by means of a supplementary statement\r\n- the right to ask for the processing of your personal data to be restricted\r\n- the right to ask for your personal data to be deleted if there is no longer a justification for it\r\n- the right to object to automated decision making, including profiling, that has a legal or significant effect on you as an individual\r\n\r\nIf you want to see the personal data that we hold on you, you can make a subject access request. Send your request by post to:\r\n\r\nDisclosure Team  \r\nPost point 10.25  \r\n102 Petty France  \r\nLondon  \r\nSW1H 9AJ\r\n\r\nor email: data.access@justice.gov.uk\r\n\r\nFor all other rights, please write to us at:\r\n\r\n[insert your postal and email addresses]\r\n\r\n###Getting more information\r\n\r\nYou can get more details on:\r\n\r\n- agreements we have with other organisations for sharing information\r\n- when we can pass on personal information without telling you, for example, to help with the prevention or detection of crime or to produce anonymised statistics\r\n- instructions we give to staff on how to collect, use or delete your personal information\r\n- how we check that the information we have is accurate and up-to-date\r\n- how to make a complaint\r\n\r\nFor more information, please contact the [your organisation] data protection officer at:\r\n\r\n[insert the postal and email addresses of your data protection officer - for the MoJ, this is:\r\n\r\nThe Data Protection Officer  \r\nMinistry of Justice  \r\n10 South Colonnade\nCanary Wharf  \r\nLondon  \r\nE14 4PU\r\n\r\nEmail: DPO@justice.gov.uk]\r\n\r\n###Making a complaint\r\n\r\nWhen we ask you for information, we will keep to the law. If you think that your information has not been handled correctly, you can contact the [Information Commissioner](https://ico.org.uk/) for independent advice about data protection on the address below:\r\n\r\nInformation Commissioner's Office  \r\nWycliffe House  \r\nWater Lane  \r\nWilmslow  \r\nCheshire  \r\nSK9 5AF\r\n\r\nTelephone: 0303 123 1113",
+      "_type": "page.standalone",
+      "_uuid": "d2749744-72c7-41e5-8666-b3a83acc844b",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "This accessibility statement applies to [describe your form here - for example, the general enquiries form for the CICA]. There is a separate [accessibility statement for the main GOV.UK website](https://www.gov.uk/help/accessibility-statement).\r\n\r\n###Using this online form\r\n\r\nThis form was built using MoJ Forms, a tool developed by the Ministry of Justice, and uses components from the [GOV.UK Design System](https://design-system.service.gov.uk/).\r\n\r\n[insert your organisation here] is responsible for the content of this online form. The Ministry of Justice is responsible for its technical aspects.\r\n\r\nWe want as many people as possible to be able to use this online form. For example, that means you should be able to:\r\n\r\n- change colours, contrast levels and fonts\r\n- zoom in up to 300% without the text spilling off the screen\r\n- navigate the form using just a keyboard\r\n- navigate the form using speech recognition software\r\n- listen to the form using a screen reader (including recent versions of JAWS, NVDA and VoiceOver)\r\n\r\nWe’ve also made the text as simple as possible to understand.\r\n\r\n[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.\r\n\r\n###Feedback and contact information\r\n\r\nIf you need information on this website in a different format:\r\n\r\n[insert your contact details for user requests here - add other channels, such as text phones or Relay UK, as required]\r\n\r\n- email: [your email address]\r\n- call: [your telephone number]\r\n- [Hours - e.g. Monday to Friday, 9am to 5pm]\r\n\r\nWe'll consider your request and get back to you in [add your SLA - e.g. a week or 5 working days].\r\n\r\n###Reporting accessibility problems with this form\r\n\r\nWe’re always looking to improve the accessibility of this form. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact:\r\n\r\n[insert your contact details for user feedback here - add other channels, such as text phones or Relay UK, as required]\r\n\r\n- email: [your email address]\r\n- call: [your telephone number]\r\n- [Hours - e.g. Monday to Friday, 9am to 5pm]\r\n\r\n###Enforcement procedure\r\n\r\nThe Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the [Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).\r\n\r\n###Technical information about this online form’s accessibility\r\n\r\nWe are committed to making our online forms and services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.\r\n\r\n####Compliance status\r\n\r\nThis online form is fully compliant with the [Web Content Accessibility Guidelines version 2.1 AA standard](https://www.w3.org/TR/WCAG21/)\r\n\r\n###Preparation of this accessibility statement\r\n\r\nThis statement was prepared on [date when it was first published]. It was last reviewed on [date when it was last reviewed].\r\n\r\nThis form was last tested on [date when you performed your basic accessibility check].\r\n\r\nIn order to test the compliance of all forms built using the MoJ Forms tool, the Ministry of Justice commissioned The Digital Accessibility Centre (DAC) to carry out a WCAG 2.1 AA level audit of a sample form. This included extensive testing by users with a wide range of disabilities. The audit was performed on 8 April 2021. The audit highlighted a number of non-compliance issues which were fixed on 11 May 2021.\r\n\r\nIn addition, this form was tested by [insert team or organisation here]. It was tested using the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) following guidance from the Ministry of Justice and the Government Digital Service (GDS).\r\n\r\n###What we’re doing to improve accessibility\r\n\r\nWe will monitor the accessibility of this website on an ongoing basis and fix any accessibility issues reported to us.",
+      "_type": "page.standalone",
+      "_uuid": "ce09854a-3ffa-4325-9013-142962432508",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.16.1'.freeze
+  VERSION = '2.16.2'.freeze
 end

--- a/spec/models/grid_spec.rb
+++ b/spec/models/grid_spec.rb
@@ -567,6 +567,16 @@ RSpec.describe MetadataPresenter::Grid do
           end
         end
       end
+
+      context 'inserting confirmation page' do
+        let(:latest_metadata) { metadata_fixture(:branching_12) }
+        let(:confirmation_uuid) { '48b0bcd1-7ab1-424f-8250-9a1f0beed2f7' }
+
+        it 'builds the correct main flow' do
+          # The confirmation page will always be in the last column, first row
+          expect(grid.build.last.first.uuid).to eq(confirmation_uuid)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/c4I4IvM3/2410-sometime-the-flow-view-shows-confirmation-before-cya-and-other-bugs)
- If confirmation and CYA pages exist, deliberately set the confirmation page to be after the CYA page.
- Bump to 2.16.2

### Before
![before](https://user-images.githubusercontent.com/29227502/164647115-3362dee9-6025-4cd0-b4fc-6e83bdb357e7.png)

### After
![after](https://user-images.githubusercontent.com/29227502/164647140-aef83301-3560-424e-b0cf-cca9d0739272.png)
