### PR TITLE
Move editor specific functionality of autocomplete into Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
-## [Unreleased]
+## [2.17.8] - 2022-07-12
 
 ### Changed
 
 - Removed graphviz dependency and rake task which used it to build flows
+- Moved the editable functionalties of the autocomplete component to the Editor app
 
 ## [2.17.7] - 2022-07-04
 

--- a/app/views/metadata_presenter/component/_autocomplete.html.erb
+++ b/app/views/metadata_presenter/component/_autocomplete.html.erb
@@ -11,4 +11,6 @@
   class: "govuk-!-width-two-thirds"
 %>
 
-<button type="button" class="fb-govuk-button fb-govuk-button-inverted"><%=t('actions.upload_options')%></button>
+<% if editable? %>
+  <%= render partial: '/partials/editable_autocomplete', locals: { component: component } %>
+<% end %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.7'.freeze
+  VERSION = '2.17.8'.freeze
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/mU4YFw6r/2688-autocomplete-check-for-previously-uploaded-items-on-the-component-view)

The upload options button on the autocomplete component, will only be seen in the Editor. The runner does not need to know about this functionality. As such, we have moved this part of the autocomplete template out of the presenter and into a partial in the Editor app.

### Bump to version 2.17.8
This version also includes the removal of Graphviz dependency and associated rake task found in this [PR](https://github.com/ministryofjustice/fb-metadata-presenter/pull/255)