### PR TITLE
Replace inline event handlers with listeners for CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.8] - 2023-06-27
+### Changed
+ - Replace inline event handlers with event listeners to meet CSP requirements
+
 ## [3.0.7] - 2023-06-26
 ### Changed
  - Update Editable components to use custom element for simpler progressive

--- a/app/views/metadata_presenter/analytics/_cookie_banner_confirmation.html.erb
+++ b/app/views/metadata_presenter/analytics/_cookie_banner_confirmation.html.erb
@@ -1,6 +1,6 @@
 
 <div class="govuk-cookie-banner" id="govuk-cookie-banner" data-nosnippet role="region" aria-label="<%= t('presenter.analytics.heading', service_name: service.service_name) %>" data-module="cookie-banner">
-  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message-accepted" role="alert" style="display: none;" data-cookie-banner-element="message-accepted">
+  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message-accepted" role="alert" data-cookie-banner-element="message-accepted" hidden>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-cookie-banner__content">
@@ -13,7 +13,7 @@
     <%= render partial: 'metadata_presenter/analytics/hide_cookie_banner' %>
   </div>
 
-  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message-rejected" role="alert" style="display: none;" data-cookie-banner-element="message-rejected">
+  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message-rejected" role="alert" data-cookie-banner-element="message-rejected" hidden>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-cookie-banner__content">

--- a/app/views/metadata_presenter/analytics/_cookie_banner_confirmation.html.erb
+++ b/app/views/metadata_presenter/analytics/_cookie_banner_confirmation.html.erb
@@ -1,6 +1,6 @@
 
-<div class="govuk-cookie-banner" id="govuk-cookie-banner" data-nosnippet role="region" aria-label="<%= t('presenter.analytics.heading', service_name: service.service_name) %>">
-  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message-accepted" role="alert" style="display: none;">
+<div class="govuk-cookie-banner" id="govuk-cookie-banner" data-nosnippet role="region" aria-label="<%= t('presenter.analytics.heading', service_name: service.service_name) %>" data-module="cookie-banner">
+  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message-accepted" role="alert" style="display: none;" data-cookie-banner-element="message-accepted">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-cookie-banner__content">
@@ -10,15 +10,10 @@
         </div>
       </div>
     </div>
-
-    <div class="govuk-button-group">
-      <button class="govuk-button" data-module="govuk-button" onclick="analytics.hideCookieBanner()">
-        <%= t('presenter.analytics.hide') %>
-      </button>
-    </div>
+    <%= render partial: 'metadata_presenter/analytics/hide_cookie_banner' %>
   </div>
 
-  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message-rejected" role="alert" style="display: none;">
+  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message-rejected" role="alert" style="display: none;" data-cookie-banner-element="message-rejected">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-cookie-banner__content">
@@ -28,11 +23,6 @@
         </div>
       </div>
     </div>
-
-    <div class="govuk-button-group">
-      <button class="govuk-button" data-module="govuk-button" onclick="analytics.hideCookieBanner()">
-        <%= t('presenter.analytics.hide') %>
-      </button>
-    </div>
+    <%= render partial: 'metadata_presenter/analytics/hide_cookie_banner' %>
   </div>
 </div>

--- a/app/views/metadata_presenter/analytics/_cookie_banner_request.html.erb
+++ b/app/views/metadata_presenter/analytics/_cookie_banner_request.html.erb
@@ -1,5 +1,5 @@
-<div class="govuk-cookie-banner" id="govuk-cookie-banner" data-nosnippet role="region" aria-label="<%= t('presenter.analytics.heading', service_name: service.service_name) %>">
-  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message">
+<div class="govuk-cookie-banner" id="govuk-cookie-banner" data-nosnippet role="region" aria-label="<%= t('presenter.analytics.heading', service_name: service.service_name) %>" data-module="cookie-banner">
+  <div class="govuk-cookie-banner__message govuk-width-container" id="govuk-cookie-banner-message" data-cookie-banner-element="message">
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -14,11 +14,11 @@
       </div>
     </div>
 
-    <div class="govuk-button-group">
-      <button type="button" class="govuk-button" data-module="govuk-button" onclick='analytics.accept("<%= analytics_cookie_name %>")'>
+    <div class="govuk-button-group" >
+      <button id="cookies-accept" type="button" class="govuk-button" data-module="govuk-button" data-cookie-banner-element="accept-button" data-cookie-name="<%= analytics_cookie_name %>">
         <%= t('presenter.analytics.accept') %>
       </button>
-      <button type="button" class="govuk-button" data-module="govuk-button" onclick='analytics.reject("<%= analytics_cookie_name %>")'>
+      <button id="cookies-reject" type="button" class="govuk-button" data-module="govuk-button" data-cookie-banner-element="reject-button" data-cookie-name="<%= analytics_cookie_name %>">
         <%= t('presenter.analytics.reject') %>
       </button>
       <a class="govuk-link" href="/cookies"><%= t('presenter.analytics.view_cookies') %></a>

--- a/app/views/metadata_presenter/analytics/_hide_cookie_banner.html.erb
+++ b/app/views/metadata_presenter/analytics/_hide_cookie_banner.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-button-group">
+  <button id="hide-cookie-banner" class="govuk-button" data-module="govuk-button" data-cookie-banner-element="hide-button">
+    <%= t('presenter.analytics.hide') %>
+  </button>
+</div>
+

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0.7'.freeze
+  VERSION = '3.0.8'.freeze
 end


### PR DESCRIPTION
The CSP does not allow inline event handlers to be used so we have replaced these with event listeners.

### Bump to version 3.0.8