### PR TITLE
Correctly traverse pages based on user answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.0] - 2022-06-09
+
+### Fixed
+
+- Fixed issue where pages traversed based on user answers were incomplete and therefore
+  missing from submission payloads and generated PDF files
+
 ## [2.16.14] - 2022-06-09
 
 ### Fixed

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -34,7 +34,7 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
   end
 
   def start_page
-    pages.first
+    pages.find { |page| page.type == 'page.start' }
   end
 
   def service_slug

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.16.14'.freeze
+  VERSION = '2.17.0'.freeze
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -152,8 +152,15 @@ RSpec.describe MetadataPresenter::Service do
   end
 
   describe '#start_page' do
+    let(:service) do
+      meta = metadata_fixture(:branching)
+      meta['pages'] = meta['pages'].shuffle
+      MetadataPresenter::Service.new(meta)
+    end
+
     it 'returns the correct start page' do
-      expect(service.start_page.id).to eq(service_metadata['pages'][0]['_id'])
+      expect(service.start_page.type).to eq('page.start')
+      expect(service.start_page.url).to eq('/')
     end
   end
 

--- a/spec/models/traversed_pages_spec.rb
+++ b/spec/models/traversed_pages_spec.rb
@@ -4,60 +4,159 @@ RSpec.describe MetadataPresenter::TraversedPages do
       service, user_data, current_page
     )
   end
-  let(:service_metadata) { metadata_fixture(:branching) }
+  let(:service_metadata) do
+    meta = metadata_fixture(:branching)
+    meta['pages'] = meta['pages'].shuffle
+    meta
+  end
 
   describe '#all' do
     subject(:all) do
-      traversed_pages.all
+      traversed_pages.all.map(&:url)
     end
 
     context 'when current page is blank' do
-      subject(:traversed_pages) { described_class.new(service, user_data) }
-      let(:user_data) { {} }
+      let(:current_page) { nil }
 
-      it 'returns all pages until last page based on user answers' do
-        expect(all.map(&:url)).to match_array(
-          [
-            '/',
-            'name',
-            'do-you-like-star-wars',
-            'favourite-fruit',
-            'favourite-band',
-            'best-formbuilder',
-            'which-formbuilder',
-            'burgers',
-            'we-love-chickens',
-            'marvel-series',
-            'best-arnold-quote',
-            'arnold-incomplete-answers',
-            'check-answers'
-          ]
-        )
+      context 'journey ends at the confirmation page' do
+        let(:user_data) do
+          {
+            'name_text_1' => 'some name',
+            'do-you-like-star-wars_radios_1' => 'Only on weekends',
+            'star-wars-knowledge_text_1' => 'Know all about star wars',
+            'star-wars-knowledge_radios_1' => 'Tony Stark',
+            'favourite-fruit_radios_1' => 'Oranges',
+            'orange-juice_radios_1' => 'No',
+            'favourite-band_radios_1' => 'Beatles',
+            'music-app_radios_1' => 'Spotify',
+            'best-formbuilder_radios_1' => ' MoJ',
+            'burgers_checkboxes_1' => ['Chicken, cheese, tomato'],
+            'marvel-series_radios_1' => 'The Falcon and the Winter Soldier',
+            'best-arnold-quote_checkboxes_1' => [
+              'You are not you. You are me',
+              'Get to the chopper',
+              'You have been terminated'
+            ]
+          }
+        end
+
+        it 'returns all pages until last page based on user answers' do
+          expect(all).to match_array(
+            [
+              '/',
+              'name',
+              'do-you-like-star-wars',
+              'star-wars-knowledge',
+              'favourite-fruit',
+              'orange-juice',
+              'favourite-band',
+              'music-app',
+              'best-formbuilder',
+              'which-formbuilder',
+              'burgers',
+              'we-love-chickens',
+              'marvel-series',
+              'marvel-quotes',
+              'best-arnold-quote',
+              'arnold-right-answers',
+              'check-answers',
+              'confirmation'
+            ]
+          )
+        end
+
+        context 'journey ends with an exit page' do
+          let(:service_metadata) do
+            meta = metadata_fixture(:branching_7)
+            meta['pages'] = meta['pages'].shuffle
+            meta
+          end
+          let(:user_data) do
+            {
+              'page-b_text_1' => 'some text',
+              'page-c_text_1' => 'some more text',
+              'page-d_radios_1' => 'Item 3',
+              'page-i_text_1' => 'even more text'
+            }
+          end
+
+          it 'returns all pages until last page based on user answers' do
+            expect(all).to match_array(
+              [
+                '/',
+                'page-b',
+                'page-c',
+                'page-d',
+                'page-i',
+                'page-g'
+              ]
+            )
+          end
+        end
       end
     end
 
-    context 'when using the old flow metadata' do
+    context 'when current page is present' do
+      let(:current_page) { service.find_page_by_url('name') }
       let(:user_data) { {} }
