### PR TITLE
Update check answers page button text and move button labels into locales 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [Unreleased]
+
+### Changed
+
+ - Update button label for check answers page to 'Submit'
+ - Move button labels into locales file
+
 ## [2.17.3] - 2022-06-24
 
 ### Changed

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -85,7 +85,7 @@
                  } %>
 
         <button <%= 'disabled' if editable? %> data-prevent-double-click="true" class="fb-block fb-block-actions govuk-button" data-module="govuk-button" data-block-id="actions" data-block-type="actions">
-        Accept and send application
+          <%= t('actions.submit') -%>
         </button>
       <% end %>
 

--- a/app/views/metadata_presenter/page/form.html.erb
+++ b/app/views/metadata_presenter/page/form.html.erb
@@ -8,7 +8,7 @@
       <%- end %>
        <%= form_tag(reserved_answers_path, method: :post) do  %>
         <button class='govuk-button govuk-button--start govuk-!-margin-top-2'>
-        Continue
+          <%= t('actions.continue') -%>
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
           </svg>

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -7,7 +7,7 @@
 
       <%= form_tag(root_path, method: :post) do %>
         <button <%= 'disabled' if editable? %> class='govuk-button govuk-button--start govuk-!-margin-top-2'>
-          Start now
+          <%= t('actions.start') -%>
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
           </svg>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  actions:
+    start: Start Now
+    continue: Continue
+    submit: Submit
   analytics:
     heading: Cookies on %{service_name}
     body_1: We use some essential cookies to make this service work.


### PR DESCRIPTION
Changes the button text on the check answers page to 'Submit'

This label is now within the locales file.

Also moved the 'Start Now' and 'Continue' button labels into the locales file.

![image](https://user-images.githubusercontent.com/595564/175980482-05d0c303-9e41-4518-aa89-874a304690b8.png)
