### PR TITLE
Update date and text validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.16.9] - 2022-05-20
+
+### Fixed
+
+- Check whether date is valid before validating after and before
+- Coerce string length validators to integer before comparing user answers
+
 ## [2.16.8] - 2022-05-19
 
 - Fix date valdiators which were reversed

--- a/app/validators/metadata_presenter/date_after_validator.rb
+++ b/app/validators/metadata_presenter/date_after_validator.rb
@@ -1,6 +1,8 @@
 module MetadataPresenter
-  class DateAfterValidator < BaseValidator
+  class DateAfterValidator < DateValidator
     def invalid_answer?
+      return if super
+
       answer_date = "#{user_answer.year}-#{user_answer.month}-#{user_answer.day}"
       Date.parse(answer_date).iso8601 < Date.parse(component.validation[schema_key]).iso8601
     end

--- a/app/validators/metadata_presenter/date_before_validator.rb
+++ b/app/validators/metadata_presenter/date_before_validator.rb
@@ -1,6 +1,8 @@
 module MetadataPresenter
-  class DateBeforeValidator < BaseValidator
+  class DateBeforeValidator < DateValidator
     def invalid_answer?
+      return if super
+
       answer_date = "#{user_answer.year}-#{user_answer.month}-#{user_answer.day}"
       Date.parse(answer_date).iso8601 > Date.parse(component.validation[schema_key]).iso8601
     end

--- a/app/validators/metadata_presenter/max_length_validator.rb
+++ b/app/validators/metadata_presenter/max_length_validator.rb
@@ -1,7 +1,7 @@
 module MetadataPresenter
   class MaxLengthValidator < BaseValidator
     def invalid_answer?
-      user_answer.to_s.size > component.validation[schema_key]
+      user_answer.to_s.size > component.validation[schema_key].to_i
     end
   end
 end

--- a/app/validators/metadata_presenter/min_length_validator.rb
+++ b/app/validators/metadata_presenter/min_length_validator.rb
@@ -1,7 +1,7 @@
 module MetadataPresenter
   class MinLengthValidator < BaseValidator
     def invalid_answer?
-      user_answer.to_s.size < component.validation[schema_key]
+      user_answer.to_s.size < component.validation[schema_key].to_i
     end
   end
 end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.16.8'.freeze
+  VERSION = '2.16.9'.freeze
 end

--- a/spec/validators/date_after_validator_spec.rb
+++ b/spec/validators/date_after_validator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe MetadataPresenter::DateAfterValidator do
         }
       end
 
-      it 'returns invalid' do
+      it 'returns valid' do
         expect(validator).to be_valid
       end
     end
@@ -38,8 +38,22 @@ RSpec.describe MetadataPresenter::DateAfterValidator do
           'holiday_date_1(1i)' => '1990'
         }
       end
-      it 'returns valid' do
+      it 'returns invalid' do
         expect(validator).to_not be_valid
+      end
+    end
+
+    context 'when not a valid date' do
+      let(:answers) do
+        {
+          'holiday_date_1(3i)' => 'not a day',
+          'holiday_date_1(2i)' => '1',
+          'holiday_date_1(1i)' => '1999'
+        }
+      end
+
+      it 'returns valid' do
+        expect(validator).to be_valid
       end
     end
   end

--- a/spec/validators/date_before_validator_spec.rb
+++ b/spec/validators/date_before_validator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe MetadataPresenter::DateBeforeValidator do
         }
       end
 
-      it 'returns invalid' do
+      it 'returns valid' do
         expect(validator).to be_valid
       end
     end
@@ -38,8 +38,23 @@ RSpec.describe MetadataPresenter::DateBeforeValidator do
           'holiday_date_1(1i)' => '2055'
         }
       end
-      it 'returns valid' do
+
+      it 'returns invalid' do
         expect(validator).to_not be_valid
+      end
+    end
+
+    context 'when not a valid date' do
+      let(:answers) do
+        {
+          'holiday_date_1(3i)' => '1',
+          'holiday_date_1(2i)' => '1',
+          'holiday_date_1(1i)' => 'not a year'
+        }
+      end
+
+      it 'returns valid' do
+        expect(validator).to be_valid
       end
     end
   end


### PR DESCRIPTION
Calling size on a string returns and integer to the component length
configuration also needs to be an integer.

The date component already has a date validator on it by default which
checks whether the user input is in fact a valid date. Therefore the
date_after and date_before components should not attempt to validate
whether the date is  valid before or after what is configured. Just let the
date validator error surface back to the user.

Publish 2.16.9