### PR TITLE
Add AutocompleteItem model and ability to assign items to autocomplete components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
-## [Unreleased]
+## [2.17.10] - 2022-07-20
+
+### Added
+
+- Add `AutocompleteItem` model, this maps the metadata structure of an autocomplete item
+- Instantiate AutocompleteItem object when the component is of type autocomplete
+- Assign the autocomplete items for the preview functionality, using the `autocomplete_items` method
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ that you need to write the following methods in your controller:
 2. load_user_data
 3. editable?
 4. create_submission
+5. assign_autocomplete_items
 
 The user answers can be accessed via `params[:answers]`.
 
@@ -79,6 +80,8 @@ mountable app:
 
 The `create_submission` is related to process the submission in a backend
 service.
+
+The `autocomplete_items` takes the components on a page and retrieves any items for them that may exist. For the Editor it will make an API call, for the Runner it will look it up via an environment variable.
 
 ## Generate documentation
 

--- a/app/controllers/metadata_presenter/pages_controller.rb
+++ b/app/controllers/metadata_presenter/pages_controller.rb
@@ -5,6 +5,11 @@ module MetadataPresenter
       @page ||= service.find_page_by_url(request.env['PATH_INFO'])
 
       if @page
+        if @page.autocomplete_component_present?
+          items = autocomplete_items(@page.components)
+          @page.assign_autocomplete_items(items)
+        end
+
         @page_answers = PageAnswers.new(@page, @user_data)
         render template: @page.template
       else

--- a/app/models/metadata_presenter/autocomplete_item.rb
+++ b/app/models/metadata_presenter/autocomplete_item.rb
@@ -1,0 +1,9 @@
+class MetadataPresenter::AutocompleteItem < MetadataPresenter::Metadata
+  def id
+    value
+  end
+
+  def name
+    text
+  end
+end

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -20,8 +20,12 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
 
   def items
     Array(metadata.items).map do |item|
-      MetadataPresenter::Item.new(item, editor: editor?)
+      item_klass.new(item, editor: editor?)
     end
+  end
+
+  def item_klass
+    type == 'autocomplete' ? MetadataPresenter::AutocompleteItem : MetadataPresenter::Item
   end
 
   SUPPORTS_BRANCHING = %w[radios checkboxes].freeze

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -39,7 +39,8 @@ module MetadataPresenter
     end
 
     def components
-      to_components(metadata.components, collection: :components)
+      @components ||=
+        to_components(metadata.components, collection: :components)
     end
 
     def extra_components
@@ -102,6 +103,17 @@ module MetadataPresenter
 
     def multiple_questions?
       type == 'page.multiplequestions'
+    end
+
+    def autocomplete_component_present?
+      components.any? { |component| component.type == 'autocomplete' }
+    end
+
+    def assign_autocomplete_items(items)
+      component_uuids = items.keys
+      components.each do |component|
+        component.items = items[component.uuid] if component.uuid.in?(component_uuids)
+      end
     end
 
     private

--- a/config/initializers/supported_components.rb
+++ b/config/initializers/supported_components.rb
@@ -21,7 +21,7 @@ Rails.application.config.supported_components =
       content: %w(content)
     },
     singlequestion: {
-      input: %w(text textarea number date radios checkboxes email upload),
+      input: %w(text textarea number date radios checkboxes email upload autocomplete),
       content: %w()
      }
   })

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -71,6 +71,12 @@
     "2ef7d11e-0307-49e9-9fe2-345dc528dd66": {
       "_type": "flow.page",
       "next": {
+        "default": "c7755991-436b-4495-afa6-803db58cefbc"
+      }
+    },
+    "c7755991-436b-4495-afa6-803db58cefbc": {
+      "_type": "flow.page",
+      "next": {
         "default": "e337070b-f636-49a3-a65c-f506675265f0"
       }
     },
@@ -567,6 +573,33 @@
           }
         }
       ]
