### PR TITLE
2454 confirmation template width bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.16.5] - 2022-05-09
+
+### Changed
+
+- Small design bug fix to Confirmation page
+
 ## [2.16.4] - 2022-05-06
 
 ### Added

--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -30,7 +30,6 @@
     </div>
     <%= render template: 'metadata_presenter/footer/footer' %>
 
-    <%= javascript_pack_tag 'application' %>
     <%= javascript_pack_tag 'govuk' %>
   </body>
 </html>

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -1,5 +1,5 @@
 <div class="fb-main-grid-wrapper" data-fb-pagetype="<%= @page.type %>">
-  <div class="govuk-panel govuk-panel--confirmation">
+  <div class="govuk-panel govuk-panel--confirmation govuk-grid-column-two-thirds">
     <h1 class="fb-editable govuk-panel__title"
         data-fb-content-type="element"
         data-fb-content-id="page[heading]">

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.16.4'.freeze
+  VERSION = '2.16.5'.freeze
 end


### PR DESCRIPTION
- Fix small design bug (width Confirmation)
- Silenced JS error message (was pulling unwanted Editor code)

**Visual was:**
<img width="1066" alt="Screenshot 2022-05-09 at 08 45 12" src="https://user-images.githubusercontent.com/76942244/167363988-53d48988-2b16-4b60-ad21-71c64565f89f.png">

**Visual now:**
<img width="1047" alt="Screenshot 2022-05-09 at 08 45 23" src="https://user-images.githubusercontent.com/76942244/167364051-c2995096-43c8-4c09-a038-35c00890e7e5.png">
