### PR TITLE
Validates when user's answer is not in autocomplete list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.14] - 2022-08-03
+
+### Added
+
+ - Add autocomplete validator for when a user answer is not a valid select item
+
 ## [2.17.13] - 2022-07-27
 
 ### Added
 
- - Add govuk 'accessible-autocomplete' component 
+ - Add govuk 'accessible-autocomplete' component
 
 ### Changed
 

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -43,6 +43,8 @@ module MetadataPresenter
 
     def render_validation_error
       @user_data = answers_params
+      load_autocomplete_items
+
       render template: page.template, status: :unprocessable_entity
     end
 

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -4,7 +4,7 @@ module MetadataPresenter
 
     def create
       @previous_answers = reload_user_data.deep_dup
-      @page_answers = PageAnswers.new(page, answers_params)
+      @page_answers = PageAnswers.new(page, answers_params, autocomplete_items(page.components))
 
       upload_files if upload?
 

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -57,6 +57,13 @@ module MetadataPresenter
     end
     helper_method :analytics_tags_present?
 
+    def load_autocomplete_items
+      if @page.autocomplete_component_present?
+        items = autocomplete_items(@page.components)
+        @page.assign_autocomplete_items(items)
+      end
+    end
+
     private
 
     def not_found

--- a/app/controllers/metadata_presenter/pages_controller.rb
+++ b/app/controllers/metadata_presenter/pages_controller.rb
@@ -5,10 +5,7 @@ module MetadataPresenter
       @page ||= service.find_page_by_url(request.env['PATH_INFO'])
 
       if @page
-        if @page.autocomplete_component_present?
-          items = autocomplete_items(@page.components)
-          @page.assign_autocomplete_items(items)
-        end
+        load_autocomplete_items
 
         @page_answers = PageAnswers.new(@page, @user_data)
         render template: @page.template

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -3,16 +3,17 @@ module MetadataPresenter
     include ActiveModel::Model
     include ActiveModel::Validations
     include ActionView::Helpers
-    attr_reader :page, :answers, :uploaded_files
+    attr_reader :page, :answers, :uploaded_files, :autocomplete_items
 
-    def initialize(page, answers)
+    def initialize(page, answers, autocomplete_items = nil)
       @page = page
       @answers = answers
+      @autocomplete_items = autocomplete_items
       @uploaded_files = []
     end
 
     def validate_answers
-      ValidateAnswers.new(self, components: components).valid?
+      ValidateAnswers.new(self, components: components, autocomplete_items: autocomplete_items).valid?
     end
 
     delegate :components, to: :page

--- a/app/validators/metadata_presenter/autocomplete_validator.rb
+++ b/app/validators/metadata_presenter/autocomplete_validator.rb
@@ -1,0 +1,21 @@
+module MetadataPresenter
+  class AutocompleteValidator < BaseValidator
+    attr_reader :autocomplete_items
+
+    def initialize(page_answers:, component:, autocomplete_items:)
+      super(page_answers: page_answers, component: component)
+
+      @autocomplete_items = autocomplete_items
+    end
+
+    def invalid_answer?
+      return if autocomplete_item_list.blank?
+
+      autocomplete_item_list.exclude?(JSON.parse(user_answer))
+    end
+
+    def autocomplete_item_list
+      @autocomplete_item_list ||= autocomplete_items[component.uuid]
+    end
+  end
+end

--- a/app/validators/metadata_presenter/validate_answers.rb
+++ b/app/validators/metadata_presenter/validate_answers.rb
@@ -1,10 +1,11 @@
 module MetadataPresenter
   class ValidateAnswers
-    attr_reader :page_answers, :components
+    attr_reader :page_answers, :components, :autocomplete_items
 
-    def initialize(page_answers, components:)
+    def initialize(page_answers, components:, autocomplete_items:)
       @page_answers = page_answers
       @components = Array(components)
+      @autocomplete_items = autocomplete_items
     end
 
     def valid?
@@ -21,8 +22,10 @@ module MetadataPresenter
       components.map { |component|
         component_validations(component).map do |key|
           "MetadataPresenter::#{key.classify}Validator".constantize.new(
-            page_answers: page_answers,
-            component: component
+            {
+              component: component,
+              page_answers: page_answers
+            }.merge(autocomplete_param(key))
           )
         end
       }.compact.flatten
@@ -32,6 +35,10 @@ module MetadataPresenter
       return [] if component.validation.blank?
 
       component.validation.select { |_, value| value.present? }.keys
+    end
+
+    def autocomplete_param(key)
+      key == 'autocomplete_item' ? { autocomplete_items: autocomplete_items } : {}
     end
   end
 end