+    },
+    {
+      "_id": "page.countries",
+      "url": "countries",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "c7755991-436b-4495-afa6-803db58cefbc",
+      "heading": "",
+      "components": [
+        {
+          "_id": "countries_autocomplete_1",
+          "hint": "",
+          "name": "countries_autocomplete_1",
+          "_type": "autocomplete",
+          "_uuid": "4dc23b9c-9757-4526-813d-b43efbe07dad",
+          "items": [
+          ],
+          "errors": {
+          },
+          "legend": "Countries",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
     },
     {
       "_id": "page.check-answers",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.9'.freeze
+  VERSION = '2.17.10'.freeze
 end

--- a/spec/models/autocomplete_item_spec.rb
+++ b/spec/models/autocomplete_item_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe MetadataPresenter::AutocompleteItem do
+  subject(:autocomplete_item) { described_class.new(metadata) }
+
+  describe '#id' do
+    let(:metadata) { { 'value' => 'some value' } }
+
+    it 'returns the value property' do
+      expect(subject.id).to eq('some value')
+    end
+  end
+
+  describe '#name' do
+    let(:metadata) { { 'text' => 'some text' } }
+
+    it 'returns the name property' do
+      expect(subject.name).to eq('some text')
+    end
+  end
+end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -28,6 +28,27 @@ RSpec.describe MetadataPresenter::Component do
         expect(item).to respond_to(:description)
       end
     end
+
+    it 'returns an array of Item classes' do
+      expect(component.items).to all(be_an(MetadataPresenter::Item))
+    end
+
+    context 'when component is an autocomplete type' do
+      before do
+        allow(component).to receive(:type).and_return('autocomplete')
+      end
+
+      it 'contains objects that respond to the necessary properties' do
+        component.items.each do |item|
+          expect(item).to respond_to(:id)
+          expect(item).to respond_to(:name)
+        end
+      end
+
+      it 'returns an array of AutocompleteItem classes' do
+        expect(component.items).to all(be_an(MetadataPresenter::AutocompleteItem))
+      end
+    end
   end
 
   describe '#humanised_title' do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -318,4 +318,45 @@ RSpec.describe MetadataPresenter::Page do
       end
     end
   end
+
+  describe '#autocomplete_component_present?' do
+    context 'when there is an autocomplete component' do
+      subject(:page) { service.find_page_by_url('countries') }
+
+      it 'returns true' do
+        expect(page.autocomplete_component_present?).to be_truthy
+      end
+    end
+
+    context 'when there is no autocomplete component' do
+      subject(:page) do
+        service.find_page_by_url('dog-picture')
+      end
+
+      it 'returns false' do
+        expect(page.autocomplete_component_present?).to be_falsey
+      end
+    end
+  end
+
+  describe '#assign_autocomplete_items' do
+    subject(:page) { service.find_page_by_url('countries') }
+    let(:component_id) { page.components.first.uuid }
+    let(:items) do
+      {
+        component_id => [{ 'text' => 'abc', 'value' => '123' }]
+      }
+    end
+
+    before do
+      page.assign_autocomplete_items(items)
+    end
+
+    it 'sets the autocomplete items' do
+      expected_items = page.components.first.items
+      expect(expected_items).to all(be_an(MetadataPresenter::AutocompleteItem))
+      expect(expected_items.first.text).to eq('abc')
+      expect(expected_items.first.value).to eq('123')
+    end
+  end
 end

--- a/spec/models/traversed_pages_spec.rb
+++ b/spec/models/traversed_pages_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe MetadataPresenter::TraversedPages do
                 'star-wars-knowledge',
                 'how-many-lights',
                 'dog-picture',
+                'countries',
                 'check-answers',
                 'confirmation'
               ]

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
           .and_return(MetadataPresenter::OfflineUploadAdapter)
       end
 
-      it 'redirect to the check your answers' do
+      it 'redirect to the next page' do
         post '/dog-picture', params: { answers: answers }
-        expect(response).to redirect_to('/check-answers')
+        expect(response).to redirect_to('/countries')
       end
 
       it 'uploads the file' do


### PR DESCRIPTION
[Trello](https://trello.com/c/82s692KP/2714-autocomplete-preview-mechanism)

### Add AutocompleteItem model
This adds the model which maps the metadata structure of a given autocomplete item to the corresponding id and name methods that are used when generating the select component on the page.

### Instantiate AutocompleteItem objects when autocomplete component
When the component is an autocomplete type then we want to make use of the new AutocompleteItem model instead of the the standard Item model.

### Assign autocomplete items for autocomplete components in preview
Since the items are not readily available in the service metadata we need to call the Metadata API to find the correct items and assign these items to the correct component when we load an autocomplete page in preview mode.

### Add autocomplete as a supported component for a single question page
This enables autocomplete component and associated answer to render on the check your answers page

### Bump to 2.17.10

### In Preview mode
<img width="1318" alt="Screenshot 2022-07-19 at 16 49 09" src="https://user-images.githubusercontent.com/29227502/179793895-115972a5-db4d-46a0-bc50-5f1dce5d8ff6.png">

<img width="596" alt="Screenshot 2022-07-19 at 16 49 24" src="https://user-images.githubusercontent.com/29227502/179793917-6d5256b4-8617-4998-aa5c-c4f7905f93f8.png">
