### PR TITLE
Changes required for updating to govuk-frontend 4.3.1

### DIFF
--- a/app/views/metadata_presenter/header/show.html.erb
+++ b/app/views/metadata_presenter/header/show.html.erb
@@ -1,5 +1,5 @@
 <header class="govuk-header" role="banner" data-module="govuk-header">
-  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+  <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
@@ -28,7 +28,7 @@
     </div>
     <% if service.service_name.present? %>
       <div class="govuk-header__content">
-        <a href="<%= root_path %>" class="govuk-header__link govuk-header__link--service-name">
+        <a href="<%= root_path %>" class="govuk-header__link govuk-header__service-name [deprecated] govuk-header__link--service-name [deprecated]">
           <%= service.service_name %>
         </a>
     <% end %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.17'.freeze
+  VERSION = '2.17.18'.freeze
 end


### PR DESCRIPTION
Make the changes required for updating to govuk-frontend 4.3.1
* mark `govuk-header__link--service-name` as deprecated and add the replacement class^
* Add `data-module="govuk-skip-link"` onto the skip link component

^ cannot remove this class yet as this change will go live before the runner is updated and also preview in the editor will still be using an older version of govuk-frontend.  Once the editor is updated to govuk-frontend > 4.1.0 this class can be removed.



