### PR TITLE
Change service_slug method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.20.0] - 2023-05-19
+### Changed
+
+- Change `service_name`method to allow for backwards compatibility
+- Add `service_slug_config` method to check for `SERVICE_SLUG` config in Runner and Editor
+
 ## [2.19.5] - 2023-05-19
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The `autocomplete_items` takes the components on a page and retrieves any items 
 
 `save_and_return_enabled?` method checks whether save and return is enabled in the Runner or Editor app. In the Runner save and return is enabled when the `ENV['SAVE_AND_RETURN']` environment variable is present. In the Editor, save and return enabled can be ascertained by checking the `ServiceConfiguration` table.
 
+`service_slug_config` method checks whether the user has configured their own service URL. In the Editor this will be a `SERVICE_SLUG` row in the `ServiceConfiguration` table. In the Runner, it will be the `ENV['SERVICE_SLUG']` config.
+If it does not exist, we use the current method of parameterizing the `service_name`.
+
 ## Generate documentation
 
 Run `rake doc` and open the doc/index.html

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -38,6 +38,8 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
   end
 
   def service_slug
+    return service_slug_config if service_slug_config.present?
+
     service_name.gsub(/['’]/, '').parameterize
   end
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.19.5'.freeze
+  VERSION = '2.20.0'.freeze
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -54,3 +54,5 @@ class ApplicationController < ActionController::Base
   def editor_preview?; end
   helper_method :editor_preview?
 end
+
+def service_slug_config; end


### PR DESCRIPTION
### Add service_slug_config method
This method will be added to the Editor and Runner to check for the `SERVICE_SLUG` service config.
If it is present, then we can use it, if not we continue using the current method, ie: parameterise service_name

Change the existing `service_slug` method to check whether a `SERVICE_SLUG` config exists in either the Editor or the Runner.

### Bump to presenter 2.20.0