### PR TITLE
Payment link heading exit page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.33] - 2023-01-20
+### Fixed
+
+- Heading for the confirmation page not being updated when payment links are enabled
+
 ## [2.17.32] - 2023-01-03
 ### Changed
 

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -8,7 +8,7 @@
     <h1 class="fb-editable govuk-panel__title"
         data-fb-content-type="element"
         data-fb-content-id="page[heading]">
-      <% if payment_link_enabled? %>
+      <% if payment_link_enabled? && @page.heading == 'Application complete' %>
         <p><%= I18n.t('presenter.confirmation.payment_enabled') %></p>
       <% else %>
         <%= @page.heading %>

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -8,7 +8,7 @@
     <h1 class="fb-editable govuk-panel__title"
         data-fb-content-type="element"
         data-fb-content-id="page[heading]">
-      <% if payment_link_enabled? && @page.heading == 'Application complete' %>
+      <% if payment_link_enabled? && @page.heading == I18n.t('presenter.confirmation.application_complete') %>
         <p><%= I18n.t('presenter.confirmation.payment_enabled') %></p>
       <% else %>
         <%= @page.heading %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
       reference_number: 'Your reference number is:'
       payment_enabled: You still need to pay
       continue_to_pay_button: Continue to pay
+      application_complete: 'Application complete'
     footer:
       cookies:
         heading: "Cookies"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.32'.freeze
+  VERSION = '2.17.33'.freeze
 end


### PR DESCRIPTION
The heading of the confirmation page was not updating when payment link was enabled.

Co-authored-by: Natalie Seeto <[natalie.seeto@digital.justice.gov.uk](mailto:natalie.seeto@digital.justice.gov.uk)>