### PR TITLE
Return both text and value when calling id on an AutocompleteItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,26 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.12] - 2022-07-28
+
+### Added
+
+- Add autocomplete countries fixture
+- Add ability to extract the text from an autocomplete answer when used on a checkanswers page
+- Add 'autocomplete?' method to the component model
+
+### Changed
+
+- Update autocomplete page schema to include an items property
+- Remove items property from the select schema
+- Change the AutocompleteItem model id method to return both the text and value as a JSON string
+- Override to_json method on the component model to remove 'items' from the return JSON string
+
 ## [2.17.11] - 2022-07-22
 
 ### Fixed
 
 - Cookie banner should only show if MoJ analytics on or form owner has set
-
 
 ## [2.17.10] - 2022-07-20
 

--- a/app/models/metadata_presenter/autocomplete_item.rb
+++ b/app/models/metadata_presenter/autocomplete_item.rb
@@ -1,6 +1,6 @@
 class MetadataPresenter::AutocompleteItem < MetadataPresenter::Metadata
   def id
-    value
+    { text: text, value: value }.to_json
   end
 
   def name

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -25,13 +25,17 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
   end
 
   def item_klass
-    type == 'autocomplete' ? MetadataPresenter::AutocompleteItem : MetadataPresenter::Item
+    autocomplete? ? MetadataPresenter::AutocompleteItem : MetadataPresenter::Item
   end
 
   SUPPORTS_BRANCHING = %w[radios checkboxes].freeze
 
   def supports_branching?
     type.in?(SUPPORTS_BRANCHING)
+  end
+
+  def autocomplete?
+    type == 'autocomplete'
   end
 
   def content?

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -10,6 +10,17 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
   # Threshold percentage at which the remaining count is shown
   VALIDATION_STRING_LENGTH_THRESHOLD = 75
 
+  # Overriding here because autocomplete component's items property is non interactable
+  # in the Editor therefore it does not need to exist in the data-fb-content-data
+  # attribute on the page. The data-fb-content-data attribute is what is used to
+  # update user interactable elements such as the component question or page section
+  # heading etc.
+  def to_json(*_args)
+    return super unless autocomplete?
+
+    JSON.parse(super).to_json(except: 'items')
+  end
+
   def to_partial_path
     "metadata_presenter/component/#{type}"
   end

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -106,7 +106,7 @@ module MetadataPresenter
     end
 
     def autocomplete_component_present?
-      components.any? { |component| component.type == 'autocomplete' }
+      components.any?(&:autocomplete?)
     end
 
     def assign_autocomplete_items(items)

--- a/app/presenters/metadata_presenter/page_answers_presenter.rb
+++ b/app/presenters/metadata_presenter/page_answers_presenter.rb
@@ -83,5 +83,9 @@ module MetadataPresenter
     def upload(file_hash)
       file_hash['original_filename']
     end
+
+    def autocomplete(value)
+      JSON.parse(value)['text']
+    end
   end
 end

--- a/fixtures/countries.json
+++ b/fixtures/countries.json
@@ -1,0 +1,7 @@
+{
+  "4dc23b9c-9757-4526-813d-b43efbe07dad": [
+    { "text": "Afghanistan", "value": "AF"},
+    { "text": "Albania", "value": "AL"},
+    { "text": "Australia", "value": "AU"}
+  ]
+}

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.11'.freeze
+  VERSION = '2.17.12'.freeze
 end

--- a/schemas/component/autocomplete.json
+++ b/schemas/component/autocomplete.json
@@ -4,14 +4,12 @@
   "title": "Autocomplete",
   "description": "Let users select one option from an auto-completing list",
   "type": "object",
-  "allOf": [
-    {
-      "$ref": "definition.select"
-    }
-  ],
   "properties": {
     "_type": {
       "const": "autocomplete"
+    },
+    "items": {
+      "$ref": "definition.select"
     }
   }
 }

--- a/schemas/definition/select.json
+++ b/schemas/definition/select.json
@@ -2,15 +2,9 @@
   "$id": "http://gov.uk/schema/v1.0.0/definition/select",
   "_name": "definition.select",
   "title": "Select component definition",
