### PR TITLE
Fix grid disconnection bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.3] - 2023-06-09
+### Changed
+ - Updated grid traversal to ensure traversal of all routes to fix bugs where
+     pages were appearing disconnected when they shouldn't be.
+
 ## [3.0.2] - 2023-05-25
 ### Changed
  - Implementation of retrieving the service slug has changed, we now call the `service_slug_config`

--- a/app/models/metadata_presenter/grid.rb
+++ b/app/models/metadata_presenter/grid.rb
@@ -121,7 +121,6 @@ module MetadataPresenter
     end
 
     def traverse_all_routes
-      Rails.logger.info('traversing all routes')
       # Always traverse the route from the start_from uuid. Defaulting to the
       # start page of the form unless otherwise specified.
       # Get all the potential routes from any branching points that exist.
@@ -454,7 +453,6 @@ module MetadataPresenter
     # Not easy to calculate exactly, aiming for a number that is bigger than
     # total possible routes but not too much bigger.
     def total_potential_routes
-      # @total_potential_routes = service.branches.sum { |branch| branch.conditionals.size + 1 } + 1
       total_conditionals = service.branches.sum { |branch| branch.conditionals.size + 1 }
       @total_potential_routes ||= total_conditionals * total_conditionals
     end

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.0.3'.freeze
 end


### PR DESCRIPTION
This PR hopefully fixes (🤞) the issue where pages that are fully connnected according to the metadata appear in the unconnected section of the flow view.

Pages apperar in the unconnected section when they are not found within `traverse_all_routes` method.

So the issue is that pages that should be traversed, weren't being traversed.

#### Ensure traversal of all routes
We were doing the following:

`traversed_routes |= route.routes`

Which only adds in new routes if traversed routes is empty, which didn't seem right - we should traverse every route we find.

#### Increase total_potential_routes
Logs indicated that we were hitting the limit of traversing routes.  A simple sum of conditionals did not seem high enough to account for potential of nested branching routes through the form.

The increased route traversal was meaning that we were always hitting the recursion break as routes can loop back to earlier pages in the form.

So a catch was added to aonly add routes for traversal if we haven't already "found" the first page uuid of the route.

This resolves the issue in the forms with known issues, and our largest form (COP) is still rendering correctly.


