### PR TITLE
Suffix duplicate file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.19.5] - 2023-05-19
+### Changed
+
+- Append a suffix to file upload names if they are duplicates
+
 ## [2.19.4] - 2023-05-18
 ### Changed
 

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -72,12 +72,12 @@ module MetadataPresenter
       @page_answers.page.upload_components.each do |component|
         answer = user_data[component.id]
 
-        if answer.presence
-          filename = answer.nil? ? "" : answer["original_filename"].delete('>"[]{}*?:|]/<')
-          extname = File.extname(filename)
-          basename = File.basename(filename, extname)
-          filename_regex = Regexp.new("^#{Regexp.quote(basename)}(?>-\((\d)\))?.#{Regexp.quote(extname)}")
+        original_filename = answer.nil? ? @page_answers.send(component.id)["original_filename"] : answer["original_filename"]
 
+        if original_filename.presence
+          extname = File.extname(original_filename)
+          basename = File.basename(original_filename, extname)
+          filename_regex = /^#{Regexp.quote(basename)}(?>-\((\d)\))?#{Regexp.quote(extname)}/
           previous_matching_uploads = user_data.select { |_k, v| v.instance_of?(Hash) && v['original_filename'] =~ filename_regex }
           @page_answers.count = previous_matching_uploads.count
         end

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -72,13 +72,13 @@ module MetadataPresenter
       @page_answers.page.upload_components.each do |component|
         answer = user_data[component.id]
 
-        previous_matching_uploads = user_data.select { |k, v| v.class == Hash && v["original_filename"] == @page_answers.send(component.id)["original_filename"]}
+        previous_matching_uploads = user_data.select { |_k, v| v.instance_of?(Hash) && v['original_filename'] == @page_answers.send(component.id)['original_filename'] }
         @page_answers.count = previous_matching_uploads.count
         @page_answers.uploaded_files.push(uploaded_file(answer, component))
       end
     end
 
-    def uploaded_file(answer, component, count = nil)
+    def uploaded_file(answer, component)
       if answer.present?
         @page_answers.answers[component.id] = answer
         MetadataPresenter::UploadedFile.new(

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -76,7 +76,7 @@ module MetadataPresenter
           @page_answers.uploaded_files.push(uploaded_file(answer, component))
         else
           # file name already uploaded
-          @page_answers.send(component.id)["original_filename"] = append_file_suffix(@page_answers.send(component.id)["original_filename"], previous_matching_uploads.count)
+          answer["original_filename"] = append_file_suffix(answer["original_filename"], previous_matching_uploads.count)
           @page_answers.uploaded_files.push(uploaded_file(answer, component))
         end
       end

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -73,12 +73,8 @@ module MetadataPresenter
         answer = user_data[component.id]
 
         previous_matching_uploads = user_data.select { |k, v| v.class == Hash && v["original_filename"] == @page_answers.send(component.id)["original_filename"]}
-        if(previous_matching_uploads == {})
-          @page_answers.uploaded_files.push(uploaded_file(answer, component))
-        else
-          # file name already uploaded
-          @page_answers.uploaded_files.push(uploaded_file(answer, component, previous_matching_uploads.count))
-        end
+        @page_answers.count = previous_matching_uploads.count
+        @page_answers.uploaded_files.push(uploaded_file(answer, component))
       end
     end
 
@@ -90,15 +86,6 @@ module MetadataPresenter
           component:
         )
       else
