### PR TITLE
Fix analytics id strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.16.14] - 2022-06-09
+
+### Fixed
+
+- Pass analytics IDs as string literals in JS scripts
+
 ## [2.16.13] - 2022-06-08
 
 ### Added

--- a/app/views/metadata_presenter/analytics/_ga4.html.erb
+++ b/app/views/metadata_presenter/analytics/_ga4.html.erb
@@ -5,6 +5,6 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', <%= analytic_tag %>);
+  gtag('config', '<%= analytic_tag %>');
 </script>
 <!-- End Global site tag (gtag.js) - Google Analytics -->

--- a/app/views/metadata_presenter/analytics/_gtm.html.erb
+++ b/app/views/metadata_presenter/analytics/_gtm.html.erb
@@ -3,5 +3,5 @@
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer',<%= analytic_tag %>);</script>
+})(window,document,'script','dataLayer','<%= analytic_tag %>');</script>
 <!-- End Google Tag Manager -->

--- a/app/views/metadata_presenter/analytics/_ua.html.erb
+++ b/app/views/metadata_presenter/analytics/_ua.html.erb
@@ -5,7 +5,7 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  ga('create', <%= analytic_tag %>, 'auto');
+  ga('create', '<%= analytic_tag %>', 'auto');
   ga('send', 'pageview');
 </script>
 <!-- End Google Universal Analytics -->

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.16.13'.freeze
+  VERSION = '2.16.14'.freeze
 end


### PR DESCRIPTION
When passed into the JS functions the GA tags need to be string literals.

Publish 2.16.14