### PR TITLE
Surface component validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.16.4] - 2022-05-06
+
+### Added
+
+- Surface supported validations for each component
+
 ## [2.16.3] - 2022-05-05
 
 ### Added

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -1,4 +1,6 @@
 class MetadataPresenter::Component < MetadataPresenter::Metadata
+  VALIDATION_BUNDLES = { 'number' => 'number' }.freeze
+
   def to_partial_path
     "metadata_presenter/component/#{type}"
   end
@@ -29,5 +31,23 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
 
   def find_item_by_uuid(uuid)
     items.find { |item| item.uuid == uuid }
+  end
+
+  def supported_validations
+    return [] if validation_bundle_key.nil?
+
+    JSON::Validator.schema_for_uri(validation_bundle_key)
+                   .schema['properties']['validation']['properties']
+                   .keys
+  end
+
+  private
+
+  def validation_bundle_key
+    @validation_bundle_key ||=
+      if type.in?(VALIDATION_BUNDLES.keys)
+        definition_bundle = VALIDATION_BUNDLES[type]
+        "validations.#{definition_bundle}_bundle"
+      end
   end
 end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.16.3'.freeze
+  VERSION = '2.16.4'.freeze
 end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -117,4 +117,31 @@ RSpec.describe MetadataPresenter::Component do
       end
     end
   end
+
+  describe '#supported_validations' do
+    context 'when validation bundle exists for component type' do
+      let(:attributes) { { '_type' => 'number' } }
+      let(:expected_validations) do
+        %w[
+          exclusive_maximum
+          exclusive_minimum
+          maximum
+          minimum
+          multiple_of
+        ]
+      end
+
+      it 'returns the supported validations for that component type' do
+        expect(component.supported_validations).to match_array(expected_validations)
+      end
+    end
+
+    context 'when validation bundle does not exist for component type' do
+      let(:attributes) { { '_type' => 'no-validation-component' } }
+
+      it 'returns an empty array' do
+        expect(component.supported_validations).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Return the supported validations for a given component object or an
empty array if there are none.

Publish 2.16.4