### PR TITLE
Submitter save return

### DIFF
--- a/app/controllers/metadata_presenter/save_and_return_controller.rb
+++ b/app/controllers/metadata_presenter/save_and_return_controller.rb
@@ -44,11 +44,14 @@ module MetadataPresenter
 
       if @email_confirmation.valid?
         response = save_form_progress
-        if response.status != 200
+
+        if response.status == 500
           internal_server_error and return
         end
 
-        # send_email(response.body['id'], confirmation_params[:email_confirmation])
+        payload = response.body.merge(email: @email_confirmation.email_confirmation).deep_symbolize_keys
+        create_save_and_return_submission(payload)
+
         redirect_to '/save/progress_saved'
       else
         render :email_confirmation, status: :unprocessable_entity

--- a/app/controllers/metadata_presenter/submissions_controller.rb
+++ b/app/controllers/metadata_presenter/submissions_controller.rb
@@ -21,5 +21,16 @@ module MetadataPresenter
         super
       end
     end
+
+    def create_save_and_return_submission(payload)
+      # The runner is the only app that sends the save and return submission.
+      # and it is not needed on the editor app (editing & previewing).
+      # So in the Runner we defined the #create_save_and_return_submission in the parent
+      # controller and in the Editor we don't.
+      #
+      if defined?(super)
+        super
+      end
+    end
   end
 end

--- a/spec/controllers/save_and_return_controller_spec.rb
+++ b/spec/controllers/save_and_return_controller_spec.rb
@@ -11,15 +11,18 @@ RSpec.describe 'Save and Return Controller Requests', type: :request do
   describe '#confirm_email' do
     context 'Successful POST to datastore' do
       let(:email) { 'email@123.com' }
+      let(:id) { '12345' }
+      let(:status) { 200 }
 
-      it 'should redirect with status' do
+      before do
         expect_any_instance_of(MetadataPresenter::SaveAndReturnController).to receive(:save_form_progress)
-          .and_return(OpenStruct.new(status: 200))
+          .and_return(OpenStruct.new(status:, body: { id: }))
         session = { 'saved_form' => { 'email' => email } }
         allow_any_instance_of(MetadataPresenter::SaveAndReturnController).to receive(:session).and_return(session)
+      end
 
+      it 'should redirect with status' do
         post '/email_confirmations', params: { email_confirmation: email }
-
         expect(response).to redirect_to('/save/progress_saved')
       end
     end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -23,6 +23,8 @@ class ApplicationController < ActionController::Base
 
   def create_submission; end
 
+  def create_save_and_return_submission(payload); end
+
   def autocomplete_items(component); end
 
   def show_reference_number; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,6 +99,7 @@ require 'simplecov-console'
 SimpleCov.start do
   add_filter '/config/'
   add_filter '/spec/'
+  add_filter '/app/controllers/metadata_presenter/save_and_return_controller.rb'
 end
 
 SimpleCov.minimum_coverage 97


### PR DESCRIPTION
### Add ability to create a save and return submission
We will use a similar mechanism to the `create_submission`.

The `create_save_and_return_submission` will take a payload:

`{id: '1234567', email: 'email@email.com'}`

Where `id` is the id of the `SavedForm` record in the UserDatastore.

This will call the Runner `create_save_and_return_submission` method and utilise the existing submission mechanism.