### PR TITLE
Google analytics tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [Unreleased]
+
+- Add google analytics tags to the application layout
+
 ## [2.16.12] - 2022-06-01
 
 ### Changed

--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -4,7 +4,7 @@
     <title><%= service.service_name %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    
+
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_pack_url('media/images/favicon.ico') %>" type="image/x-icon" />
   <link rel="mask-icon" href="<%= asset_pack_url('media/images/govuk-mask-icon.svg') %>" color="blue">
@@ -15,9 +15,14 @@
 
     <%= stylesheet_pack_tag 'govuk' %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
+
+    <%= render template: 'metadata_presenter/analytics/analytics' %>
   </head>
 
   <body class="govuk-template__body">
+    <% if ENV['GTM'].present? %>
+      <%= render partial: 'metadata_presenter/analytics/gtm_body', locals: { analytic_tag: ENV['GTM'] } %>
+    <% end %>
     <%= render template: 'metadata_presenter/header/show' %>
     <div class="govuk-width-container govuk-body-m">
       <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">

--- a/app/views/metadata_presenter/analytics/_ga4.html.erb
+++ b/app/views/metadata_presenter/analytics/_ga4.html.erb
@@ -1,0 +1,10 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= analytic_tag %>"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', <%= analytic_tag %>);
+</script>
+<!-- End Global site tag (gtag.js) - Google Analytics -->

--- a/app/views/metadata_presenter/analytics/_google.html.erb
+++ b/app/views/metadata_presenter/analytics/_google.html.erb
@@ -1,0 +1,5 @@
+<% analytics.each do |analytic| %>
+  <% if ENV[analytic].present? %>
+    <%= render partial: "metadata_presenter/analytics/#{analytic.downcase}", locals: { analytic_tag: ENV[analytic] } %>
+  <% end %>
+<% end %>

--- a/app/views/metadata_presenter/analytics/_gtm.html.erb
+++ b/app/views/metadata_presenter/analytics/_gtm.html.erb
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer',<%= analytic_tag %>);</script>
+<!-- End Google Tag Manager -->

--- a/app/views/metadata_presenter/analytics/_gtm_body.html.erb
+++ b/app/views/metadata_presenter/analytics/_gtm_body.html.erb
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= analytic_tag %>"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/app/views/metadata_presenter/analytics/_ua.html.erb
+++ b/app/views/metadata_presenter/analytics/_ua.html.erb
@@ -1,0 +1,11 @@
+<!-- Google Universal Analytics -->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', <%= analytic_tag %>, 'auto');
+  ga('send', 'pageview');
+</script>
+<!-- End Google Universal Analytics -->

--- a/app/views/metadata_presenter/analytics/analytics.html.erb
+++ b/app/views/metadata_presenter/analytics/analytics.html.erb
@@ -1,0 +1,3 @@
+<% Rails.application.config.supported_analytics.each do |provider, analytics| %>
+  <%= render partial: "metadata_presenter/analytics/#{provider}", locals: { analytics: analytics } %>
+<% end %>

--- a/config/initializers/supported_analytics.rb
+++ b/config/initializers/supported_analytics.rb
@@ -1,0 +1,1 @@
+Rails.application.config.supported_analytics = { google: %w[UA GTM GA4] }


### PR DESCRIPTION
This adds the script tags for analytics to the head of the application
layout. We initially support Google Analytics at this time. There are
three types:

- UA (Universal Analytics)
- GTM (Google Tag Manager)
- GA4 (Google Analytics 4)

Each one injects a different script into the head. In the case of Google
Tag Manager it also adds a no-script tag to the beginning of the body.