### PR TITLE
Prevent submit on save for later from check answers page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.19.2] - 2023-05-10
+### Changed
+
+- Prevent submission of form when clicking save for later on check answers page
+
 ## [2.19.1] - 2023-05-10
 ### Changed
 

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -6,6 +6,11 @@ module MetadataPresenter
       @previous_answers = reload_user_data.deep_dup
       @page_answers = PageAnswers.new(page, answers_params, autocomplete_items(page.components))
 
+      if params[:save_for_later_check_answers].present?
+        # this flag is sent by the check answers page, and we don't want to submit & validate here
+        redirect_to save_path(page_slug: params[:page_slug]) and return
+      end
+
       if params[:save_for_later].present?
         save_user_data
         # NOTE: if the user is on a file upload page, files will not be uploaded before redirection

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -6,11 +6,6 @@ module MetadataPresenter
       @previous_answers = reload_user_data.deep_dup
       @page_answers = PageAnswers.new(page, answers_params, autocomplete_items(page.components))
 
-      if params[:save_for_later_check_answers].present?
-        # this flag is sent by the check answers page, and we don't want to submit & validate here
-        redirect_to save_path(page_slug: params[:page_slug]) and return
-      end
-
       if params[:save_for_later].present?
         save_user_data
         # NOTE: if the user is on a file upload page, files will not be uploaded before redirection

--- a/app/controllers/metadata_presenter/submissions_controller.rb
+++ b/app/controllers/metadata_presenter/submissions_controller.rb
@@ -4,6 +4,11 @@ module MetadataPresenter
       @page = service.confirmation_page
 
       if @page
+        if params[:save_for_later_check_answers].present?
+          # this flag is sent by the check answers page, and we don't want to submit & validate here
+          redirect_to save_path(page_slug: params[:page_slug]) and return
+        end
+
         create_submission
         redirect_to_page @page.url
       else

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -89,9 +89,9 @@
             <%= t('presenter.actions.submit') -%>
             <% if save_and_return_enabled? %>
             <% if editor_preview? || editable? %>
-              <%= button_to t('presenter.save_and_return.save'), '/', params: { page_slug:request.env['PATH_INFO'] }, method: :post, class: "govuk-button govuk-button--secondary", name: 'save_for_later', disabled: true %>
+              <%= button_to t('presenter.save_and_return.save'), '/', params: { page_slug:request.env['PATH_INFO'] }, method: :post, class: "govuk-button govuk-button--secondary", name: 'save_for_later_check_answers', disabled: true %>
             <% else %>
-              <%= button_to t('presenter.save_and_return.save'), '/', params: { page_slug:request.env['PATH_INFO'] }, method: :post, class: "govuk-button govuk-button--secondary", name: 'save_for_later'%>
+              <%= button_to t('presenter.save_and_return.save'), '/', params: { page_slug:request.env['PATH_INFO'] }, method: :post, class: "govuk-button govuk-button--secondary", name: 'save_for_later_check_answers'%>
             <% end %>
           <% end %>        </div>
       <% end %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.19.1'.freeze
+  VERSION = '2.19.2'.freeze
 end

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe 'Answers Controller Requests', type: :request do
       
       expect(response).to redirect_to('/save')
     end
+  end
 
-    it 'does not save from check your answers' do
-      expect_any_instance_of(MetadataPresenter::AnswersController).to_not receive(:save_user_data)
-      post '/', params: { save_for_later_check_answers: true }
+  describe 'reserved submissions path' do
+    it 'does not create a submission from check your answers' do
+      expect_any_instance_of(MetadataPresenter::SubmissionsController).to_not receive(:create_submission)
+      post '/reserved/submissions', params: { save_for_later_check_answers: true }
       
       expect(response).to redirect_to('/save')
     end

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe 'Answers Controller Requests', type: :request do
+  describe '#create' do
+    it 'saves and redirects if the param is set' do
+      expect_any_instance_of(MetadataPresenter::AnswersController).to receive(:save_user_data)
+      post '/', params: { save_for_later: true }
+      
+      expect(response).to redirect_to('/save')
+    end
+
+    it 'does not save from check your answers' do
+      expect_any_instance_of(MetadataPresenter::AnswersController).to_not receive(:save_user_data)
+      post '/', params: { save_for_later_check_answers: true }
+      
+      expect(response).to redirect_to('/save')
+    end
+  end
+end

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'Answers Controller Requests', type: :request do
     it 'saves and redirects if the param is set' do
       expect_any_instance_of(MetadataPresenter::AnswersController).to receive(:save_user_data)
       post '/', params: { save_for_later: true }
-      
+
       expect(response).to redirect_to('/save')
     end
   end
@@ -12,7 +12,7 @@ RSpec.describe 'Answers Controller Requests', type: :request do
     it 'does not create a submission from check your answers' do
       expect_any_instance_of(MetadataPresenter::SubmissionsController).to_not receive(:create_submission)
       post '/reserved/submissions', params: { save_for_later_check_answers: true }
-      
+
       expect(response).to redirect_to('/save')
     end
   end


### PR DESCRIPTION
Noticed that it would validate and submit as this page is treated like an answers page, which is not desirable because that just submits the form from here and will not redirect to save for later.