### PR TITLE
Check number value for necessary validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.16.10] - 2022-05-20
+
+### Fixed
+
+- Check whether answer is a number before validating minimum and maximum
+
 ## [2.16.9] - 2022-05-20
 
 ### Fixed

--- a/app/validators/metadata_presenter/maximum_validator.rb
+++ b/app/validators/metadata_presenter/maximum_validator.rb
@@ -1,6 +1,8 @@
 module MetadataPresenter
-  class MaximumValidator < BaseValidator
+  class MaximumValidator < NumberValidator
     def invalid_answer?
+      return if super
+
       Float(user_answer, exception: false) > Float(component.validation[schema_key], exception: false)
     end
   end

--- a/app/validators/metadata_presenter/minimum_validator.rb
+++ b/app/validators/metadata_presenter/minimum_validator.rb
@@ -1,6 +1,8 @@
 module MetadataPresenter
-  class MinimumValidator < BaseValidator
+  class MinimumValidator < NumberValidator
     def invalid_answer?
+      return if super
+
       Float(user_answer, exception: false) < Float(component.validation[schema_key], exception: false)
     end
   end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.16.9'.freeze
+  VERSION = '2.16.10'.freeze
 end

--- a/spec/validators/maximum_validator_spec.rb
+++ b/spec/validators/maximum_validator_spec.rb
@@ -35,5 +35,13 @@ RSpec.describe MetadataPresenter::MaximumValidator do
         end
       end
     end
+
+    context 'when not a number' do
+      let(:answers) { { 'your-age_number_1' => 'i am not a number' } }
+
+      it 'returns valid' do
+        expect(validator).to be_valid
+      end
+    end
   end
 end

--- a/spec/validators/minimum_validator_spec.rb
+++ b/spec/validators/minimum_validator_spec.rb
@@ -35,5 +35,13 @@ RSpec.describe MetadataPresenter::MinimumValidator do
         end
       end
     end
+
+    context 'when not a number' do
+      let(:answers) { { 'your-age_number_1' => 'i am not a number' } }
+
+      it 'returns valid' do
+        expect(validator).to be_valid
+      end
+    end
   end
 end


### PR DESCRIPTION
Similar to the date component, the default metadata for a number
component already includes the 'Number' validation. Therefore do not
bother validating the minimum or maximum unless the number validation is
valid.