### PR TITLE
Cast components to an array to prevent method calls on nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed issue where page components were `nil`
+
 ## [2.17.9] - 2022-07-18
 
 ### Changed
@@ -15,7 +21,7 @@ All notable changes to this project will be documented in this file.
 - Global (MoJ Forms) analytics always included, if analytics allowed
 - Global (MoJ Forms) analytics ID is different from Form Owner settings
 - Form Owner settings only shows if allowed and set
-	
+
 ## [2.17.8] - 2022-07-12
 
 ### Changed

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -111,7 +111,7 @@ module MetadataPresenter
     end
 
     def to_components(node_components, collection:)
-      node_components&.map do |component|
+      Array(node_components).map do |component|
         MetadataPresenter::Component.new(
           component.merge(collection: collection),
           editor: editor?


### PR DESCRIPTION
We have recently received a handful of [Sentry errors](https://sentry.io/organizations/ministryofjustice/issues/3397888992/events/?project=5684538&referrer=slack) which have been due to methods being called on nil, meaning no components exist on a page.
Casting to an Array means we now call methods on an empty array if no components exist on a page.