### PR TITLE
Adding reference number to the confirmation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
-## [2.17.24] - 2022-11-22
+## [2.17.24] - 2022-11-23
 ### Added
 
 - Add reference number to confirmation page
+- Provide methods to ensure reference number is correct when in the Editor and Runner apps
 
 ## [2.17.23] - 2022-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.24] - 2022-11-22
+### Added
+
+- Add reference number to confirmation page
+
 ## [2.17.23] - 2022-10-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ that you need to write the following methods in your controller:
 3. editable?
 4. create_submission
 5. assign_autocomplete_items
+6. reference_number_enabled?
+7. show_reference_number
 
 The user answers can be accessed via `params[:answers]`.
 
@@ -82,6 +84,10 @@ The `create_submission` is related to process the submission in a backend
 service.
 
 The `autocomplete_items` takes the components on a page and retrieves any items for them that may exist. For the Editor it will make an API call, for the Runner it will look it up via an environment variable.
+
+`reference_number_enabled?` method checks whether reference number is enabled in the Runner or Editor app. For the Runner app reference number is enabled when the `ENV['REFERENCE_NUMBER']` variable is present. In the Editor, reference number enabled is checked by checking the `ServiceConfiguration` table.
+
+`show_reference_number` method will present the placeholder reference number if viewing in the Editor/Preview or will present a generated reference number if in the Runner.
 
 ## Generate documentation
 

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -7,24 +7,23 @@
       <%= @page.heading %>
     </h1>
 
-  <% if ENV['REFERENCE_NUMBER'] == 'enabled' %>
-    <div class="govuk-panel__body">Your reference number</div>
     <div class="govuk-panel__body">
-      <strong>
-      <%= @page.reference_number %>
-      </strong>
+      <% if reference_number_enabled? %>
+        <p>Your reference number<br />
+          <strong><%= show_reference_number %></strong>
+        </p>
+      <% end %>
+
+      <%# Do not replace with app/views/metadata_presenter/attribute _lede.html.erb because that is different %>
+      <% if @page.lede %>
+        <div class="fb-editable"
+            data-fb-content-id="page[lede]"
+            data-fb-content-type="element"
+            data-fb-default-text="<%= default_text('lede') %>">
+          <%= @page.lede %>
+        </div>
+      <%- end %>
     </div>
-    <br>
-  <% end %>
-    <%# Do not replace with app/views/metadata_presenter/attribute _lede.html.erb because that is different %>
-    <% if @page.lede %>
-      <div class="fb-editable govuk-panel__body"
-           data-fb-content-id="page[lede]"
-           data-fb-content-type="element"
-           data-fb-default-text="<%= default_text('lede') %>">
-        <%= @page.lede %>
-      </div>
-    <%- end %>
   </div>
 
   <div class="govuk-grid-row">

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -7,6 +7,15 @@
       <%= @page.heading %>
     </h1>
 
+  <% if ENV['REFERENCE_NUMBER'] == 'enabled' %>
+    <div class="govuk-panel__body">Your reference number</div>
+    <div class="govuk-panel__body">
+      <strong>
+      <%= @page.reference_number %>
+      </strong>
+    </div>
+    <br>
+  <% end %>
     <%# Do not replace with app/views/metadata_presenter/attribute _lede.html.erb because that is different %>
     <% if @page.lede %>
       <div class="fb-editable govuk-panel__body"

--- a/default_metadata/page/confirmation.json
+++ b/default_metadata/page/confirmation.json
@@ -2,5 +2,6 @@
   "_id": "page.confirmation",
   "_type": "page.confirmation",
   "heading": "Application complete",
+  "reference_number": "123-ABCD-456",
   "components": []
 }

--- a/default_metadata/page/confirmation.json
+++ b/default_metadata/page/confirmation.json
@@ -2,6 +2,5 @@
   "_id": "page.confirmation",
   "_type": "page.confirmation",
   "heading": "Application complete",
-  "reference_number": "123-ABCD-456",
   "components": []
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.23'.freeze
+  VERSION = '2.17.24'.freeze
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -25,6 +25,12 @@ class ApplicationController < ActionController::Base
 
   def autocomplete_items(component); end
 
+  def show_reference_number; end
+  helper_method :show_reference_number
+
+  def reference_number_enabled?; end
+  helper_method :reference_number_enabled?
+
   def default_metadata
     Rails.application.config.default_metadata
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/pXXDM00K/3075-reference-number-adjust-template-in-the-presenter)

### Add reference number to confirmation page template
This commit adds the reference number to the confirmation page template.
The reference number will be non-editable and needs to be auto-generated on submission.
We tested the 'REFERENCE_NUMBER' env vars locally, so can confirm the reference number will only appear when the env var is enabled.

### Show the correct reference number dependent on the app
When in the Editor app, there is no need to generate a reference number, so we want to use a placeholder.

When in the Runner, we want to generate a new reference number every time.

`reference_number_enabled?` and `show_reference_number` are methods that will be defined in the Editor and the Runner.

### Bump to version 2.17.24

![Screenshot 2022-11-22 at 11 23 54](https://user-images.githubusercontent.com/29227502/203302762-dc30bdee-3f4d-4ae9-a2db-3642ddc85fad.png)