### PR TITLE
Update in_progress? helper to allowed_page?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.17.45] - 2023-03-29
+### Changed
+
+ - update helper method from `in_progress?` to `allowed_page?` as it is a more
+     accurate and less confusing name.
+
 ## [2.17.44] - 2023-03-39
 ### Changed
 

--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -28,6 +28,7 @@
      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
+
     <div class="govuk-modal-dialogue-inert-container">
       <% if show_cookie_request? %>
         <%= render partial: 'metadata_presenter/analytics/cookie_banner_request' %>
@@ -43,7 +44,7 @@
           <% if back_link.present? %>
             <a class="govuk-back-link" href="<%= back_link %>">Back</a>
           <% end %>
-          <% if !in_progress? %>
+          <% if !allowed_page? %>
             <%= render partial: 'metadata_presenter/session/timeout_fallback' %>
           <% end %>
           <%= yield %>
@@ -53,7 +54,7 @@
       <%= render template: 'metadata_presenter/footer/footer' %>
     </div>
 
-    <% if !in_progress? %>
+    <% if !allowed_page? %>
       <%= render partial: 'metadata_presenter/session/timeout_warning_modal' %>
     <% end %>
   </body>


### PR DESCRIPTION
The in_progress? method was incorrectly named - it was returning true for standalone pages, the start page, and the session expired url.

Have renamed this method to `allowed_page?` which returns to the previous language and is actually accurately describing the condition!

So now if we are not on an *allowed_page* we want to include the session timeout warning partials.