### PR TITLE
Fix date after and date before valdiators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.16.8] - 2022-05-19
+
+- Fix date valdiators which were reversed
+
+### Fixed
+
 ## [2.16.7] - 2022-05-17
 
 ### Fixed

--- a/app/validators/metadata_presenter/date_after_validator.rb
+++ b/app/validators/metadata_presenter/date_after_validator.rb
@@ -2,7 +2,7 @@ module MetadataPresenter
   class DateAfterValidator < BaseValidator
     def invalid_answer?
       answer_date = "#{user_answer.year}-#{user_answer.month}-#{user_answer.day}"
-      Date.parse(answer_date).iso8601 > Date.parse(component.validation[schema_key]).iso8601
+      Date.parse(answer_date).iso8601 < Date.parse(component.validation[schema_key]).iso8601
     end
   end
 end

--- a/app/validators/metadata_presenter/date_before_validator.rb
+++ b/app/validators/metadata_presenter/date_before_validator.rb
@@ -2,7 +2,7 @@ module MetadataPresenter
   class DateBeforeValidator < BaseValidator
     def invalid_answer?
       answer_date = "#{user_answer.year}-#{user_answer.month}-#{user_answer.day}"
-      Date.parse(answer_date).iso8601 < Date.parse(component.validation[schema_key]).iso8601
+      Date.parse(answer_date).iso8601 > Date.parse(component.validation[schema_key]).iso8601
     end
   end
 end

--- a/default_metadata/string/error.date_after.json
+++ b/default_metadata/string/error.date_after.json
@@ -1,6 +1,6 @@
 {
   "_id": "error.date_after",
   "_type": "string.error",
-  "description": "Input (date) is later than allowed",
-  "value": "Enter an earlier date for %{control}"
+  "description": "Input (date) is earlier than allowed",
+  "value": "Enter a later date for %{control}"
 }

--- a/default_metadata/string/error.date_before.json
+++ b/default_metadata/string/error.date_before.json
@@ -1,6 +1,6 @@
 {
   "_id": "error.date_before",
   "_type": "string.error",
-  "description": "Input (date) is earlier than allowed",
-  "value": "Enter a later date for %{control}"
+  "description": "Input (date) is later than allowed",
+  "value": "Enter an earlier date for %{control}"
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.16.7'.freeze
+  VERSION = '2.16.8'.freeze
 end

--- a/spec/validators/date_after_validator_spec.rb
+++ b/spec/validators/date_after_validator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe MetadataPresenter::DateAfterValidator do
       validator.valid?
     end
 
-    context 'when date is after the latest date' do
+    context 'when date is after the earliest date' do
       let(:answers) do
         {
           'holiday_date_1(3i)' => '1',
@@ -26,20 +26,20 @@ RSpec.describe MetadataPresenter::DateAfterValidator do
       end
 
       it 'returns invalid' do
-        expect(validator).to_not be_valid
+        expect(validator).to be_valid
       end
     end
 
-    context 'when date is before the latest date' do
+    context 'when date is before the earliest date' do
       let(:answers) do
         {
           'holiday_date_1(3i)' => '1',
           'holiday_date_1(2i)' => '1',
-          'holiday_date_1(1i)' => '1997'
+          'holiday_date_1(1i)' => '1990'
         }
       end
       it 'returns valid' do
-        expect(validator).to be_valid
+        expect(validator).to_not be_valid
       end
     end
   end

--- a/spec/validators/date_before_validator_spec.rb
+++ b/spec/validators/date_before_validator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe MetadataPresenter::DateBeforeValidator do
       validator.valid?
     end
 
-    context 'when date is before the earliest date' do
+    context 'when date is before the latest date' do
       let(:answers) do
         {
           'holiday_date_1(3i)' => '1',
@@ -26,11 +26,11 @@ RSpec.describe MetadataPresenter::DateBeforeValidator do
       end
 
       it 'returns invalid' do
-        expect(validator).to_not be_valid
+        expect(validator).to be_valid
       end
     end
 
-    context 'when date is after the earliest date' do
+    context 'when date is after the latest date' do
       let(:answers) do
         {
           'holiday_date_1(3i)' => '1',
@@ -39,7 +39,7 @@ RSpec.describe MetadataPresenter::DateBeforeValidator do
         }
       end
       it 'returns valid' do
-        expect(validator).to be_valid
+        expect(validator).to_not be_valid
       end
     end
   end


### PR DESCRIPTION
The date validators were reversed:

date_after should be validating whether a user answer is after an
earliest date set in the metadata.

date_before should be validating whether a user answer is before a
latest date set in the metadata.

Publish 2.16.8