### PR TITLE
Fix back link style and path

### DIFF
--- a/app/controllers/metadata_presenter/save_and_return_controller.rb
+++ b/app/controllers/metadata_presenter/save_and_return_controller.rb
@@ -8,7 +8,7 @@ module MetadataPresenter
     end
 
     def page_slug
-      params[:page_slug] || params[:saved_form][:page_slug]
+      session['saved_form']['page_slug'] || params[:page_slug]
     end
 
     def confirmed_email

--- a/app/views/metadata_presenter/save_and_return/email_confirmation.html.erb
+++ b/app/views/metadata_presenter/save_and_return/email_confirmation.html.erb
@@ -16,7 +16,7 @@
       
       <p class="mojf-settings-screen__description"><%= t('presenter.save_and_return.confirm_email.description') %></p>
 
-      <%= f.govuk_submit t('presenter.save_and_return.show.continue') %><% end %> <%= link_to t('presenter.save_and_return.show.cancel'), :back %>
+      <%= f.govuk_submit t('presenter.save_and_return.show.continue') %><% end %> <%= link_to t('presenter.save_and_return.show.cancel'), page_slug, class: "govuk-button govuk-button--secondary" %>
     </div>
   </div>
 </div>

--- a/app/views/metadata_presenter/save_and_return/show.html.erb
+++ b/app/views/metadata_presenter/save_and_return/show.html.erb
@@ -38,7 +38,7 @@
         %>
       </div>
 
-      <%= f.govuk_submit t('presenter.save_and_return.show.continue') %><% end %> <%= link_to t('presenter.save_and_return.show.cancel'), :back %>
+      <%= f.govuk_submit t('presenter.save_and_return.show.continue') %><% end %> <%= link_to t('presenter.save_and_return.show.cancel'), page_slug, class: "govuk-button govuk-button--secondary" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Style back link as button, ensure it returns user to page they left the form from
<img width="314" alt="image" src="https://user-images.githubusercontent.com/7647632/231136497-903d0032-f980-4cb9-8183-5024f6624409.png">
