### PR TITLE
Add MoJ Forms global analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
  - Update button label for check answers page to 'Submit'
  - Move button labels into locales file
 
+### Added
+
+- Added MoJ Forms GA4 global analytics partials
+
 ## [2.17.3] - 2022-06-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
-## [Unreleased]
+## [2.17.4]
 
 ### Changed
 
  - Update button label for check answers page to 'Submit'
  - Move button labels into locales file
+ - Changed analytics_tag to measurement_id
 
 ### Added
 

--- a/app/views/metadata_presenter/analytics/_global_analytics.html.erb
+++ b/app/views/metadata_presenter/analytics/_global_analytics.html.erb
@@ -1,9 +1,4 @@
-<!-- Google Analytics 4 -->
-<% if Rails.application.config.global_ga4.present? %>
-<script>
-  gtag('config', '<%= measurement_id %>');
-</script>
-<% else %>
+<!-- Global MoJ Forms site tag (gtag.js) - Google Analytics 4 -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=<%= measurement_id %>"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -12,5 +7,4 @@
 
   gtag('config', '<%= measurement_id %>');
 </script>
-<% end %>
-<!-- End Google Analytics 4 -->
+<!-- End Global MoJ Forms site tag (gtag.js) - Google Analytics 4 -->

--- a/app/views/metadata_presenter/analytics/_google.html.erb
+++ b/app/views/metadata_presenter/analytics/_google.html.erb
@@ -1,5 +1,5 @@
 <% analytics.each do |analytic| %>
   <% if ENV[analytic].present? %>
-    <%= render partial: "metadata_presenter/analytics/#{analytic.downcase}", locals: { analytic_tag: ENV[analytic] } %>
+    <%= render partial: "metadata_presenter/analytics/#{analytic.downcase}", locals: { measurement_id: ENV[analytic] } %>
   <% end %>
 <% end %>

--- a/app/views/metadata_presenter/analytics/_gtm.html.erb
+++ b/app/views/metadata_presenter/analytics/_gtm.html.erb
@@ -3,5 +3,5 @@
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','<%= analytic_tag %>');</script>
+})(window,document,'script','dataLayer','<%= measurement_id %>');</script>
 <!-- End Google Tag Manager -->

--- a/app/views/metadata_presenter/analytics/_ua.html.erb
+++ b/app/views/metadata_presenter/analytics/_ua.html.erb
@@ -5,7 +5,7 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '<%= analytic_tag %>', 'auto');
+  ga('create', '<%= measurement_id %>', 'auto');
   ga('send', 'pageview');
 </script>
 <!-- End Google Universal Analytics -->

--- a/app/views/metadata_presenter/analytics/analytics.html.erb
+++ b/app/views/metadata_presenter/analytics/analytics.html.erb
@@ -1,3 +1,7 @@
+<% if Rails.application.config.global_ga4.present? %>
+  <%= render partial: 'metadata_presenter/analytics/global_analytics', locals: { measurement_id: Rails.application.config.global_ga4 } %>
+<% end %>
+
 <% Rails.application.config.supported_analytics.each do |provider, analytics| %>
   <%= render partial: "metadata_presenter/analytics/#{provider}", locals: { analytics: analytics } %>
 <% end %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.3'.freeze
+  VERSION = '2.17.4'.freeze
 end


### PR DESCRIPTION
This injects the global analytics ID for the GA4 used by the MoJ Forms
team.

Since MoJ Forms will be using GA4 we do not want to overwrite a form
owners GA4 or vice versa. We only need to call the gtag function with
the additional measurement ID, as opposed to load the entire JS script
again.

Also changed `analytics_tag` to `measurement_id` as that is what Google
refers to it as.