### PR TITLE
Reference number confirmation page update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+
+## [2.17.27] - 2022-12-06
+### Changed
+
+- Updated reference number confirmation page content and move to using locales.
+
 ## [2.17.26] - 2022-12-05
 ### Changed
 

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -9,7 +9,7 @@
 
     <div class="govuk-panel__body">
       <% if reference_number_enabled? %>
-        <p>Your reference number<br />
+        <p><%= I18n.t('presenter.confirmation.reference_number') %><br />
           <strong><%= show_reference_number %></strong>
         </p>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,8 @@ en:
     maintenance:
       maintenance_page_heading: 'Sorry, this form is unavailable'
       maintenance_page_content: "If you were in the middle of completing the form, your data has not been saved.\r\n\r\nThe form will be available again from 9am on Monday 19 November 2018.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nContact us if your application is urgent \r\n\r\nEmail:  \r\nTelephone:  \r\nMonday to Friday, 9am to 5pm  \r\n[Find out about call charges](https://www.gov.uk/call-charges)"
+    confirmation:
+      reference_number: 'Your reference number is:'
     footer:
       cookies:
         heading: "Cookies"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.26'.freeze
+  VERSION = '2.17.27'.freeze
 end


### PR DESCRIPTION
This updates the content for reference numbers on the confirmation page.

Move to using the locales.

Publish 2.17.27

![Screenshot 2022-12-06 at 11 04 25](https://user-images.githubusercontent.com/3466862/205895014-9547a8d6-7238-4c23-9d91-6662b5d615d1.png)
