### PR TITLE
Changes to 404 page template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
-
 ## [2.18.6] - 2023-04-27
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.18.7] - 2023-04-27
+### Changed
+
+ - Update copy on 404 error page. Remove head and body tags as this template
+     is always loaded within a layout.
+
 ## [2.18.6] - 2023-04-27
 ### Fixed
 

--- a/app/views/errors/404.html
+++ b/app/views/errors/404.html
@@ -1,67 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+<div>
+  <h1>Page not found</h1>
+  <p>If you typed the web address, check it is correct.</p>
+  <p>If you pasted the web address, check you copied the entire address.</p>
+  <p>If the problem persists, <a href="https://moj-forms.service.justice.gov.uk/contact/">contact the MoJ Forms team.</a></p>
+</div>
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
-
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
-    </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
-</html>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.18.6'.freeze
+  VERSION = '2.18.7'.freeze
 end

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
 
     it 'renders the view correctly' do
       expect(response.body).to include(
-        "The page you were looking for doesn't exist."
+        'Page not found'
       )
     end
   end
@@ -198,7 +198,7 @@ RSpec.describe MetadataPresenter::ServiceController, type: :request do
 
       it 'returns not found' do
         expect(response.body).to include(
-          "The page you were looking for doesn't exist."
+          'Page not found'
         )
       end
     end


### PR DESCRIPTION
Updates the content of the 404 page.

Also removes the `<head>` and `<body>` parts of the tempalte as the 404 template is always loaded as part of the main app layout.

