### PR TITLE
Update H3 to H2 for Check your answers template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.26] - 2022-12-05
+### Changed
+
+ - Updated Check your answers page to use H2 tags for multiquestion page titles
+     to keep logical heading heirarchy correct for accessibility.
+
 ## [2.17.25] - 2022-12-01
 ### Fixed
 

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -27,7 +27,7 @@
               <% if page_answers_presenter.display_heading?(index) %>
         </dl>
 
-        <h3 class="govuk-heading-m"><%= page_answers_presenter.page.heading %></h3>
+        <h2 class="govuk-heading-m"><%= page_answers_presenter.page.heading %></h2>
 
         <dl class="fb-block fb-block-answers govuk-summary-list">
               <% end %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.25'.freeze
+  VERSION = '2.17.26'.freeze
 end


### PR DESCRIPTION
Updates the Check your answers page template to use H2 tag for headings of muliple question pages.  

This gives no visual change, as the same `govuk-heading-m` class is used, but it makes the heading heirarchy of the page correct and avoids the 'skipped heading level' warning from accessibility audits.

