### PR TITLE
Remove deprecated class in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.19] - 2022-08-24
+
+### Changed
+
+ - Remove deprecated govuk-header__link--service-name class now govuk-frontend
+     update is live in editor.
+
+## [2.17.18] - 2022-08-23
+
+### Changed
+
+ - Changes required by upgrading to govuk-frontend 4.3.1
+
 ## [2.17.17] - 2022-08-17
 
 ### Changed

--- a/app/views/metadata_presenter/header/show.html.erb
+++ b/app/views/metadata_presenter/header/show.html.erb
@@ -28,7 +28,7 @@
     </div>
     <% if service.service_name.present? %>
       <div class="govuk-header__content">
-        <a href="<%= root_path %>" class="govuk-header__link govuk-header__service-name [deprecated] govuk-header__link--service-name [deprecated]">
+        <a href="<%= root_path %>" class="govuk-header__link govuk-header__service-name">
           <%= service.service_name %>
         </a>
     <% end %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.18'.freeze
+  VERSION = '2.17.19'.freeze
 end


### PR DESCRIPTION
Now that govuk-frontend has been updated in the editor we can fully remove the deprecated class.

Also updated the changelog to cover the previous release too 🤭