### PR TITLE
Update email questions that use a text component to use email component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 
+## [2.17.23] - 2022-10-21
+### Changed
+
+- Updated text components that expect an email address to an email component.
 
 ## [2.17.22] - 2022-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Updated text components that expect an email address to an email component.
+- Add method to check if a component is an email component.
 
 ## [2.17.22] - 2022-09-09
 

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -57,6 +57,10 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
     type == 'upload'
   end
 
+  def email?
+    type == 'email'
+  end
+
   def find_item_by_uuid(uuid)
     items.find { |item| item.uuid == uuid }
   end

--- a/fixtures/non_finished_service.json
+++ b/fixtures/non_finished_service.json
@@ -92,35 +92,30 @@
     },
     {
       "_id": "page.email-address",
+      "url": "email-address",
+      "body": "Body section",
+      "lede": "",
       "_type": "page.singlequestion",
       "_uuid": "68fbb180-9a2a-48f6-9da6-545e28b8d35a",
-      "heading": "Email address",
+      "heading": "",
       "components": [
         {
-          "_id": "page.email-address--email.auto_name__2",
-          "_type": "text",
-          "errors": {
-            "format": {},
-            "required": {
-              "any": "Enter an email address"
-            },
-            "max_length": {
-              "any": "%{control} is too long."
-            },
-            "min_length": {
-              "any": "%{control} is too short."
-            }
-          },
+          "_id": "email-address_email_1",
+          "hint": "",
+          "name": "email-address_email_1",
+          "_type": "email",
+          "_uuid": "357aae1a-98d9-4c3b-a606-b0bcdd9e1fbd",
           "label": "Your email address",
-          "name": "email_address",
+          "errors": {
+          },
           "validation": {
+            "email": true,
             "required": true,
-            "max_length": 30,
-            "min_length": 2
+            "max_length": 256
           }
         }
       ],
-      "url": "email-address"
+      "section_heading": ""
     },
     {
       "_id": "page.parent_name",

--- a/fixtures/non_finished_service.json
+++ b/fixtures/non_finished_service.json
@@ -97,7 +97,7 @@
       "lede": "",
       "_type": "page.singlequestion",
       "_uuid": "68fbb180-9a2a-48f6-9da6-545e28b8d35a",
-      "heading": "",
+      "heading": "Email address",
       "components": [
         {
           "_id": "email-address_email_1",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.22'.freeze
+  VERSION = '2.17.23'.freeze
 end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -127,6 +127,22 @@ RSpec.describe MetadataPresenter::Component do
     end
   end
 
+  describe '#email' do
+    context 'when type is email' do
+      it 'returns true' do
+        component = described_class.new(_type: 'email')
+        expect(component.email?).to be_truthy
+      end
+    end
+
+    context 'when type is not email' do
+      it 'returns false' do
+        component = described_class.new({})
+        expect(component.content?).to be_falsey
+      end
+    end
+  end
+
   describe '#find_item_by_uuid' do
     context 'when there are items' do
       let(:attributes) do


### PR DESCRIPTION
### Update email questions that use a text component
These services were created before we had an email component available and use a text component expecting an email as an input. Now that we do, we should update these components to  use the email component.

### Add method to check whether a component is an email component

### Bump to version 2.17.23