### PR TITLE
Separate cookie request and cookie confirmation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.43] - 2023-03-29
+### Changed
+
+ - Changed the templates for the cookie warning banner.  We reload the
+     page between the request and the accept or reject banner, so they need to
+     be separated into separate partials with different conditions for being
+     shown.
+
 ## [2.17.42] - 2023-03-29
 ### Changed
 

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -47,10 +47,17 @@ module MetadataPresenter
     end
     helper_method :allow_analytics?
 
-    def show_cookie_banner?
+    def show_cookie_request?
       (Rails.application.config.respond_to?(:global_ga4) || analytics_tags_present?) && no_analytics_cookie?
     end
-    helper_method :show_cookie_banner?
+    helper_method :show_cookie_request?
+
+    def show_cookie_confirmation?
+      unless no_analytics_cookie?
+        (Rails.application.config.respond_to?(:global_ga4) || analytics_tags_present?) && params[:analytics].present?
+      end
+    end
+    helper_method :show_cookie_confirmation?
 
     def analytics_tags_present?
       Rails.application.config.supported_analytics.values.flatten.any? do |analytic|

--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -29,8 +29,11 @@
     </script>
 
     <div class="govuk-modal-dialogue-inert-container">
-      <% if show_cookie_banner? %>
-        <%= render partial: 'metadata_presenter/analytics/cookie_banner' %>
+      <% if show_cookie_request? %>
+        <%= render partial: 'metadata_presenter/analytics/cookie_banner_request' %>
+      <% end %>
+      <% if show_cookie_confirmation? %>
+        <%= render partial: 'metadata_presenter/analytics/cookie_banner_confirmation' %>
       <% end %>
 
       <%= render template: 'metadata_presenter/header/show' %>

--- a/app/views/metadata_presenter/analytics/_cookie_banner_confirmation.html.erb
+++ b/app/views/metadata_presenter/analytics/_cookie_banner_confirmation.html.erb
@@ -1,30 +1,5 @@
+
 <div class="govuk-cookie-banner" id="govuk-cookie-banner" data-nosnippet role="region" aria-label="<%= t('presenter.analytics.heading', service_name: service.service_name) %>">
-  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message">
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          <%= t('presenter.analytics.heading', service_name: service.service_name) %>
-        </h2>
-
-        <div class="govuk-cookie-banner__content">
-          <p class="govuk-body"><%= t('presenter.analytics.body_1') %></p>
-          <p class="govuk-body"><%= t('presenter.analytics.body_2') %></p>
-        </div>
-      </div>
-    </div>
-
-    <div class="govuk-button-group">
-      <button type="button" class="govuk-button" data-module="govuk-button" onclick='analytics.accept("<%= analytics_cookie_name %>")'>
-        <%= t('presenter.analytics.accept') %>
-      </button>
-      <button type="button" class="govuk-button" data-module="govuk-button" onclick='analytics.reject("<%= analytics_cookie_name %>")'>
-        <%= t('presenter.analytics.reject') %>
-      </button>
-      <a class="govuk-link" href="/cookies"><%= t('presenter.analytics.view_cookies') %></a>
-    </div>
-  </div>
-
   <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message-accepted" role="alert" style="display: none;">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/metadata_presenter/analytics/_cookie_banner_request.html.erb
+++ b/app/views/metadata_presenter/analytics/_cookie_banner_request.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-cookie-banner" id="govuk-cookie-banner" data-nosnippet role="region" aria-label="<%= t('presenter.analytics.heading', service_name: service.service_name) %>">
+  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
+          <%= t('presenter.analytics.heading', service_name: service.service_name) %>
+        </h2>
+
+        <div class="govuk-cookie-banner__content">
+          <p class="govuk-body"><%= t('presenter.analytics.body_1') %></p>
+          <p class="govuk-body"><%= t('presenter.analytics.body_2') %></p>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-button-group">
+      <button type="button" class="govuk-button" data-module="govuk-button" onclick='analytics.accept("<%= analytics_cookie_name %>")'>
+        <%= t('presenter.analytics.accept') %>
+      </button>
+      <button type="button" class="govuk-button" data-module="govuk-button" onclick='analytics.reject("<%= analytics_cookie_name %>")'>
+        <%= t('presenter.analytics.reject') %>
+      </button>
+      <a class="govuk-link" href="/cookies"><%= t('presenter.analytics.view_cookies') %></a>
+    </div>
+  </div>
+</div>

--- a/app/views/metadata_presenter/session/_timeout_warning_modal.html.erb
+++ b/app/views/metadata_presenter/session/_timeout_warning_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-timeout-warning"
      data-module="govuk-timeout-warning"
      id="js-timeout-warning"
-     data-minutes-idle-timeout="25"
+     data-minutes-idle-timeout="24"
      data-minutes-modal-visible="5"
      data-url-redirect="/session/reset"
      data-timer-text="<%= t('presenter.session_timeout_warning.timer') %>"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.17.42'.freeze
