### PR TITLE
Upgrading Presenter version to 2.17.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+
+## [2.17.35] - 2023-02-07
+### Changed
+
+- Update cookie statement from 30 to 6o minutes
+
 ## [2.17.34] - 2023-01-27
 ### Added
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.34'.freeze
+  VERSION = '2.17.35'.freeze
 end


### PR DESCRIPTION
For the runner to pick up the changes of statement for the cookie expiration from 30min to 60min, we have to update the version so the gems are packaged accordingly.