### PR TITLE
Remove unwanted characters in file uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.19.4] - 2023-05-18
+### Changed
+
+- Remove unwanted characters from file uploads
+
 ## [2.19.3] - 2023-05-10
 ### Changed
 

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -42,10 +42,12 @@ module MetadataPresenter
       return {} unless file_details
 
       if file_details.is_a?(Hash) || file_details.is_a?(ActionController::Parameters)
-        file_details.merge('original_filename' => sanitize(file_details['original_filename']))
+
+        file_details.merge('original_filename' => sanitize(filename(file_details['original_filename'])))
+
       else
         {
-          'original_filename' => sanitize(file_details.original_filename),
+          'original_filename' => sanitize(filename(file_details.original_filename)),
           'content_type' => file_details.content_type,
           'tempfile' => file_details.tempfile.path.to_s
         }
@@ -66,6 +68,14 @@ module MetadataPresenter
       ].map do |segment|
         sanitize(answers["#{component_id}(#{segment})"])
       end
+    end
+
+    private
+
+    def filename(path)
+      return sanitize(path) if path.nil?
+
+      sanitize(path).gsub(/&gt;/, '').gsub(/&lt;/, '').delete('>"[]{}*?:|]/<').delete('\\')
     end
   end
 end

--- a/app/views/metadata_presenter/component/_upload.html.erb
+++ b/app/views/metadata_presenter/component/_upload.html.erb
@@ -3,7 +3,6 @@
   <span class="govuk-hint" id="answers-dog-picture-upload-1-hint" data-fb-default-text="<%= default_text('upload_hint') %>">
     <%= component.hint.present? ? component.hint : default_text('upload_hint') %>
   </span>
-
   <p><%= @page_answers.send(component.id)['original_filename'] %></p>
 
   <p>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.19.3'.freeze
+  VERSION = '2.19.4'.freeze
 end

--- a/spec/models/page_answers_spec.rb
+++ b/spec/models/page_answers_spec.rb
@@ -218,49 +218,75 @@ RSpec.describe MetadataPresenter::PageAnswers do
           it 'sanitizes file details hash' do
             expect(
               page_answers.send('dog-picture_upload_1')['original_filename']
-            ).to eq('<img src="a">.txt')
-          end
-        end
-
-        context 'when file details is a hash' do
-          let(:page) { service.find_page_by_url('dog-picture') }
-          let(:upload_file) do
-            {
-              'original_filename' => "<script>alert('upload')</script>.png",
-              'content_type' => 'image/png',
-              'tempfile' => '/var/folders/v1/qb4w33l97jz0zfpwhl7jd1k00000gn/T/RackMultipart20210706-23929-qfs5ct.png'
-            }
-          end
-          let(:answers) do
-            { 'dog-picture_upload_1' => upload_file }
+            ).to eq('img src=a.txt')
           end
 
-          it 'sanitizes file details hash' do
-            expect(
-              page_answers.send('dog-picture_upload_1')['original_filename']
-            ).to eq("alert('upload').png")
-          end
-        end
-
-        context 'when file details is an ActionController::Parameters object' do
-          let(:page) { service.find_page_by_url('dog-picture') }
-          let(:upload_file) do
-            ActionController::Parameters.new(
+          context 'when file details is a hash' do
+            let(:upload_file) do
               {
                 'original_filename' => "<script>alert('upload')</script>.png",
                 'content_type' => 'image/png',
                 'tempfile' => '/var/folders/v1/qb4w33l97jz0zfpwhl7jd1k00000gn/T/RackMultipart20210706-23929-qfs5ct.png'
               }
-            )
-          end
-          let(:answers) do
-            { 'dog-picture_upload_1' => upload_file }
+            end
+
+            it 'sanitizes file details hash' do
+              expect(
+                page_answers.send('dog-picture_upload_1')['original_filename']
+              ).to eq("alert('upload').png")
+            end
+
+            context 'when file contains forbidden characters' do
+              let(:upload_file) do
+                {
+                  'original_filename' => 'hell\o"<>[]{}?/:|*.png',
+                  'content_type' => 'image/png',
+                  'tempfile' => '/var/folders/v1/qb4w33l97jz0zfpwhl7jd1k00000gn/T/RackMultipart20210706-23929-qfs5ct.png'
+                }
+              end
+
+              it 'removes the forbidden characters' do
+                expect(
+                  page_answers.send('dog-picture_upload_1')['original_filename']
+                ).to eq('hello.png')
+              end
+            end
           end
 
-          it 'sanitizes file details hash' do
-            expect(
-              page_answers.send('dog-picture_upload_1')['original_filename']
-            ).to eq("alert('upload').png")
+          context 'when file details is an ActionController::Parameters object' do
+            let(:upload_file) do
+              ActionController::Parameters.new(
+                {
+                  'original_filename' => "<script>alert('upload')</script>.png",
+                  'content_type' => 'image/png',
+                  'tempfile' => '/var/folders/v1/qb4w33l97jz0zfpwhl7jd1k00000gn/T/RackMultipart20210706-23929-qfs5ct.png'
+                }
+              )
+            end
+
+            it 'sanitizes file details hash' do
+              expect(
+                page_answers.send('dog-picture_upload_1')['original_filename']
+              ).to eq("alert('upload').png")
+            end
+
+            context 'when file contains forbidden characters' do
+              let(:upload_file) do
+                ActionController::Parameters.new(
+                  {
+                    'original_filename' => 'hell\o"<>[]{}?/:|*.png',
+                    'content_type' => 'image/png',
+                    'tempfile' => '/var/folders/v1/qb4w33l97jz0zfpwhl7jd1k00000gn/T/RackMultipart20210706-23929-qfs5ct.png'
+                  }
+                )
+              end
+
+              it 'removes the forbidden characters' do
+                expect(
+                  page_answers.send('dog-picture_upload_1')['original_filename']
+                ).to eq('hello.png')
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
### Remove unwanted characters in file uploads
We want to silently remove certain characters from file uploads. This commit removes these certain characters.
We need to sanitise the input before removing the other special characters. This is to first prevent any injection attacks.
We then need to remove the remaining `&gt;` or `&lt;` characters, which have resulted from the sanitising.

Here, we have catered for a `\` char to be deleted and have a test for this. However, with e2e testing the behaviour is chars before the `\` are removed. This appears to be underlying behaviour in the `ActionDispatch` class, which manipulates the 'filename' and creates an accessor called 'original_filename'. We receive the already manipulated `original_filename` in the params.

### Bump to version 2.19.4