+  VERSION = '2.17.43'.freeze
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
     end
   end
 
-  describe '#show_cookie_banner?' do
+  describe '#show_cookie_request?' do
     context 'when analytics cookie is present' do
       let(:cookies) do
         ActionDispatch::Cookies::CookieJar.build(request, { 'analytics-version-fixture' => 'accepted' })
@@ -82,13 +82,13 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
         end
 
         it 'returns falsey' do
-          expect(controller.show_cookie_banner?).to be_falsey
+          expect(controller.show_cookie_request?).to be_falsey
         end
       end
 
       context 'when analytics tag is not present' do
         it 'returns falsey' do
-          expect(controller.show_cookie_banner?).to be_falsey
+          expect(controller.show_cookie_request?).to be_falsey
         end
       end
     end
@@ -101,7 +101,97 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
         end
 
         it 'returns truthy' do
-          expect(controller.show_cookie_banner?).to be_truthy
+          expect(controller.show_cookie_request?).to be_truthy
+        end
+      end
+    end
+  end
+
+  describe '#show_cookie_confirmation?' do
+    context 'when analytics param is present' do
+      before do
+        controller.params[:analytics] = 'accepted'
+      end
+
+      context 'when analytics cookie is present' do
+        let(:cookies) do
+          ActionDispatch::Cookies::CookieJar.build(request, { 'analytics-version-fixture' => 'accepted' })
+        end
+
+        before do
+          allow_any_instance_of(MetadataPresenter::EngineController).to receive(:cookies).and_return(cookies)
+        end
+
+        context 'when analytics tags are present' do
+          before do
+            allow(ENV).to receive(:[])
+            allow(ENV).to receive(:[]).with('UA').and_return('some-analytics-tag')
+          end
+
+          it 'returns truthy' do
+            expect(controller.show_cookie_confirmation?).to be_truthy
+          end
+        end
+
+        context 'when analytics tag is not present' do
+          it 'returns falsey' do
+            expect(controller.show_cookie_confirmation?).to be_falsey
+          end
+        end
+      end
+
+      context 'when analytics cookie is not present' do
+        context 'when at least one analytics tag is present' do
+          before do
+            allow(ENV).to receive(:[])
+            allow(ENV).to receive(:[]).with('GA4').and_return('some-analytics-tag')
+          end
+
+          it 'returns falsey' do
+            expect(controller.show_cookie_confirmation?).to be_falsey
+          end
+        end
+      end
+    end
+
+    context 'when analytics param is not present' do
+      context 'when analytics cookie is present' do
+        let(:cookies) do
+          ActionDispatch::Cookies::CookieJar.build(request, { 'analytics-version-fixture' => 'accepted' })
+        end
+
+        before do
+          allow_any_instance_of(MetadataPresenter::EngineController).to receive(:cookies).and_return(cookies)
+        end
+
+        context 'when analytics tags are present' do
+          before do
+            allow(ENV).to receive(:[])
+            allow(ENV).to receive(:[]).with('UA').and_return('some-analytics-tag')
+          end
+
+          it 'returns falsey' do
+            expect(controller.show_cookie_confirmation?).to be_falsey
+          end
+        end
+
+        context 'when analytics tag is not present' do
+          it 'returns falsey' do
+            expect(controller.show_cookie_confirmation?).to be_falsey
+          end
+        end
+      end
+
+      context 'when analytics cookie is not present' do
+        context 'when at least one analytics tag is present' do
+          before do
+            allow(ENV).to receive(:[])
+            allow(ENV).to receive(:[]).with('GA4').and_return('some-analytics-tag')
+          end
+
+          it 'returns falsey' do
+            expect(controller.show_cookie_confirmation?).to be_falsey
+          end
         end
       end
     end


### PR DESCRIPTION
### Problem:
When accepting cookies, the tracking code did not load until the next page load, so the tracking for the initial page is 'lost'

### Solution:
Reload the page on accept (and reject, just for consistency of impolementation).
When relaoding the page we add a querystring to indicate cookies accepted/rejected.

Previously the cookie request, and the accep, reject messages were all in the same template and just shown/hidden by JS.

Now we're lopading/showing them separately they need to be in different partials, and be added into the page under slightly different conditions.

**N.B.**
In order to avoide too many version bumps, I've snuck in one very small change to the session timeout warning:  I've updated the minutes idle to 24 instead of 25.  

The reason for this is that due to the way javascript works `setTimeout` and `setInterval` are not perfect in terms of timing.  This means that with a backend session timeout of 30mins and a frontend idletime of 25mins plus warning time of 5mins, if those timers are fractionally out, there is an edge case that if someone waited until the last couple of seconds to dismiss the modal and continue, their session may have already timed out on the backend 😬.  

An idle time of 24mins allows nearly 2s of leeway for each minute of JS timing we do, which should be fine (and no one is going to time the full idle time and countdown to discover the 1min discrepancy!)
