### PR TITLE
Bump version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.18.2] - 2023-04-05
+### Changed
+
+ - Fix back link in save and return flow
+
 ## [2.18.1] - 2023-04-05
 ### Changed
 

--- a/app/controllers/metadata_presenter/save_and_return_controller.rb
+++ b/app/controllers/metadata_presenter/save_and_return_controller.rb
@@ -1,6 +1,5 @@
 module MetadataPresenter
   class SaveAndReturnController < EngineController
-    # before_action :check_feature_flag
     helper_method :secret_questions, :page_slug, :confirmed_email
 
     def show

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.18.1'.freeze
+  VERSION = '2.18.2'.freeze
 end


### PR DESCRIPTION
In preparation to deploy to dev/live a version of the runner referencing 2.18.2

The editor cannot set the feature flag apart from the version manually deployed to test-dev

The button accessing the save and return flow is only present on single question pages if the ENV is set