### PR TITLE
Format date validation configuration error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [Unreleased]
+
+### Changed
+
+- Format date validation configuration string to a human readable form of DD MM YYYY
+- Update validation error message content
+
 ## [2.16.10] - 2022-05-20
 
 ### Fixed

--- a/app/validators/metadata_presenter/base_validator.rb
+++ b/app/validators/metadata_presenter/base_validator.rb
@@ -75,10 +75,9 @@ module MetadataPresenter
     # is not present
     def default_error_message
       default_error_message_key = "error.#{schema_key}"
-      default_message = Rails
-                          .application
-                          .config
-                          .default_metadata[default_error_message_key]
+      default_message = Rails.application
+                             .config
+                             .default_metadata[default_error_message_key]
 
       if default_message.present?
         default_message['value'] % error_message_hash
@@ -116,8 +115,14 @@ module MetadataPresenter
     def error_message_hash
       {
         control: component.humanised_title,
-        schema_key.to_sym => component.validation[schema_key]
+        schema_key.to_sym => validation_value
       }
+    end
+
+    # The validation configuration value
+    # Override if additional formatting of the value is required
+    def validation_value
+      component.validation[schema_key]
     end
 
     # Method signature to be overwrite in the subclass if you do not want to allow

--- a/app/validators/metadata_presenter/date_validator.rb
+++ b/app/validators/metadata_presenter/date_validator.rb
@@ -1,5 +1,7 @@
 module MetadataPresenter
   class DateValidator < BaseValidator
+    DATE_STRING_VALIDATIONS = %w[date_after date_before].freeze
+
     def invalid_answer?
       Date.strptime(
         "#{user_answer.year}-#{user_answer.month}-#{user_answer.day}",
@@ -9,6 +11,12 @@ module MetadataPresenter
       false
     rescue Date::Error
       true
+    end
+
+    def validation_value
+      return unless schema_key.in?(DATE_STRING_VALIDATIONS)
+
+      Date.parse(component.validation[schema_key]).strftime('%d %m %Y')
     end
   end
 end

--- a/default_metadata/string/error.accept.json
+++ b/default_metadata/string/error.accept.json
@@ -2,5 +2,5 @@
   "_id": "error.accept",
   "_type": "string.error",
   "description": "File uploaded is wrong type",
-  "value": "%{control} was not uploaded successfully as it is the wrong type"
+  "value": "\"%{control}\" was not uploaded successfully as it is the wrong type"
 }

--- a/default_metadata/string/error.date.json
+++ b/default_metadata/string/error.date.json
@@ -2,5 +2,5 @@
   "_id": "error.date",
   "_type": "string.error",
   "description": "Input (date) is not a valid date",
-  "value": "Enter a valid date for %{control}"
+  "value": "Enter a valid date for \"%{control}\""
 }

--- a/default_metadata/string/error.date_after.json
+++ b/default_metadata/string/error.date_after.json
@@ -2,5 +2,5 @@
   "_id": "error.date_after",
   "_type": "string.error",
   "description": "Input (date) is earlier than allowed",
-  "value": "Enter a later date for %{control}"
+  "value": "Your answer for \"%{control}\" must be %{date_after} or later"
 }

--- a/default_metadata/string/error.date_before.json
+++ b/default_metadata/string/error.date_before.json
@@ -2,5 +2,5 @@
   "_id": "error.date_before",
   "_type": "string.error",
   "description": "Input (date) is later than allowed",
-  "value": "Enter an earlier date for %{control}"
+  "value": "Your answer for \"%{control}\" must be %{date_before} or earlier"
 }

--- a/default_metadata/string/error.max_length.json
+++ b/default_metadata/string/error.max_length.json
@@ -2,5 +2,5 @@
   "_id": "error.max_length",
   "_type": "string.error",
   "description": "Input (string) is too long",
-  "value": "Your answer for '%{control}' is too long (%{max_length} characters at most)"
+  "value": "Your answer for \"%{control}\" must be %{max_length} characters or fewer"
 }

--- a/default_metadata/string/error.max_word.json
+++ b/default_metadata/string/error.max_word.json
@@ -2,5 +2,5 @@
   "_id": "error.max_word",
   "_type": "string.error",
   "description": "Input (number) is higher than the maximum number of words allowed",
-  "value": "Enter a lower number of words for %{control}"
+  "value": "Your answer for \"%{control}\" must be %{max_word} words or fewer"
 }

--- a/default_metadata/string/error.maximum.json
+++ b/default_metadata/string/error.maximum.json
@@ -2,5 +2,5 @@
   "_id": "error.maximum",
   "_type": "string.error",
   "description": "Input (number) is larger than the maximum allowed",
