### PR TITLE
Add ability to manually inject properties into Global Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.16] - 2022-08-08
+
+### Added
+
+ - Ability to manually inject properties into Global Analytics
+
 ## [2.17.15] - 2022-08-04
 
 ### Fixed

--- a/app/views/metadata_presenter/analytics/_global_analytics.html.erb
+++ b/app/views/metadata_presenter/analytics/_global_analytics.html.erb
@@ -1,9 +1,13 @@
 <!-- Global MoJ Forms site tag (gtag.js) - Google Analytics 4 -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=#{global_measurement_id}"></script>
 <script>
+  var manual_global_analytics_properties = {
+    <%= yield :manual_global_analytics_properties %>
+  }
+
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', '<%= global_measurement_id %>');
+  gtag('config', '<%= global_measurement_id %>', manual_global_analytics_properties);
 </script>
 <!-- End Global MoJ Forms site tag (gtag.js) - Google Analytics 4 -->

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -1,3 +1,4 @@
+<% content_for :manual_global_analytics_properties do %>'page_title': 'Confirmation page'<% end %>
 <div class="fb-main-grid-wrapper" data-fb-pagetype="<%= @page.type %>">
   <div class="govuk-panel govuk-panel--confirmation govuk-grid-column-two-thirds">
     <h1 class="fb-editable govuk-panel__title"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.15'.freeze
+  VERSION = '2.17.16'.freeze
 end


### PR DESCRIPTION
Updated Global Analytics to allow for develop injection of key:value pairs to the GA4 initiation process. 
This was originally designed to allow for manual page title values, like this:

gtag('config', 'MEASUREMENT_ID', {
   'page_title': 'Travel Destinations',
   'currency': 'USD'
});

(example taken from Google Documentation)

The implementation allows for more than the page_title addition alone, since you could also inject the currency value, if desired. Values added can come from the related page type template (in this commit that means the Confirmation page) but also allows for putting values directly into the global analytics template. 

Setting as a JS variable rather simply adding direct to the gtag function should mean developers can test out value using the browser console, without having to keep updating the Metadata Presenter templates, until ready.

