### PR TITLE
Fix autocomplete validator key being referenced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.15] - 2022-08-04
+
+### Fixed
+
+ - Autocomplete validator key is `autocomplete`
+
 ## [2.17.14] - 2022-08-03
 
 ### Added

--- a/app/validators/metadata_presenter/validate_answers.rb
+++ b/app/validators/metadata_presenter/validate_answers.rb
@@ -38,7 +38,7 @@ module MetadataPresenter
     end
 
     def autocomplete_param(key)
-      key == 'autocomplete_item' ? { autocomplete_items: autocomplete_items } : {}
+      key == 'autocomplete' ? { autocomplete_items: autocomplete_items } : {}
     end
   end
 end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.14'.freeze
+  VERSION = '2.17.15'.freeze
 end


### PR DESCRIPTION
### Fix validator key being referenced
The key was changed from `autocomplete_item` to `autocomplete` but this reference to the old key had been missed. Update so it now references the correct key.

### 2.17.15