### PR TITLE
Autocomplete schema update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.3] - 2022-06-24
+
+### Changed
+
+- Move definitions to component level rather than definition level, this is in
+  line with the existing component schemas.
+
 ## [2.17.2] - 2022-06-16
 
 ### Changed

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.2'.freeze
+  VERSION = '2.17.3'.freeze
 end

--- a/schemas/component/autocomplete.json
+++ b/schemas/component/autocomplete.json
@@ -7,6 +7,12 @@
   "allOf": [
     {
       "$ref": "definition.select"
+    },
+    {
+      "$ref": "definition.field"
+    },
+    {
+      "$ref": "definition.width_class.input"
     }
   ],
   "properties": {

--- a/schemas/definition/select.json
+++ b/schemas/definition/select.json
@@ -2,14 +2,6 @@
   "$id": "http://gov.uk/schema/v1.0.0/definition/select",
   "_name": "definition.select",
   "title": "Select component definition",
-  "allOf": [
-    {
-      "$ref": "definition.field"
-    },
-    {
-      "$ref": "definition.width_class.input"
-    }
-  ],
   "properties": {
     "items": {
       "title": "Items",


### PR DESCRIPTION
[Trello](https://trello.com/c/026Zl7pq/2632-autocomplete-create-post-endpoint-to-retrieve-autocomplete-data-from-metadata-db)

### Move definition fields into the component level
Definitions in existing schemas are present on the component level rather than the definition level.
Move the definitions out of the `select_items` schema and into the `autocomplete` schema.
 
### Bump version 2.17.3