### PR TITLE
2.17.21 Update static Cookie content to be included in content lookups

### DIFF
--- a/app/views/metadata_presenter/page/standalone.html.erb
+++ b/app/views/metadata_presenter/page/standalone.html.erb
@@ -9,7 +9,7 @@
          <%= t('presenter.footer.cookies.heading') %>
        </h1>
 
-       <div data-fb-content-type="content">
+       <div data-fb-content-type="static">
          <%= to_html t('presenter.footer.cookies.body') %>
        </div>
 


### PR DESCRIPTION
Correction to PR https://github.com/ministryofjustice/fb-metadata-presenter/pull/270 which didn't added correct content type. Not changing version because the intention of this change is the same as previous (last) commit and haven't updated Editor or Runner to pull in that (2.17.21) version, yet. 