-      let(:service_metadata) { metadata_fixture(:version) }
-      let(:current_page) { service.find_page_by_url('check-answers') }
 
-      it 'returns all pages until current page' do
-        expect(all.map(&:url)).to match_array(
-          [
-            '/',
-            'name',
-            'email-address',
-            'parent-name',
-            'your-age',
-            'family-hobbies',
-            'do-you-like-star-wars',
-            'holiday',
-            'burgers',
-            'star-wars-knowledge',
-            'how-many-lights',
-            'dog-picture'
-          ]
-        )
+      it 'returns the pages up to the current page' do
+        expect(all).to eq(['/'])
+      end
+    end
+
+    context 'when there is no branching' do
+      let(:user_data) { {} }
+      let(:service_metadata) do
+        meta = metadata_fixture(:version)
+        meta['pages'] = meta['pages'].shuffle
+        meta
+      end
+
+      context 'when current_page is present' do
+        let(:current_page) { service.find_page_by_url('how-many-lights') }
+
+        it 'returns all pages until current page using the default next' do
+          expect(all).to match_array(
+            [
+              '/',
+              'name',
+              'email-address',
+              'parent-name',
+              'your-age',
+              'family-hobbies',
+              'do-you-like-star-wars',
+              'holiday',
+              'burgers',
+              'star-wars-knowledge'
+            ]
+          )
+        end
+
+        context 'when current_page is not present' do
+          let(:current_page) { nil }
+
+          it 'returns all the pages up until there is no default next' do
+            expect(all).to match_array(
+              [
+                '/',
+                'name',
+                'email-address',
+                'parent-name',
+                'your-age',
+                'family-hobbies',
+                'do-you-like-star-wars',
+                'holiday',
+                'burgers',
+                'star-wars-knowledge',
+                'how-many-lights',
+                'dog-picture',
+                'check-answers',
+                'confirmation'
+              ]
+            )
+          end
+        end
       end
     end
 
@@ -72,7 +171,7 @@ RSpec.describe MetadataPresenter::TraversedPages do
       end
 
       it 'returns all pages traversed and answered' do
-        expect(all.map(&:url)).to eq(
+        expect(all).to eq(
           [
             '/',
             'name',
@@ -98,7 +197,7 @@ RSpec.describe MetadataPresenter::TraversedPages do
       end
 
       it 'returns all pages traversed and answered' do
-        expect(all.map(&:url)).to eq(
+        expect(all).to eq(
           [
             '/',
             'name',
@@ -110,6 +209,42 @@ RSpec.describe MetadataPresenter::TraversedPages do
             'best-formbuilder'
           ]
         )
+      end
+    end
+
+    context 'when there is an infinite looping flow (page pointing to itself)' do
+      let(:service_metadata) do
+        meta = metadata_fixture(:branching_11)
+        meta['pages'] = meta['pages'].shuffle
+        meta
+      end
+      let(:user_data) do
+        {
+          'page-b_text_1' => 'the',
+          'page-c_text_1' => 'past',
+          'page-d_radios_1' => 'Item 3',
+          'page-i_text_1' => 'is a',
+          'page-a_text_1' => 'foreign',
+          'page-b_checkboxes_1' => ['Option 3'],
+          'destinationb_checkboxes_1' => ['Option 3'],
+          'page-j_checkboxes_1' => ['Option 1'],
+          'page-k_text_1' => 'country',
+          'page-e_text_1' => 'they',
+          'page-f_checkboxes_1' => ['Option D'],
+          'page-n_text_1' => 'do',
+          'page-o_text_1' => 'things',
+          'page-p_text_1' => 'differently',
+          'page-d_text_1' => 'there'
+        }
+      end
+      let(:current_page) { nil }
+
+      it 'does not raise any errors' do
+        expect { all }.to_not raise_error
+      end
+
+      it 'does not exceed the number of flow objects in the service' do
+        expect(all.count).to be <= service.flow.count
       end
     end
   end


### PR DESCRIPTION
The object responsible for traversing user answers can take a page
which tells it when to stop. If none is provided it would previously
take the last page in the `pages` array of the metadata. This was
perfectly fine before branching as the `pages` array was the thing
used to dictate the order of a form which always ended in a
Confirmation page.

However now branching uses a `flow` object system to dictate what a
user should see next based on their answers, the `pages` array order
no longer matters. The last page is simply the last page created by
the user.

Therefore we should traverse the user answers all the way to end of a
journey based upon their answers. In the instances of a page being
supplied we traverse up to and not including that page. If none is
provided then we go all the way until there is no longer the ability to
find another page. These instances are:

- end of the flow (i.e a confirmation page)
- an exit page
- a page with no default next which usually only happens if the form is
  currently not been finished its creation by the Editor user
  
Additionally get the start page by type instead of picking the first page
in the `pages` array.

Publish 2.17.0