### PR TITLE
Add autocomplete component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
  - Add govuk 'accessible-autocomplete' component 
 
-### changed
+### Changed
 
  - Reorganize scripts and styles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.13] - 2022-07-27
+
+### Added
+
+ - Add govuk 'accessible-autocomplete' component 
+
+### changed
+
+ - Reorganize scripts and styles
+
 ## [2.17.12] - 2022-07-28
 
 ### Added

--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -14,8 +14,8 @@
   <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-152x152.png') %>">
   <link rel="apple-touch-icon" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon.png') %>">
 
-    <%= stylesheet_pack_tag 'govuk' %>
-    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= javascript_pack_tag 'runner_application', 'govuk', defer: true %> 
+    <%= stylesheet_pack_tag 'govuk', 'runner_application', media: 'all' %>
 
     <% if allow_analytics? %>
       <%= render template: 'metadata_presenter/analytics/analytics' %>
@@ -30,15 +30,12 @@
     <%= render template: 'metadata_presenter/header/show' %>
     <div class="govuk-width-container govuk-body-m">
       <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
-      <% if back_link.present? %>
-        <a class="govuk-back-link" href="<%= back_link %>">Back</a>
-      <% end %>
-
+        <% if back_link.present? %>
+          <a class="govuk-back-link" href="<%= back_link %>">Back</a>
+        <% end %>
         <%= yield %>
       </main>
     </div>
     <%= render template: 'metadata_presenter/footer/footer' %>
-    <%= javascript_pack_tag 'runner_application' %>
-    <%= javascript_pack_tag 'govuk' %>
   </body>
 </html>

--- a/app/views/metadata_presenter/component/_autocomplete.html.erb
+++ b/app/views/metadata_presenter/component/_autocomplete.html.erb
@@ -3,14 +3,19 @@
   component.items,
   :id,
   :name,
+  selected: component.value,
   label: { text: input_title },
   hint:  {
       data: { "fb-default-text" => default_text('hint') },
       text: component.hint
     },
-  class: "govuk-!-width-two-thirds"
+  class: "govuk-!-width-two-thirds fb-autocomplete",
+  options: {
+    include_blank: true
+  }
 %>
 
 <% if editable? %>
   <%= render partial: '/partials/editable_autocomplete', locals: { component: component } %>
 <% end %>
+

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.12'.freeze
+  VERSION = '2.17.13'.freeze
 end


### PR DESCRIPTION
PR to add the govuk autocomplete component into the presenter.

Includes adjustments to loading of styles scripts. 

Moved JS to head with `defer` attribute for better performance (being in the head means it gets discovered early by the browsers parser / preload scanner, but defer means its till runs after HTML is in place)


