### PR TITLE
Fix formatting of content component on the checkanswers page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.37] - 2023-02-27
+### Fixed
+
+ - Update the output of the `@page.send_body` content in the template to use
+    the `to_html` helper like all other content components
+
 ## [2.17.36] - 2023-02-06
 ### Changed
 

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -70,7 +70,7 @@
           <div class="fb-send-body fb-editable govuk-body"
                data-fb-content-type="content"
                data-fb-content-id="page[send_body]">
-            <%= @page.send_body %>
+            <%= to_html (@page.send_body) %>
           </div>
         <% end %>
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.36'.freeze
+  VERSION = '2.17.37'.freeze
 end


### PR DESCRIPTION
The `@page.send_body` content component on the check answers page is an editable content component, however it is not rendered into the components array like all the other components.

There was a bug in how links were being rendered in this component. They were being handled incorrectly and link syntax was being escaped.

This was caused because we were outputtung markdown into the content of the comopnent on page render rather than convering to html first (like we do in all other components).