### PR TITLE
Add form maintenance page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.23] - 2022-10-27
 
+### Added
+
+- Added the ability to display a maintenance page for an individual form, based
+    on the presence of ENV config values.
 
 ## [2.17.22] - 2022-09-09
 

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -5,6 +5,8 @@ module MetadataPresenter
     helper MetadataPresenter::ApplicationHelper
     default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
+    before_action :show_maintenance_page
+
     def reload_user_data
       if defined? super
         super
@@ -64,6 +66,10 @@ module MetadataPresenter
       end
     end
 
+    def maintenance_mode?
+      ENV['MAINTENANCE_MODE'].present? && ENV['MAINTENANCE_MODE'] == '1'
+    end
+
     private
 
     def not_found
@@ -76,6 +82,16 @@ module MetadataPresenter
 
     def no_analytics_cookie?
       cookies[analytics_cookie_name].blank?
+    end
+
+    def show_maintenance_page
+      if maintenance_mode?
+        @maintenance_page = {
+          heading: ENV['MAINTENANCE_PAGE_HEADING'] || t('presenter.maintenance.maintenance_page_heading'),
+          content: ENV['MAINTENANCE_PAGE_CONTENT'] || t('presenter.maintenance.maintenance_page_content')
+        }
+        render 'metadata_presenter/maintenance/show'
+      end
     end
   end
 end

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -84,12 +84,19 @@ module MetadataPresenter
       cookies[analytics_cookie_name].blank?
     end
 
+    def maintenance_page_content
+      return t('presenter.maintenance.maintenance_page_content') unless ENV['MAINTENANCE_PAGE_CONTENT']
+
+      Base64.decode64(ENV['MAINTENANCE_PAGE_CONTENT'])
+    end
+
     def show_maintenance_page
       if maintenance_mode?
         @maintenance_page = {
           heading: ENV['MAINTENANCE_PAGE_HEADING'] || t('presenter.maintenance.maintenance_page_heading'),
-          content: ENV['MAINTENANCE_PAGE_CONTENT'] || t('presenter.maintenance.maintenance_page_content')
+          content: maintenance_page_content
         }
+
         render 'metadata_presenter/maintenance/show'
       end
     end

--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -14,7 +14,7 @@
   <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-152x152.png') %>">
   <link rel="apple-touch-icon" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon.png') %>">
 
-    <%= javascript_pack_tag 'runner_application', 'govuk', defer: true %> 
+    <%= javascript_pack_tag 'runner_application', 'govuk', defer: true %>
     <%= stylesheet_pack_tag 'govuk', 'runner_application', media: 'all' %>
 
     <% if allow_analytics? %>

--- a/app/views/metadata_presenter/maintenance/show.html.erb
+++ b/app/views/metadata_presenter/maintenance/show.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= @maintenance_page[:heading] %></h1>
+    <div class="maintenance-content">
+      <%= to_html @maintenance_page[:content] %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,9 @@ en:
       rejected: rejected
       confirmation: You've %{action} analytics cookies.
       hide: Hide this message
+    maintenance:
+      maintenance_page_heading: 'Sorry, this form is unavailable'
+      maintenance_page_content: "If you were in the middle of completing the form, your data has not been saved.\r\n\r\nThe form will be available again from 9am on Monday 19 November 2018.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nContact us if your application is urgent \r\n\r\nEmail:  \r\nTelephone:  \r\nMonday to Friday, 9am to 5pm  \r\n[Find out about call charges](https://www.gov.uk/call-charges)"
     footer:
       cookies:
         heading: "Cookies"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.22'.freeze
+  VERSION = '2.17.23'.freeze
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -142,4 +142,31 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
       end
     end
   end
+
+  context 'maintenance mode' do
+    context 'when maintenance mode is enabled' do
+      before do
+        allow(ENV).to receive(:[])
+        allow(ENV).to receive(:[]).with('MAINTENANCE_MODE').and_return('1')
+      end
+
+      before :each do
+        subject { get '/' }
+      end
+
+      describe '#maintenance_mode' do
+        it 'returns true' do
+          expect(controller.maintenance_mode?).to be_truthy
+        end
+      end
+    end
+
+    context 'when maintenance mode is not enabled' do
+      describe '#maintenance_mode' do
+        it 'returns true' do
+          expect(controller.maintenance_mode?).to be_falsey
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -18,6 +18,28 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
     end
   end
 
+  context 'maintenance mode enabled' do
+    before do
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with('MAINTENANCE_MODE').and_return('1')
+
+      get '/'
+    end
+
+    it 'returns an ok status' do
+      expect(response).to be_successful
+    end
+
+    it 'renders the view correctly' do
+      expect(response.body).to include 'Sorry, this form is unavailable'
+    end
+
+    it 'renders the maintenance page for any page' do
+      get '/name'
+      expect(response.body).to include 'Sorry, this form is unavailable'
+    end
+  end
+
   describe 'GET /name' do
     before do
       get '/name'


### PR DESCRIPTION
Adds in the template for the individual form maintenance page.

Checks the value of the `MAINTENANCE_MODE` env var and displays the maintenance page as needed.