### PR TITLE
Check global ga4 presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
-## [2.17.4]
+## [2.17.5] - 2022-06-28
+
+### Fixed
+
+- Check whether the global_ga4 has actually been set on the Rails config object
+
+## [2.17.4] - - 2022-06-27
 
 ### Changed
 

--- a/app/views/metadata_presenter/analytics/_ga4.html.erb
+++ b/app/views/metadata_presenter/analytics/_ga4.html.erb
@@ -1,5 +1,5 @@
 <!-- Google Analytics 4 -->
-<% if Rails.application.config.global_ga4.present? %>
+<% if Rails.application.config.respond_to?(:global_ga4) %>
 <script>
   gtag('config', '<%= measurement_id %>');
 </script>

--- a/app/views/metadata_presenter/analytics/analytics.html.erb
+++ b/app/views/metadata_presenter/analytics/analytics.html.erb
@@ -1,4 +1,4 @@
-<% if Rails.application.config.global_ga4.present? %>
+<% if Rails.application.config.respond_to?(:global_ga4) %>
   <%= render partial: 'metadata_presenter/analytics/global_analytics', locals: { measurement_id: Rails.application.config.global_ga4 } %>
 <% end %>
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.4'.freeze
+  VERSION = '2.17.5'.freeze
 end


### PR DESCRIPTION
We need to check whether the `global_ga4` property has actually been
created on the Rails.application.config so checking whether the value is
present is not enough.

Publish 2.17.5