-  "value": "Enter a lower number for %{control}"
+  "value": "Your answer for \"%{control}\" must be %{maximum} or lower"
 }

--- a/default_metadata/string/error.min_length.json
+++ b/default_metadata/string/error.min_length.json
@@ -2,5 +2,5 @@
   "_id": "error.min_length",
   "_type": "string.error",
   "description": "Input (string) is too short",
-  "value": "Your answer for '%{control}' is too short (%{min_length} characters at least)"
+  "value": "Your answer for \"%{control}\" must be %{min_length} characters or more"
 }

--- a/default_metadata/string/error.min_word.json
+++ b/default_metadata/string/error.min_word.json
@@ -2,5 +2,5 @@
   "_id": "error.min_word",
   "_type": "string.error",
   "description": "Input (number) is lower than the minimum number of words allowed",
-  "value": "Enter a higher number of words for %{control}"
+  "value": "Your answer for \"%{control}\" must be %{min_word} words or more"
 }

--- a/default_metadata/string/error.minimum.json
+++ b/default_metadata/string/error.minimum.json
@@ -2,5 +2,5 @@
   "_id": "error.minimum",
   "_type": "string.error",
   "description": "Input (number) is lower than the minimum allowed",
-  "value": "Enter a higher number for %{control}"
+  "value": "Your answer for \"%{control}\" must be %{minimum} or higher"
 }

--- a/default_metadata/string/error.number.json
+++ b/default_metadata/string/error.number.json
@@ -2,5 +2,5 @@
   "_id": "error.number",
   "_type": "string.error",
   "description": "Input (number) is not a number",
-  "value": "Enter a number for %{control}"
+  "value": "Enter a number for \"%{control}\""
 }

--- a/default_metadata/string/error.required.json
+++ b/default_metadata/string/error.required.json
@@ -2,6 +2,6 @@
   "_id": "error.required",
   "_type": "string.error",
   "description": "Input is required",
-  "value": "Enter an answer for %{control}",
-  "value:cy": "Rhowch ateb i {control}"
+  "value": "Enter an answer for \"%{control}\"",
+  "value:cy": "Rhowch ateb i \"{control}\""
 }

--- a/default_metadata/string/error.virus_scan.json
+++ b/default_metadata/string/error.virus_scan.json
@@ -2,6 +2,6 @@
   "_id": "error.virus_scan",
   "_type": "string.error",
   "description": "File uploaded contains virus",
-  "value": "%{control} was not uploaded successfully because it contains a virus"
+  "value": "\"%{control}\" was not uploaded successfully because it contains a virus"
 }
 

--- a/spec/validators/accept_validator_spec.rb
+++ b/spec/validators/accept_validator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe MetadataPresenter::AcceptValidator do
       it 'returns a custom error message' do
         validator.valid?
         expect(page_answers.errors.full_messages).to eq(
-          ['beethoven.txt was not uploaded successfully as it is the wrong type']
+          ['"beethoven.txt" was not uploaded successfully as it is the wrong type']
         )
       end
     end

--- a/spec/validators/date_after_validator_spec.rb
+++ b/spec/validators/date_after_validator_spec.rb
@@ -57,4 +57,19 @@ RSpec.describe MetadataPresenter::DateAfterValidator do
       end
     end
   end
+
+  describe '#validation_value' do
+    let(:answers) do
+      {
+        'holiday_date_1(3i)' => '1',
+        'holiday_date_1(2i)' => '1',
+        'holiday_date_1(1i)' => '1999'
+      }
+    end
+    let(:expected_formatted_date) { '29 08 1997' }
+
+    it 'correctly formats the date validation configuration value' do
+      expect(validator.validation_value).to eq(expected_formatted_date)
+    end
+  end
 end

--- a/spec/validators/date_before_validator_spec.rb
+++ b/spec/validators/date_before_validator_spec.rb
@@ -58,4 +58,19 @@ RSpec.describe MetadataPresenter::DateBeforeValidator do
       end
     end
   end
+
+  describe '#validation_value' do
+    let(:answers) do
+      {
+        'holiday_date_1(3i)' => '1',
+        'holiday_date_1(2i)' => '1',
+        'holiday_date_1(1i)' => '1950'
+      }
+    end
+    let(:expected_formatted_date) { '05 11 1955' }
+
+    it 'correctly formats the date validation configuration value' do
+      expect(validator.validation_value).to eq(expected_formatted_date)
+    end
+  end
 end

