### PR TITLE
Use relative or fully qualified links in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.30] - 2022-12-20
+### Changed
+
+- Allow the use of fully qualified or relative URLs for the footer links
+
 ## [2.17.29] - 2022-12-16
 ### Added
  - Add continue to pay button to confirmation page if payment link is enabled

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -70,6 +70,14 @@ module MetadataPresenter
       ENV['MAINTENANCE_MODE'].present? && ENV['MAINTENANCE_MODE'] == '1'
     end
 
+    def external_or_relative_link(link)
+      uri = URI.parse(link)
+      return link if uri.scheme.present? && uri.host.present?
+
+      link.starts_with?('/') ? link : link.prepend('/')
+    end
+    helper_method :external_or_relative_link
+
     private
 
     def not_found

--- a/app/views/metadata_presenter/footer/_meta.html.erb
+++ b/app/views/metadata_presenter/footer/_meta.html.erb
@@ -2,7 +2,7 @@
 <ul class="govuk-footer__inline-list">
 <% service.meta.items.each do |item| %>
   <li class="govuk-footer__inline-list-item">
-    <a class="govuk-footer__link" href=<%= File.join(request.script_name, item.href) %>><%= item.text %></a>
+    <a class="govuk-footer__link" href=<%= external_or_relative_link(item.href) %>><%= item.text %></a>
   </li>
 <% end %>
 </ul>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.29'.freeze
+  VERSION = '2.17.30'.freeze
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -169,4 +169,30 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
       end
     end
   end
+
+  describe '#external_or_relative_link' do
+    context 'when link is fully qualified' do
+      let(:link) { 'https://www.example.com' }
+
+      it 'returns the fully qualified link' do
+        expect(controller.external_or_relative_link(link)).to eq(link)
+      end
+    end
+
+    context 'when link does not have / at start' do
+      let(:link) { 'somelink' }
+
+      it 'prepends / at the beginning of the relative link' do
+        expect(controller.external_or_relative_link(link)).to eq('/somelink')
+      end
+    end
+
+    context 'when link does have / at the start' do
+      let(:link) { '/somelink' }
+
+      it 'returns the relative link' do
+        expect(controller.external_or_relative_link(link)).to eq(link)
+      end
+    end
+  end
 end


### PR DESCRIPTION
There may be a need in the future to allow for some of the footer URLs
to link to external domains. By not prepending the request.script_name
to the footer href we allow for the metadata link to be a fully
qualified link OR a relative link

If the relative link does not have a '/' at the start then prepend one.

Publish 2.17.30