### PR TITLE
Add submission complete page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.1] - 2023-05-24
+### Added 
+ - Add in submission complete template, to display on back navigation from
+     confirmation page
+
 ## [3.0] - 2023-05-22
 ### Changed
 

--- a/app/controllers/metadata_presenter/pages_controller.rb
+++ b/app/controllers/metadata_presenter/pages_controller.rb
@@ -8,6 +8,11 @@ module MetadataPresenter
         load_autocomplete_items
 
         @page_answers = PageAnswers.new(@page, @user_data)
+
+        if(@page.template == 'metadata_presenter/page/checkanswers')
+          response.headers["Cache-Control"] = "private, no-store"
+        end
+
         render template: @page.template
       else
         not_found

--- a/app/controllers/metadata_presenter/pages_controller.rb
+++ b/app/controllers/metadata_presenter/pages_controller.rb
@@ -1,5 +1,8 @@
 module MetadataPresenter
+
   class PagesController < EngineController
+    before_action :set_caching_header
+
     def show
       @user_data = load_user_data # method signature
       @page ||= service.find_page_by_url(request.env['PATH_INFO'])
@@ -8,10 +11,6 @@ module MetadataPresenter
         load_autocomplete_items
 
         @page_answers = PageAnswers.new(@page, @user_data)
-
-        if(@page.template == 'metadata_presenter/page/checkanswers')
-          response.headers["Cache-Control"] = "private, no-store"
-        end
 
         render template: @page.template
       else
@@ -30,6 +29,12 @@ module MetadataPresenter
 
     def answered_pages
       TraversedPages.new(service, load_user_data, @page).all
+    end
+
+    private
+
+    def set_caching_header
+      response.headers["Cache-Control"] = "no-store"
     end
   end
 end

--- a/app/controllers/metadata_presenter/pages_controller.rb
+++ b/app/controllers/metadata_presenter/pages_controller.rb
@@ -1,5 +1,4 @@
 module MetadataPresenter
-
   class PagesController < EngineController
     before_action :set_caching_header
 
@@ -34,7 +33,7 @@ module MetadataPresenter
     private
 
     def set_caching_header
-      response.headers["Cache-Control"] = "no-store"
+      response.headers['Cache-Control'] = 'no-store'
     end
   end
 end

--- a/app/controllers/metadata_presenter/session_controller.rb
+++ b/app/controllers/metadata_presenter/session_controller.rb
@@ -1,5 +1,7 @@
 module MetadataPresenter
   class SessionController < EngineController
     def expired; end
+
+    def complete; end
   end
 end

--- a/app/views/metadata_presenter/session/complete.html.erb
+++ b/app/views/metadata_presenter/session/complete.html.erb
@@ -1,10 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Submission completed</h1>
+    <h1 class="govuk-heading-l"><%= t('presenter.session_complete.title') %></h1>
     <div class="maintenance-content">
-      <p>This form has already been submitted.<p>  
-      <p>To protect your personal information, we have reset the form and cleared your answers.</p>
-      <p>If you wish to you can <%= link_to 'Start a new form', root_url %></p>
+      <%= to_html t('presenter.session_complete.content') %>
+      <p><%= link_to t('presenter.session_complete.restart_link'), root_url %></p>
     </div>
   </div>
 </div>

--- a/app/views/metadata_presenter/session/complete.html.erb
+++ b/app/views/metadata_presenter/session/complete.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Submission completed</h1>
+    <div class="maintenance-content">
+      <p>This form has already been submitted.<p>  
+      <p>To protect your personal information, we have reset the form and cleared your answers.</p>
+      <p>If you wish to you can <%= link_to 'Start a new form', root_url %></p>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,10 @@ en:
       title: Your form has been reset
       content: "To protect your personal information, we have reset the form and cleared your answers.\r\n\r\nThis is because you were inactive for 30 minutes."
       restart_link: Start again
+    session_complete:
+      title: Submission complete
+      content: "This form has already been submitted.\r\n\r\nTo protect your personal information, we have reset the form and cleared your answers."
+      restart_link: Start again
     confirmation:
       reference_number: 'Your reference number is:'
       payment_enabled: You still need to pay

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ MetadataPresenter::Engine.routes.draw do
   get '/reserved/file/:component_id', to: 'file#destroy', as: :remove_file
 
   get 'session/expired', to: 'session#expired'
+  get 'session/complete', to: 'session#complete'
 
   get 'save', to: 'save_and_return#show'
   post 'saved_forms', to: 'save_and_return#create'

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0'.freeze
+  VERSION = '3.0.1'.freeze
 end


### PR DESCRIPTION
Adds a template for the submission complete page, which will be shown to the user if they try and use the back button after the confirmtaion page.

We also add a route for it.