### PR TITLE
Fix preview link path generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.31] - 2022-12-20
+### Fixed
+
+- Fix preview links when in the Editor
+
 ## [2.17.30] - 2022-12-20
 ### Changed
 

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -74,7 +74,11 @@ module MetadataPresenter
       uri = URI.parse(link)
       return link if uri.scheme.present? && uri.host.present?
 
-      link.starts_with?('/') ? link : link.prepend('/')
+      if editor_preview?
+        File.join(request.script_name, link)
+      else
+        link.starts_with?('/') ? link : link.prepend('/')
+      end
     end
     helper_method :external_or_relative_link
 
@@ -107,6 +111,10 @@ module MetadataPresenter
 
         render 'metadata_presenter/maintenance/show'
       end
+    end
+
+    def editor_preview?
+      URI(request.original_url).path.split('/').last == 'preview'
     end
   end
 end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.30'.freeze
+  VERSION = '2.17.31'.freeze
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -194,5 +194,20 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
         expect(controller.external_or_relative_link(link)).to eq(link)
       end
     end
+
+    context 'when in preview in the editor' do
+      let(:link) { '/somelink' }
+      let(:original_url) { "http://some-domain.com#{preview_path}" }
+      let(:preview_path) { '/services/some-service-id/preview' }
+
+      before do
+        allow_any_instance_of(ActionDispatch::Request).to receive(:original_url).and_return(original_url)
+        allow_any_instance_of(ActionDispatch::Request).to receive(:script_name).and_return(preview_path)
+      end
+
+      it 'uses the request script name to build the correct path' do
+        expect(controller.external_or_relative_link(link)).to eq('/services/some-service-id/preview/somelink')
+      end
+    end
   end
 end


### PR DESCRIPTION
The Editor is a multi tenant application. It allows the previewing of
several different forms. In those instances we need to include the relative
of the service that is being edited.

Publish 2.17.31