### PR TITLE
Update confirmation page template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [2.20.1] - 2023-05-22
+### Fixed
+
+- Update confirmation page template, moving optional content components into the
+    width container.
+
 ## [2.20.0] - 2023-05-19
 ### Changed
 

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -37,19 +37,19 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render 'metadata_presenter/attribute/body' %>
+
+      <%= render partial: 'metadata_presenter/component/components',
+                 locals: {
+                 f: nil,
+                 components: @page.components,
+                 tag: nil,
+                 classes: nil,
+                 input_components: @page.supported_input_components,
+                 content_components: @page.supported_content_components
+                 } %>
+
     </div>
   </div>
-
-  <%= render partial: 'metadata_presenter/component/components',
-             locals: {
-             f: nil,
-             components: @page.components,
-             tag: nil,
-             classes: nil,
-             input_components: @page.supported_input_components,
-             content_components: @page.supported_content_components
-             } %>
-
   <% if payment_link_enabled? %>
     <a href="<%= payment_link_url %>" class="govuk-button" data-module="govuk-button" data-component="pay-button"><%= t('presenter.confirmation.continue_to_pay_button') %></a>
   <% end %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '2.20.0'.freeze
+  VERSION = '2.20.1'.freeze
 end


### PR DESCRIPTION
Moves the additional content areas on the confirmation page inside the width container.

Before:
![image](https://github.com/ministryofjustice/fb-metadata-presenter/assets/595564/6fe10b36-327f-492f-ad74-462ec3a35f5b)

After:
![image](https://github.com/ministryofjustice/fb-metadata-presenter/assets/595564/8de2821d-56cd-42aa-b88d-94b95484e81b)