--- a/default_metadata/component/autocomplete.json
+++ b/default_metadata/component/autocomplete.json
@@ -7,6 +7,7 @@
   "name": "component-name",
   "legend": "Question",
   "validation": {
-    "required": true
+    "required": true,
+    "autocomplete": true
   }
 }

--- a/default_metadata/string/error.autocomplete.json
+++ b/default_metadata/string/error.autocomplete.json
@@ -1,0 +1,6 @@
+{
+  "_id": "error.autocomplete",
+  "_type": "string.error",
+  "description": "Autocomplete item is not on the list",
+  "value": "Select an option from the list"
+}

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -595,7 +595,8 @@
           },
           "legend": "Countries",
           "validation": {
-            "required": true
+            "required": true,
+            "autocomplete": true
           }
         }
       ],

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.13'.freeze
+  VERSION = '2.17.14'.freeze
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -23,6 +23,8 @@ class ApplicationController < ActionController::Base
 
   def create_submission; end
 
+  def autocomplete_items(component); end
+
   def default_metadata
     Rails.application.config.default_metadata
   end

--- a/spec/validators/autocomplete_validator_spec.rb
+++ b/spec/validators/autocomplete_validator_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe MetadataPresenter::AutocompleteValidator do
+  subject(:validator) do
+    described_class.new(page_answers: page_answers, component: component, autocomplete_items: autocomplete_items)
+  end
+  let(:component) { page.components.first }
+  let(:page_answers) { MetadataPresenter::PageAnswers.new(page, answers, autocomplete_items) }
+  let(:page) { service.find_page_by_url('/countries') }
+  let(:component_id) { page.components.first.uuid }
+  let(:autocomplete_items) do
+    {
+      component_id.to_s => [
+        { 'text' => 'Afghanistan', 'value' => 'AF' },
+        { 'text' => 'Albania', 'value' => 'AL' },
+        { 'text' => 'Australia', 'value' => 'AU' }
+      ]
+    }
+  end
+
+  describe '#valid?' do
+    before do
+      validator.valid?
+    end
+
+    context 'when answer is invalid' do
+      let(:answers) do
+        { 'countries_autocomplete_1' => '{"text":"Japan","value":"JP"}' }
+      end
+
+      it 'returns invalid' do
+        expect(validator).to_not be_valid
+      end
+    end
+
+    context 'when answer is valid' do
+      let(:answers) do
+        { 'countries_autocomplete_1' => '{"text":"Australia","value":"AU"}' }
+      end
+
+      it 'returns valid' do
+        expect(validator).to be_valid
+      end
+    end
+
+    context 'when there are no autocomplete items' do
+      let(:autocomplete_items) { {} }
+      let(:answers) do
+        { 'countries_autocomplete_1' => '{"text":"Australia","value":"AU"}' }
+      end
+
+      it 'returns valid' do
+        expect(validator).to be_valid
+      end
+    end
+
+    context 'when there are no items for the component' do
+      let(:component_id) { SecureRandom.uuid }
+      let(:answers) do
+        { 'countries_autocomplete_1' => '{"text":"Australia","value":"AU"}' }
+      end
+
+      it 'returns valid' do
+        expect(validator).to be_valid
+      end
+    end
+  end
+end

--- a/spec/validators/validate_answers_spec.rb
+++ b/spec/validators/validate_answers_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe MetadataPresenter::ValidateAnswers do
   subject(:validate_answers) do
-    described_class.new(page_answers, components: page.components)
+    described_class.new(page_answers, components: page.components, autocomplete_items: autocomplete_items)
   end
   let(:page_answers) { MetadataPresenter::PageAnswers.new(page, answers) }
+  let(:autocomplete_items) { {} }
   let(:page) { service.find_page_by_url('/name') }
 
   describe '#valid?' do


### PR DESCRIPTION
[Trello](https://trello.com/c/5sfGGfLx/2718-autocomplete-runner-validations)
 
### Add autocomplete items validator
This validator compares the user's answers to the autocomplete item select list. If the user's answer is not on the list, the answer is invalid.

### Pass `autocomplete_items` through to the validator
We need the autocomplete items in the validators so we can compare the user's answers to the items list on the component. We experimented with adding a module in the Runner and Editor apps that would allow us access to the items, however, this left us with the inability to sufficiently test the implementation. So we decided to go with passing the items in from the answers controller.
 
### Ensure the autocomplete items list is available in the answers and pages controllers
We require this method in both controllers as a user could find themselves on the autocomplete component on initial page load (GET) or after their answer has been validated (POST). Without this, the autocomplete select list would not be loaded into the component.

### 2.17.14