--- a/spec/validators/max_length_validator_spec.rb
+++ b/spec/validators/max_length_validator_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe MetadataPresenter::MaxLengthValidator do
 
         it 'uses the default error message' do
           expect(page_answers.errors.full_messages).to eq(
-            ["Your answer for 'Full name' is too long (10 characters at most)"]
+            ['Your answer for "Full name" must be 10 characters or fewer']
           )
         end
       end

--- a/spec/validators/min_length_validator_spec.rb
+++ b/spec/validators/min_length_validator_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe MetadataPresenter::MinLengthValidator do
 
         it 'uses the default error message' do
           expect(page_answers.errors.full_messages).to eq(
-            ["Your answer for 'Full name' is too short (2 characters at least)"]
+            ['Your answer for "Full name" must be 2 characters or more']
           )
         end
       end

--- a/spec/validators/required_validator_spec.rb
+++ b/spec/validators/required_validator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe MetadataPresenter::RequiredValidator do
 
         it 'set default error message on page' do
           expect(page_answers.errors.full_messages).to eq(
-            ['Enter an answer for Full name']
+            ['Enter an answer for "Full name"']
           )
         end
       end
@@ -83,7 +83,7 @@ RSpec.describe MetadataPresenter::RequiredValidator do
           it 'returns errors' do
             validator.valid?
             expect(page_answers.errors[:holiday_date_1]).to include(
-              'Enter an answer for What is the day that you like to take holidays?'
+              'Enter an answer for "What is the day that you like to take holidays?"'
             )
           end
         end

--- a/spec/validators/virus_scan_validator_spec.rb
+++ b/spec/validators/virus_scan_validator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe MetadataPresenter::VirusScanValidator do
       it 'returns a custom error message' do
         validator.valid?
         expect(page_answers.errors.full_messages).to eq(
-          ['scooby_do.txt was not uploaded successfully because it contains a virus']
+          ['"scooby_do.txt" was not uploaded successfully because it contains a virus']
         )
       end
     end


### PR DESCRIPTION
For the date_after and date_before validations we want to be able to
inject a formatted date into the error message to the user. However we
do not want to do this for the `date` validator itself as the value for
this is a boolean and not a date string.

Also remove the single quotes around the question name.

Also inject the validation config value into the error message.

## Minimum and Maximum Character Length

### Before

<img width="750" alt="min_length_before" src="https://user-images.githubusercontent.com/3466862/170685787-ee1c77fd-3c1e-4dc6-afba-acec125c0d8f.png">

<img width="764" alt="max_length_before" src="https://user-images.githubusercontent.com/3466862/170685791-a8a56686-70ec-4dd2-b758-7dfa43163c3b.png">

### After

![Screenshot 2022-05-27 at 14 46 44](https://user-images.githubusercontent.com/3466862/170712559-15d8a753-a2da-4e66-9356-66a83d55db5d.png)

![Screenshot 2022-05-27 at 14 46 57](https://user-images.githubusercontent.com/3466862/170712564-90069d9b-07eb-4d9d-b7d0-cfcfa397cd19.png)

## Minimum and Maximum Word Count

### Before

<img width="819" alt="max_word_before" src="https://user-images.githubusercontent.com/3466862/170685901-5ef76a45-4532-418d-a641-bf4dd58fbbc3.png">

<img width="758" alt="min_word_before" src="https://user-images.githubusercontent.com/3466862/170685897-9906798b-1171-4a27-bc7e-b39491634427.png">

### After

![Screenshot 2022-05-27 at 14 50 48](https://user-images.githubusercontent.com/3466862/170712930-256825b7-8f2e-4fcf-8efe-8c5ab7082901.png)

![Screenshot 2022-05-27 at 14 51 04](https://user-images.githubusercontent.com/3466862/170712931-874935c8-1700-4e29-a165-8fc00f4fb1b3.png)

## Date After and Before 

### Before

<img width="730" alt="date_before_before" src="https://user-images.githubusercontent.com/3466862/170686034-e72ada94-ce71-4007-8966-b19d62f4592f.png">

<img width="748" alt="date_after_before" src="https://user-images.githubusercontent.com/3466862/170686027-a1a282a3-1ffe-4317-b9dc-3d6d7df17538.png">

### After

![Screenshot 2022-05-27 at 14 52 20](https://user-images.githubusercontent.com/3466862/170713180-1c77f88b-c943-49a5-8eac-1cedc4e4cce4.png)

![Screenshot 2022-05-27 at 14 52 32](https://user-images.githubusercontent.com/3466862/170713185-71a44c1c-5a41-4684-a849-1aac71d2224c.png)

