### PR TITLE
Fix question heading spacing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 ## [2.18.4] - 2023-04-14
+### Fixed
+
+ - Fixed spacing between titles and components on multiple question pages.
+
+## [2.18.4] - 2023-04-14
 
  - Update start page template to new content
 

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -1,20 +1,20 @@
 <% components.each_with_index do |component, index| %>
-  <div class="fb-editable"
-        id="<%= component.id %>"
-        data-fb-content-type="<%= component.type %>"
-        data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
-        data-fb-content-data="<%= component.to_json %>">
+  <div class="fb-editable govuk-!-margin-top-8"
+       id="<%= component.id %>"
+       data-fb-content-type="<%= component.type %>"
+       data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
+       data-fb-content-data="<%= component.to_json %>">
 
-    <%= render partial: component, locals: {
-        f: f,
-        component: component,
-        component_id: "page[#{component.collection}[#{index}]]",
-        input_title: main_title(
-          component: component,
-          tag: :h2,
-          classes: classes
-        )
-      }
-    %>
+       <%= render partial: component, locals: {
+         f: f,
+         component: component,
+         component_id: "page[#{component.collection}[#{index}]]",
+         input_title: main_title(
+           component: component,
+           tag: :h2,
+           classes: classes
+         )
+       }
+     %>
   </div>
 <% end %>

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -12,7 +12,7 @@
             f: f,
             components: @page.components,
             tag: :h2,
-            classes: 'govuk-heading-m govuk-!-margin-top-8',
+            classes: 'govuk-heading-m',
             input_components: @page.supported_input_components,
             content_components: @page.supported_content_components
           }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.18.4'.freeze
+  VERSION = '2.18.5'.freeze
 end


### PR DESCRIPTION
There were spoacing issues between the page title and the first component on multiple question pages when the first component was a checkbox or radion component.

This was caused due to the margin between components being added into the `label` element within the question,a nd the checkboxes and radios components have a `fieldset` element that was preventing the margin between the title and the question collapsing.


Solution was to move the margin out onto the actual question element itself in order for the margins to collapse correctly.

![image](https://user-images.githubusercontent.com/595564/234518536-feb1e17c-6bcd-4f1a-a9a1-9b8f62ccbed7.png)
Before: Too much spacing betweeen title and first question

![image](https://user-images.githubusercontent.com/595564/234518875-c43da9c0-1823-431d-b292-d30e08b01697.png)
After: Margins collapsing correctly
