### PR TITLE
Adds continue to pay button on confirmation page if payment_link is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.29] - 2022-12-16
+### Added
+ - Add continue to pay button to confirmation page if payment link is enabled
+
 ## [2.17.28] - 2022-12-12
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ that you need to write the following methods in your controller:
 5. assign_autocomplete_items
 6. reference_number_enabled?
 7. show_reference_number
+8. payment_link_enabled?
+9. payment_link_url
 
 The user answers can be accessed via `params[:answers]`.
 
@@ -88,6 +90,10 @@ The `autocomplete_items` takes the components on a page and retrieves any items 
 `reference_number_enabled?` method checks whether reference number is enabled in the Runner or Editor app. For the Runner app reference number is enabled when the `ENV['REFERENCE_NUMBER']` variable is present. In the Editor, reference number enabled is checked by checking the `ServiceConfiguration` table.
 
 `show_reference_number` method will present the placeholder reference number if viewing in the Editor/Preview or will present a generated reference number if in the Runner.
+
+`payment_link_enabled?` method checks whether payment link is enabled in the Runner or Editor app. For the Runner app payment link is enabled when the `ENV['PAYMENT_LINK']` variable is present. In the Editor, payment link enabled is checked by checking the `ServiceConfiguration` table.
+
+`payment_link_url` method will present the payment link url. For the Runner this is the value of the `ENV['PAYMENT_LINK']` variable. In the Editor the value comes from the `ServiceConfiguration` table.
 
 ## Generate documentation
 

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -48,5 +48,9 @@
              classes: nil,
              input_components: @page.supported_input_components,
              content_components: @page.supported_content_components
-           } %>
+             } %>
+
+  <% if payment_link_enabled? %>
+    <a href="<%= payment_link_url %>" class="govuk-button" data-module="govuk-button" data-component="pay-button"><%= t('presenter.confirmation.continue_to_pay_button') %></a>
+  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
     confirmation:
       reference_number: 'Your reference number is:'
       payment_enabled: You still need to pay
+      continue_to_pay_button: Continue to pay
     footer:
       cookies:
         heading: "Cookies"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.28'.freeze
+  VERSION = '2.17.29'.freeze
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -34,6 +34,9 @@ class ApplicationController < ActionController::Base
   def payment_link_enabled?; end
   helper_method :payment_link_enabled?
 
+  def payment_link_url; end
+  helper_method :payment_link_url
+
   def default_metadata
     Rails.application.config.default_metadata
   end


### PR DESCRIPTION
If payment link is enabled we need to show a 'continue to pay' button on the confirmation page to enable the user to take action.

Runner:
![image](https://user-images.githubusercontent.com/595564/208141706-8aac56f3-844c-4d82-8b5e-7c20a8bcd804.png)

Editor (Edit screen):
![image](https://user-images.githubusercontent.com/595564/208141836-4cdabc25-c2ea-474e-bbb5-af811e8aa122.png)

Editor (Preview):
![image](https://user-images.githubusercontent.com/595564/208141926-9dc09925-7b4a-44db-a2d8-8da402faf053.png)

