### PR TITLE
Use correct confirmation page if payment link is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.28] - 2022-12-12
+### Added
+
+- Add logic to change confirmation page style based on whether payment link is enabled.
 
 ## [2.17.27] - 2022-12-06
 ### Changed

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -1,10 +1,18 @@
 <% content_for :manual_global_analytics_properties do %>'page_title': 'Confirmation page'<% end %>
 <div class="fb-main-grid-wrapper" data-fb-pagetype="<%= @page.type %>">
+<% if payment_link_enabled? %>
+  <div class="govuk-panel govuk-panel--confirmation-payment govuk-grid-column-two-thirds">
+  <% else %>
   <div class="govuk-panel govuk-panel--confirmation govuk-grid-column-two-thirds">
+<% end %>
     <h1 class="fb-editable govuk-panel__title"
         data-fb-content-type="element"
         data-fb-content-id="page[heading]">
-      <%= @page.heading %>
+      <% if payment_link_enabled? %>
+        <p><%= I18n.t('presenter.confirmation.payment_enabled') %></p>
+      <% else %>
+        <%= @page.heading %>
+      <% end %>
     </h1>
 
     <div class="govuk-panel__body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
       maintenance_page_content: "If you were in the middle of completing the form, your data has not been saved.\r\n\r\nThe form will be available again from 9am on Monday 19 November 2018.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nContact us if your application is urgent \r\n\r\nEmail:  \r\nTelephone:  \r\nMonday to Friday, 9am to 5pm  \r\n[Find out about call charges](https://www.gov.uk/call-charges)"
     confirmation:
       reference_number: 'Your reference number is:'
+      payment_enabled: You still need to pay
     footer:
       cookies:
         heading: "Cookies"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.27'.freeze
+  VERSION = '2.17.28'.freeze
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -31,6 +31,9 @@ class ApplicationController < ActionController::Base
   def reference_number_enabled?; end
   helper_method :reference_number_enabled?
 
+  def payment_link_enabled?; end
+  helper_method :payment_link_enabled?
+
   def default_metadata
     Rails.application.config.default_metadata
   end


### PR DESCRIPTION
We need to use a different confirmation page when payment link is enabled. The differences are:
- Heading has changed to 'You still need to pay'
- Panel colour needs to change from green to blue


Once this has been merged in we can merge in the following PRs:
- https://github.com/ministryofjustice/fb-editor/pull/1958
- https://github.com/ministryofjustice/fb-runner/pull/1058