-  "properties": {
-    "items": {
-      "title": "Items",
-      "description": "Items that users can select",
-      "type": "array",
-      "items": {
-        "$ref": "definition.select_item"
-      }
-    }
+  "type": "array",
+  "items": {
+    "$ref": "definition.select_item"
   },
   "required": [
     "items"

--- a/schemas/definition/select_item.json
+++ b/schemas/definition/select_item.json
@@ -17,12 +17,8 @@
       "type": "string"
     }
   },
-  "allOf": [
-    {
-      "$ref": "definition.component"
-    }
-  ],
   "required": [
+    "text",
     "value"
   ],
   "category": [

--- a/spec/models/autocomplete_item_spec.rb
+++ b/spec/models/autocomplete_item_spec.rb
@@ -2,15 +2,15 @@ RSpec.describe MetadataPresenter::AutocompleteItem do
   subject(:autocomplete_item) { described_class.new(metadata) }
 
   describe '#id' do
-    let(:metadata) { { 'value' => 'some value' } }
+    let(:metadata) { { 'text' => 'some text', 'value' => 'some value' } }
 
     it 'returns the value property' do
-      expect(subject.id).to eq('some value')
+      expect(subject.id).to eq('{"text":"some text","value":"some value"}')
     end
   end
 
   describe '#name' do
-    let(:metadata) { { 'text' => 'some text' } }
+    let(:metadata) { { 'text' => 'some text', 'value' => 'some value' } }
 
     it 'returns the name property' do
       expect(subject.name).to eq('some text')

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -89,6 +89,22 @@ RSpec.describe MetadataPresenter::Component do
     end
   end
 
+  describe '#autocommplete?' do
+    context 'when type is autocomplete' do
+      it 'returns true' do
+        component = described_class.new(_type: 'autocomplete')
+        expect(component.autocomplete?).to be_truthy
+      end
+    end
+
+    context 'when type is not autocomplete' do
+      it 'returns false' do
+        component = described_class.new({})
+        expect(component.content?).to be_falsey
+      end
+    end
+  end
+
   describe '#find_item_by_uuid' do
     context 'when there are items' do
       let(:attributes) do

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -1,6 +1,28 @@
 RSpec.describe MetadataPresenter::Component do
   subject(:component) { described_class.new(attributes) }
 
+  describe '#to_json' do
+    context 'when autocomplete component' do
+      let(:component) do
+        service.find_page_by_url('countries').components.first
+      end
+
+      it 'removes the items property from the returned json' do
+        expect(JSON.parse(component.to_json).keys).to_not include('items')
+      end
+    end
+
+    context 'when not an autocomplete component' do
+      let(:component) do
+        service.find_page_by_url('do-you-like-star-wars').components.first
+      end
+
+      it 'does not remove the items property from the returned json' do
+        expect(JSON.parse(component.to_json).keys).to include('items')
+      end
+    end
+  end
+
   describe '#to_partial_path' do
     let(:attributes) { { '_type' => 'email' } }
 


### PR DESCRIPTION
## Update autocomplete page and select schemas

The autocomplete page needs to have the items property.

The select schema does not need to have the items property.

The select_item schema needs to have both text and value properties.

## Return both text and value when calling id on an AutocompleteItem

When the items for a component are passed into an autocomplete page
template `id` is used to set the 'value' on each select item. When a
user chooses and item and submits the answer it this value that gets
sent to the datastore.

However when we come to present the answer back to the user, either on
the autocomplete page when they go back to it or on a checkanswers page,
we want to have the text (aka name) as this is usually the human
readable form.

When we come to submit the form payload at that point we want to have
the 'value' since this is the thing that a Form Owner would actually
make use of.

Also add a countries fixture for use with testing.

## Override to_json method on the component model

Calling to_json on a component objects injects all the component
attributes into the data-fb-content-data element for that component.
This is updated whenever a user makes changes to an interactable element
in the Editor, such as a component question or a section heading etc.

For autocomplete components we do not need to inject all the select
items into the data-fb-content-data element as they are not interactable
in the Editor. Therefore we can just remove them entirely before loading
the page.
 
## Publish 2.17.12