### PR TITLE
Add session expired template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.34] - 2023-01-27
+### Added
+
+ - Added in a session expiry route and template to inform uses when their
+     session has expired.
+
 ## [2.17.33] - 2023-01-20
 ### Fixed
 

--- a/app/controllers/metadata_presenter/session_controller.rb
+++ b/app/controllers/metadata_presenter/session_controller.rb
@@ -1,0 +1,5 @@
+module MetadataPresenter
+  class SessionController < EngineController
+    def expired; end
+  end
+end

--- a/app/views/metadata_presenter/session/expired.html.erb
+++ b/app/views/metadata_presenter/session/expired.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('presenter.session_expired.title') %></h1>
+    <div class="maintenance-content">
+      <%= to_html t('presenter.session_expired.content') %>
+      <p><%= link_to t('presenter.session_expired.restart_link'), root_url %></p>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,10 @@ en:
     maintenance:
       maintenance_page_heading: 'Sorry, this form is unavailable'
       maintenance_page_content: "If you were in the middle of completing the form, your data has not been saved.\r\n\r\nThe form will be available again from 9am on Monday 19 November 2018.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nContact us if your application is urgent \r\n\r\nEmail:  \r\nTelephone:  \r\nMonday to Friday, 9am to 5pm  \r\n[Find out about call charges](https://www.gov.uk/call-charges)"
+    session_expired:
+      title: Your form has been reset
+      content: "The form has a time limit of 60 minutes. This is to protect your personal information.\r\n\r\nWe apologise for the inconvenience. Please try again."
+      restart_link: Start again
     confirmation:
       reference_number: 'Your reference number is:'
       payment_enabled: You still need to pay

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ MetadataPresenter::Engine.routes.draw do
   # as get verb.
   get '/reserved/file/:component_id', to: 'file#destroy', as: :remove_file
 
+  get 'session/expired', to: 'session#expired'
+
   post '/', to: 'answers#create'
   match '*path', to: 'answers#create', via: :post
   match '*path', to: 'pages#show',

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.33'.freeze
+  VERSION = '2.17.34'.freeze
 end


### PR DESCRIPTION
Add in a route and template to show when the users session has expired.

A (slightly) nicer experience for the user than just being dumped back on the start page!

This should be safe to merge in as there is no redirect in the runner to this route yet.

