### PR TITLE
Only show banner if MoJForms analytics active or user has set analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.11] - 2022-07-22
+
+### Fixed
+
+- Cookie banner should only show if MoJ analytics on or form owner has set
+
+
 ## [2.17.10] - 2022-07-20
 
 ### Added

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -46,7 +46,7 @@ module MetadataPresenter
     helper_method :allow_analytics?
 
     def show_cookie_banner?
-      no_analytics_cookie?
+      (Rails.application.config.respond_to?(:global_ga4) || analytics_tags_present?) && no_analytics_cookie?
     end
     helper_method :show_cookie_banner?
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.10'.freeze
+  VERSION = '2.17.11'.freeze
 end


### PR DESCRIPTION
Fixes issues causing Live to show Cookie Banner without Analytics being switched on.