-        if (count.presence)
-          FileUploader.new(
-            session:,
-            page_answers: @page_answers,
-            component:,
-            adapter: upload_adapter,
-            count:
-          ).upload
-        end
         FileUploader.new(
           session:,
           page_answers: @page_answers,

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -73,10 +73,9 @@ module MetadataPresenter
         answer = user_data[component.id]
 
         if answer.presence
-          byebug
-          filename = answer.nil? ? path : path.delete('>"[]{}*?:|]/<')
-          extname = File.extname(answer)
-          basename = File.basename(answer, extname)
+          filename = answer.nil? ? "" : answer["original_filename"].delete('>"[]{}*?:|]/<')
+          extname = File.extname(filename)
+          basename = File.basename(filename, extname)
           filename_regex = Regexp.new("^#{Regexp.quote(basename)}(?>-\((\d)\))?.#{Regexp.quote(extname)}")
 
           previous_matching_uploads = user_data.select { |_k, v| v.instance_of?(Hash) && v['original_filename'] =~ filename_regex }

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -72,18 +72,22 @@ module MetadataPresenter
       @page_answers.page.upload_components.each do |component|
         answer = user_data[component.id]
 
-        original_filename = answer.nil? ? @page_answers.send(component.id)["original_filename"] : answer["original_filename"]
+        original_filename = answer.nil? ? @page_answers.send(component.id)['original_filename'] : answer['original_filename']
 
         if original_filename.presence
-          extname = File.extname(original_filename)
-          basename = File.basename(original_filename, extname)
-          filename_regex = /^#{Regexp.quote(basename)}(?>-\((\d)\))?#{Regexp.quote(extname)}/
-          previous_matching_uploads = user_data.select { |_k, v| v.instance_of?(Hash) && v['original_filename'] =~ filename_regex }
-          @page_answers.count = previous_matching_uploads.count
+          @page_answers.count = update_count_matching_filenames(original_filename, user_data)
         end
 
         @page_answers.uploaded_files.push(uploaded_file(answer, component))
       end
+    end
+
+    def update_count_matching_filenames(original_filename, user_data)
+      extname = File.extname(original_filename)
+      basename = File.basename(original_filename, extname)
+      filename_regex = /^#{Regexp.quote(basename)}(?>-\((\d)\))?#{Regexp.quote(extname)}/
+
+      user_data.select { |_k, v| v.instance_of?(Hash) && v['original_filename'] =~ filename_regex }.count
     end
 
     def uploaded_file(answer, component)

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -72,8 +72,15 @@ module MetadataPresenter
       @page_answers.page.upload_components.each do |component|
         answer = user_data[component.id]
 
-        previous_matching_uploads = user_data.select { |_k, v| v.instance_of?(Hash) && v['original_filename'] == @page_answers.send(component.id)['original_filename'] }
-        @page_answers.count = previous_matching_uploads.count
+        if answer.presence
+          extname = File.extname(answer)
+          basename = File.basename(answer, extname)
+          filename_regex = Regexp.new("^#{Regexp.quote(basename)}(?>-\((\d)\))?.#{Regexp.quote(extname)}")
+
+          previous_matching_uploads = user_data.select { |_k, v| v.instance_of?(Hash) && v['original_filename'] =~ filename_regex }
+          @page_answers.count = previous_matching_uploads.count
+        end
+
         @page_answers.uploaded_files.push(uploaded_file(answer, component))
       end
     end

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -71,25 +71,18 @@ module MetadataPresenter
       user_data = load_user_data
       @page_answers.page.upload_components.each do |component|
         answer = user_data[component.id]
-        previous_matching_uploads = user_data.select { |key, val| val == @page_answers.send(component.id)["original_filename"] }
+
+        previous_matching_uploads = user_data.select { |k, v| v.class == Hash && v["original_filename"] == @page_answers.send(component.id)["original_filename"]}
         if(previous_matching_uploads == {})
           @page_answers.uploaded_files.push(uploaded_file(answer, component))
         else
           # file name already uploaded
-          answer["original_filename"] = append_file_suffix(answer["original_filename"], previous_matching_uploads.count)
-          @page_answers.uploaded_files.push(uploaded_file(answer, component))
+          @page_answers.uploaded_files.push(uploaded_file(answer, component, previous_matching_uploads.count))
         end
       end
     end
 
-    def append_file_suffix(filename, count)
-      extname = File.extname(filename)
-      basename = File.basename(filename, extname)
-
-      "#{basename}-(#{count})#{extname}"
-    end
-
-    def uploaded_file(answer, component)
+    def uploaded_file(answer, component, count = nil)
       if answer.present?
         @page_answers.answers[component.id] = answer
         MetadataPresenter::UploadedFile.new(
@@ -97,6 +90,15 @@ module MetadataPresenter
           component:
         )
       else
+        if (count.presence)
+          FileUploader.new(
+            session:,
+            page_answers: @page_answers,
+            component:,
+            adapter: upload_adapter,
+            count:
+          ).upload
+        end
         FileUploader.new(
           session:,
           page_answers: @page_answers,

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -73,6 +73,8 @@ module MetadataPresenter
         answer = user_data[component.id]
 
         if answer.presence
+          byebug
+          filename = answer.nil? ? path : path.delete('>"[]{}*?:|]/<')
           extname = File.extname(answer)
           basename = File.basename(answer, extname)
           filename_regex = Regexp.new("^#{Regexp.quote(basename)}(?>-\((\d)\))?.#{Regexp.quote(extname)}")

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -22,6 +22,14 @@ module MetadataPresenter
       end
     end
 
+    def update_count_matching_filenames(original_filename, user_data)
+      extname = File.extname(original_filename)
+      basename = File.basename(original_filename, extname)
+      filename_regex = /^#{Regexp.quote(basename)}(?>-\((\d)\))?#{Regexp.quote(extname)}/
+
+      user_data.select { |_k, v| v.instance_of?(Hash) && v['original_filename'] =~ filename_regex }.count
+    end
+
     private
 
     def page
@@ -80,14 +88,6 @@ module MetadataPresenter
 
         @page_answers.uploaded_files.push(uploaded_file(answer, component))
       end
-    end
-
-    def update_count_matching_filenames(original_filename, user_data)
-      extname = File.extname(original_filename)
-      basename = File.basename(original_filename, extname)
-      filename_regex = /^#{Regexp.quote(basename)}(?>-\((\d)\))?#{Regexp.quote(extname)}/
-
-      user_data.select { |_k, v| v.instance_of?(Hash) && v['original_filename'] =~ filename_regex }.count
     end
 
     def uploaded_file(answer, component)

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -82,7 +82,7 @@ module MetadataPresenter
 
         original_filename = answer.nil? ? @page_answers.send(component.id)['original_filename'] : answer['original_filename']
 
-        if original_filename.presence
+        if original_filename.present?
           @page_answers.count = update_count_matching_filenames(original_filename, user_data)
         end
 

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -71,9 +71,22 @@ module MetadataPresenter
       user_data = load_user_data
       @page_answers.page.upload_components.each do |component|
         answer = user_data[component.id]
-
-        @page_answers.uploaded_files.push(uploaded_file(answer, component))
+        previous_matching_uploads = user_data.select { |key, val| val == @page_answers.send(component.id)["original_filename"] }
+        if(previous_matching_uploads == {})
+          @page_answers.uploaded_files.push(uploaded_file(answer, component))
+        else
+          # file name already uploaded
+          @page_answers.send(component.id)["original_filename"] = append_file_suffix(@page_answers.send(component.id)["original_filename"], previous_matching_uploads.count)
+          @page_answers.uploaded_files.push(uploaded_file(answer, component))
+        end
       end
+    end
+
+    def append_file_suffix(filename, count)
+      extname = File.extname(filename)
+      basename = File.basename(filename, extname)
+
+      "#{basename}-(#{count})#{extname}"
     end
 
     def uploaded_file(answer, component)

--- a/app/models/metadata_presenter/file_uploader.rb
+++ b/app/models/metadata_presenter/file_uploader.rb
@@ -1,19 +1,20 @@
 module MetadataPresenter
   class FileUploader
     include ActiveModel::Model
-    attr_accessor :session, :page_answers, :component, :adapter
+    attr_accessor :session, :page_answers, :component, :adapter, :count
 
     def upload
-      UploadedFile.new(file: upload_file, component:)
+      UploadedFile.new(file: upload_file(count), component:)
     end
 
-    def upload_file
+    def upload_file(count)
       return {} if file_details.blank?
 
       adapter.new(
         session:,
         file_details:,
-        allowed_file_types: component.validation['accept']
+        allowed_file_types: component.validation['accept'],
+        count:
       ).call
     end
 

--- a/app/models/metadata_presenter/file_uploader.rb
+++ b/app/models/metadata_presenter/file_uploader.rb
@@ -13,7 +13,7 @@ module MetadataPresenter
       adapter.new(
         session:,
         file_details:,
-        allowed_file_types: component.validation['accept'],
+        allowed_file_types: component.validation['accept']
       ).call
     end
 

--- a/app/models/metadata_presenter/file_uploader.rb
+++ b/app/models/metadata_presenter/file_uploader.rb
@@ -1,20 +1,19 @@
 module MetadataPresenter
   class FileUploader
     include ActiveModel::Model
-    attr_accessor :session, :page_answers, :component, :adapter, :count
+    attr_accessor :session, :page_answers, :component, :adapter
 
     def upload
-      UploadedFile.new(file: upload_file(count), component:)
+      UploadedFile.new(file: upload_file, component:)
     end
 
-    def upload_file(count)
+    def upload_file
       return {} if file_details.blank?
 
       adapter.new(
         session:,
         file_details:,
         allowed_file_types: component.validation['accept'],
-        count:
       ).call
     end
 

--- a/app/models/metadata_presenter/offline_upload_adapter.rb
+++ b/app/models/metadata_presenter/offline_upload_adapter.rb
@@ -1,7 +1,7 @@
 module MetadataPresenter
   class OfflineUploadAdapter
     include ActiveModel::Model
-    attr_accessor :session, :file_details, :allowed_file_types
+    attr_accessor :session, :file_details, :allowed_file_types, :count
 
     def call
       {}

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -76,7 +76,7 @@ module MetadataPresenter
 
       filename = sanitize(path).gsub(/&gt;/, '').gsub(/&lt;/, '').delete('>"[]{}*?:|]/<').delete('\\')
 
-      if count.presence && count.positive?
+      if count.present? && count.positive?
         extname = File.extname(filename)
         basename = File.basename(filename, extname)
 

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -50,11 +50,11 @@ module MetadataPresenter
           sanitized_filename = "#{basename}-(#{count})#{extname}"
         end
 
-        if filename.presence
-          filename = sanitized_filename.gsub(/["\[\]\/\\{}*?:|]/, '')
+        if sanitized_filename.presence
+          sanitized_filename = sanitized_filename.gsub(/["\[\]\/\\{}*?:|]/, '')
         end
 
-        file_details.merge('original_filename' => filename)
+        file_details.merge('original_filename' => sanitized_filename)
       else
         {
           'original_filename' => sanitize(file_details.original_filename),

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -49,7 +49,11 @@ module MetadataPresenter
     
           sanitized_filename = "#{basename}-(#{count})#{extname}"
         end
-        filename = sanitized_filename.gsub(/["\[\]\/\\{}*?:|]/, '')
+
+        if filename.presence
+          filename = sanitized_filename.gsub(/["\[\]\/\\{}*?:|]/, '')
+        end
+
         file_details.merge('original_filename' => filename)
       else
         {

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -72,22 +72,18 @@ module MetadataPresenter
     private
 
     def filename(path)
-<<<<<<< HEAD
-      filename = path.nil? ? path : path.delete('>"[]{}*?:|]/<')
+      return sanitize(path) if path.nil?
+
+      filename = sanitize(path).gsub(/&gt;/, '').gsub(/&lt;/, '').delete('>"[]{}*?:|]/<').delete('\\')
 
       if count.presence && count.positive?
-        extname = File.extname(path)
-        basename = File.basename(path, extname)
+        extname = File.extname(filename)
+        basename = File.basename(filename, extname)
 
         filename = "#{basename}-(#{count})#{extname}"
       end
 
       filename
-=======
-      return sanitize(path) if path.nil?
-
-      sanitize(path).gsub(/&gt;/, '').gsub(/&lt;/, '').delete('>"[]{}*?:|]/<').delete('\\')
->>>>>>> 089c325daf74dfdbe5b22f25368a2dd4d9785571
     end
   end
 end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.19.4'.freeze
+  VERSION = '2.19.5'.freeze
 end

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-govuk'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'simplecov-console'
-  spec.add_development_dependency 'site_prism'
+  spec.add_development_dependency 'site_prism', '4.0'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'yard'
 end

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -16,4 +16,20 @@ RSpec.describe 'Answers Controller Requests', type: :request do
       expect(response).to redirect_to('/save')
     end
   end
+
+  describe 'count duplicate filenames' do
+    let(:user_data) do
+      {
+        'dog_picture_upload-1' => 'peanut.jpg',
+        'dog_picture_upload-2' => 'peanut.jpg',
+        'dog_picture_upload-3' => 'notpeanut.jpg'
+      }
+
+      it 'counts matches' do
+        expect(controller.update_count_matching_filenames(user_data, 'peanut.jpg')).to eq(2)
+        expect(controller.update_count_matching_filenames(user_data, 'peanut2.jpg')).to eq(0)
+        expect(controller.update_count_matching_filenames(user_data, 'peanut-(1).jpg')).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -18,18 +18,20 @@ RSpec.describe 'Answers Controller Requests', type: :request do
   end
 
   describe 'count duplicate filenames' do
+    let(:controller) { MetadataPresenter::AnswersController.new }
     let(:user_data) do
       {
-        'dog_picture_upload-1' => 'peanut.jpg',
-        'dog_picture_upload-2' => 'peanut.jpg',
-        'dog_picture_upload-3' => 'notpeanut.jpg'
+        'dog_picture_upload-1' => { 'original_filename' => 'peanut.jpg' },
+        'dog_picture_upload-2' => { 'original_filename' => 'peanut.jpg' },
+        'dog_picture_upload-3' => { 'original_filename' => 'notpeanut.jpg' },
+        'another_type_of_question' => 'peanut.jpg'
       }
+    end
 
-      it 'counts matches' do
-        expect(controller.update_count_matching_filenames(user_data, 'peanut.jpg')).to eq(2)
-        expect(controller.update_count_matching_filenames(user_data, 'peanut2.jpg')).to eq(0)
-        expect(controller.update_count_matching_filenames(user_data, 'peanut-(1).jpg')).to eq(0)
-      end
+    it 'counts matches' do
+      expect(controller.update_count_matching_filenames('peanut.jpg', user_data)).to eq(2)
+      expect(controller.update_count_matching_filenames('peanut2.jpg', user_data)).to eq(0)
+      expect(controller.update_count_matching_filenames('peanut-(1).jpg', user_data)).to eq(0)
     end
   end
 end

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -16,25 +16,4 @@ RSpec.describe 'Answers Controller Requests', type: :request do
       expect(response).to redirect_to('/save')
     end
   end
-
-  describe 'checking for duplicate uploads' do
-    let(:user_data) do
-      {
-        "dog-picture_upload_1"=>{"original_filename" => "peanut.jpg"}
-      }
-    end
-
-    let(:answer) do
-      {
-        "dog-picture_upload_2"=>{"original_filename" => "peanut.jpg"}
-      }
-    end
-
-    it 'adds the right count to the page answers' do
-
-      allow_any_instance_of(MetadataPresenter::AnswersController).to receive(:load_user_data).and_return(user_data)
-      expect_any_instance_of(MetadataPresenter::PageAnswers).to receive(:count).with(1)
-      post '/'
-    end
-  end
 end

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -16,4 +16,25 @@ RSpec.describe 'Answers Controller Requests', type: :request do
       expect(response).to redirect_to('/save')
     end
   end
+
+  describe 'checking for duplicate uploads' do
+    let(:user_data) do
+      {
+        "dog-picture_upload_1"=>{"original_filename" => "peanut.jpg"}
+      }
+    end
+
+    let(:answer) do
+      {
+        "dog-picture_upload_2"=>{"original_filename" => "peanut.jpg"}
+      }
+    end
+
+    it 'adds the right count to the page answers' do
+
+      allow_any_instance_of(MetadataPresenter::AnswersController).to receive(:load_user_data).and_return(user_data)
+      expect_any_instance_of(MetadataPresenter::PageAnswers).to receive(:count).with(1)
+      post '/'
+    end
+  end
 end

--- a/spec/models/page_answers_spec.rb
+++ b/spec/models/page_answers_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe MetadataPresenter::PageAnswers do
                 page_answers.send('dog-picture_upload_1')['original_filename']
               ).to eq("alert('upload')-(1).png")
             end
-  
+
             it 'appends a suffix based on previous matches' do
               subject.count = 2
               expect(

--- a/spec/models/page_answers_spec.rb
+++ b/spec/models/page_answers_spec.rb
@@ -236,6 +236,20 @@ RSpec.describe MetadataPresenter::PageAnswers do
               ).to eq("alert('upload').png")
             end
 
+            it 'appends a suffix when there are previous uploads of the same filename' do
+              subject.count = 1
+              expect(
+                page_answers.send('dog-picture_upload_1')['original_filename']
+              ).to eq("alert('upload')-(1).png")
+            end
+  
+            it 'appends a suffix based on previous matches' do
+              subject.count = 2
+              expect(
+                page_answers.send('dog-picture_upload_1')['original_filename']
+              ).to eq("alert('upload')-(2).png")
+            end
+
             context 'when file contains forbidden characters' do
               let(:upload_file) do
                 {


### PR DESCRIPTION
Adds a suffix to filename on save if it matches filename of a previous answer to ensure it is saved and included in attachments

<img width="1133" alt="image" src="https://github.com/ministryofjustice/fb-metadata-presenter/assets/7647632/08744f7d-66dd-447c-8d5b-75feaa2d3e63">
