### PR TITLE
Update service slug method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.2] - 2023-05-25
+### Changed
+ - Implementation of retrieving the service slug has changed, we now call the `service_slug_config`
+    method in the application controller.
+
 ## [3.0.1] - 2023-05-24
-### Added 
+### Added
  - Add in submission complete template, to display on back navigation from
      confirmation page
 

--- a/app/controllers/metadata_presenter/save_and_return_controller.rb
+++ b/app/controllers/metadata_presenter/save_and_return_controller.rb
@@ -42,6 +42,7 @@ module MetadataPresenter
       @saved_form.secret_question = params['saved_form']['secret_question']
       @saved_form.populate_service_values(service)
       @saved_form.populate_session_values(session)
+      @saved_form.service_slug = service_slug
       if @saved_form.valid?
         # put in session until we have confirmed email address
         @saved_form.secret_question = @saved_form.secret_question_text
@@ -230,6 +231,12 @@ module MetadataPresenter
 
     def label_text(text)
       "<h2 class='govuk-heading-m'>#{text}</h2>"
+    end
+
+    private
+
+    def service_slug
+      @service_slug ||= service_slug_config
     end
   end
 end

--- a/app/models/metadata_presenter/saved_form.rb
+++ b/app/models/metadata_presenter/saved_form.rb
@@ -21,7 +21,7 @@ module MetadataPresenter
                   :created_at,
                   :updated_at
 
-    validates :secret_question, :secret_answer, :service_slug, :page_slug, :service_version, :user_id, :user_token, presence: { message: 'Enter an answer for "%{attribute}"' }, allow_blank: false
+    validates :secret_question, :secret_answer, :page_slug, :service_version, :user_id, :user_token, presence: { message: 'Enter an answer for "%{attribute}"' }, allow_blank: false
 
     def initialize; end
 
@@ -38,7 +38,6 @@ module MetadataPresenter
     end
 
     def populate_service_values(service)
-      self.service_slug    = service.service_slug
       self.service_version = service.version_id
     end
 

--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -38,8 +38,6 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
   end
 
   def service_slug
-    return service_slug_config if service_slug_config.present?
-
     service_name.gsub(/['’]/, '').parameterize
   end
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0.1'.freeze
+  VERSION = '3.0.2'.freeze
 end

--- a/spec/controllers/save_and_return_controller_spec.rb
+++ b/spec/controllers/save_and_return_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Save and Return Controller Requests', type: :request do
 
         params = { email: 'valid@example.com', secret_answer: 'secret stuff', saved_form: { page_slug: '/a-page', secret_question: 1 } }
 
-        service = OpenStruct.new(service_slug: 'service_slug', version_id: '4567')
+        service = OpenStruct.new(version_id: '4567')
         allow_any_instance_of(MetadataPresenter::SaveAndReturnController).to receive(:service).and_return(service)
 
         post('/saved_forms', params:)
@@ -25,7 +25,7 @@ RSpec.describe 'Save and Return Controller Requests', type: :request do
         expect(session[:saved_form].page_slug).to eq(params[:saved_form][:page_slug])
         expect(session[:saved_form].secret_answer).to eq(params[:secret_answer])
         expect(session[:saved_form].secret_question).to eq(controller.text_for(params[:saved_form][:secret_question]))
-        expect(session[:saved_form].service_slug).to eq(service.service_slug)
+        expect(session[:saved_form].service_slug).to eq(params[:service_slug])
         expect(session[:saved_form].service_version).to eq(service.version_id)
         expect(session[:saved_form].user_id).to eq(session[:user_id])
         expect(session[:saved_form].user_token).to eq(session[:user_token])

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -53,6 +53,8 @@ class ApplicationController < ActionController::Base
 
   def editor_preview?; end
   helper_method :editor_preview?
-end
 
-def service_slug_config; end
+  def service_slug_config
+    service.service_slug
+  end
+end

--- a/spec/models/saved_form_spec.rb
+++ b/spec/models/saved_form_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe MetadataPresenter::SavedForm, type: :model do
   describe 'populating necessary attributes' do
     let(:params) { { 'email' => 'email@email.com', 'saved_form' => { 'page_slug' => 'slug', 'secret_question' => 'some text' }, 'secret_answer' => 'answer' } }
     let(:session) { { user_id: 'idval', user_token: 'token', user_data: { 'field1' => 'answer' } } }
-    let(:service) { OpenStruct.new(service_slug: 'service_slug', version_id: '123') }
+    let(:service) { OpenStruct.new(version_id: '123') }
 
     it 'should populate from params' do
       subject.populate_param_values(params)
@@ -29,7 +29,6 @@ RSpec.describe MetadataPresenter::SavedForm, type: :model do
       subject.populate_param_values(params)
       subject.populate_service_values(service)
 
-      expect(subject.service_slug).to eq(service.service_slug)
       expect(subject.service_version).to eq(service.version_id)
 
       expect(subject.valid?).to eq(false)


### PR DESCRIPTION
The `service_slug` method could not access the `service_slug_config` method in the application controller - generally we should not be accessing the controller from within the model.
Therefore, changed the implementation to call the `service_slug_config` method rather than accessing the service slug via the model.

In the Editor and the Runner we will use the respective service config or env variable `SERVICE_SLUG` value otherwise we will default to `service.service_slug`.