### PR TITLE
Enable max_length and max_word remaining counts to be shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.16.12] - 2022-06-01
+
+### Changed
+
+ - Updates to ensure character/word remaining count displays for textarea component
+
 ## [2.16.11] - 2022-05-27
 
 ### Added

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -6,6 +6,10 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
     'textarea' => 'string'
   }.freeze
 
+  # Used for max_length and max_word validations.
+  # Threshold percentage at which the remaining count is shown
+  VALIDATION_STRING_LENGTH_THRESHOLD = 75
+
   def to_partial_path
     "metadata_presenter/component/#{type}"
   end
@@ -44,6 +48,10 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
     JSON::Validator.schema_for_uri(validation_bundle_key)
                    .schema['properties']['validation']['properties']
                    .keys
+  end
+
+  def validation_threshold
+    VALIDATION_STRING_LENGTH_THRESHOLD
   end
 
   private

--- a/app/views/metadata_presenter/component/_textarea.html.erb
+++ b/app/views/metadata_presenter/component/_textarea.html.erb
@@ -6,8 +6,8 @@
       text: component.hint
     },
     name: "answers[#{component.name}]",
-    max_chars: component.maxchars,
-    max_words: component.maxwords,
-    threshold: component.threshold,
+    max_chars: component.validation['max_length'],
+    max_words: component.validation['max_word'],
+    threshold: component.validation_threshold,
     rows: component.rows
 %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.16.11'.freeze
+  VERSION = '2.16.12'.freeze
 end


### PR DESCRIPTION
Changes to eanble the charaters/words remaining to be shown.

Remaining counts will be shown once the threshold of 75% is reached.

![image](https://user-images.githubusercontent.com/595564/171360062-839bca26-91ae-433c-97f9-675c7e629780.png)
