### PR TITLE
Component default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.7] - 2023-06-26
+### Changed
+ - Update Editable components to use custom element for simpler progressive
+     enhancement and refactoring & improving in the editor.
+
 ## [3.0.6] - 2023-06-22
 ### Added
  - Update Editable Content areas to use a custom element - a more declarative and

--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -31,5 +31,9 @@ module MetadataPresenter
 
       MetadataPresenter::DefaultMetadata["component.#{component_type}"]['items']&.first&.[]('label')
     end
+
+    def default_page_title(type)
+      MetadataPresenter::DefaultMetadata[type.to_s]&.[]('heading')
+    end
   end
 end

--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -20,5 +20,16 @@ module MetadataPresenter
     def default_text(property)
       MetadataPresenter::DefaultText[property]
     end
+
+    def default_title(component_type)
+      MetadataPresenter::DefaultMetadata["component.#{component_type}"]&.[]('label') ||
+        MetadataPresenter::DefaultMetadata["component.#{component_type}"]&.[]('legend')
+    end
+
+    def default_item_title(component_type)
+      return unless %w[checkboxes radios].include?(component_type)
+
+      MetadataPresenter::DefaultMetadata["component.#{component_type}"]['items']&.first&.[]('label')
+    end
   end
 end

--- a/app/helpers/metadata_presenter/default_metadata.rb
+++ b/app/helpers/metadata_presenter/default_metadata.rb
@@ -1,0 +1,7 @@
+module MetadataPresenter
+  class DefaultMetadata
+    def self.[](key)
+      Rails.application.config.default_metadata[key].deep_dup
+    end
+  end
+end

--- a/app/views/metadata_presenter/attribute/_heading.html.erb
+++ b/app/views/metadata_presenter/attribute/_heading.html.erb
@@ -1,5 +1,7 @@
 <h1 class="fb-editable govuk-heading-xl"
     data-fb-content-id="page[heading]"
-    data-fb-content-type="element">
+    data-fb-content-type="element"
+    data-fb-default-value="<%= default_page_title(@page.type) %>">
   <%= @page.heading %>
 </h1>
+

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -14,7 +14,9 @@
          id="<%= component.id %>"
          data-fb-content-type="<%= component.type %>"
          data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
-         data-fb-content-data="<%= component.to_json %>">
+         data-fb-content-data="<%= component.to_json %>"
+         data-fb-default-value="<%= default_title(component.type) %>"
+         data-fb-default-item-value="<%= default_item_title(component.type) %>">
 
          <%= render partial: component, locals: {
            f: f,

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -4,7 +4,8 @@
 
       <h1 class="fb-editable govuk-heading-xl"
           data-fb-content-type="element"
-          data-fb-content-id="page[heading]">
+          data-fb-content-id="page[heading]"
+          data-fb-default-value="<%= default_page_title(@page.type) %>">
         <%= @page.heading %>
       </h1>
 

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -7,7 +7,8 @@
 <% end %>
     <h1 class="fb-editable govuk-panel__title"
         data-fb-content-type="element"
-        data-fb-content-id="page[heading]">
+        data-fb-content-id="page[heading]"
+        data-fb-default-value="<%= default_page_title(@page.type) %>">
       <% if payment_link_enabled? && @page.heading == I18n.t('presenter.confirmation.application_complete') %>
         <p><%= I18n.t('presenter.confirmation.payment_enabled') %></p>
       <% else %>

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -6,7 +6,8 @@
 
       <h1 class="fb-editable govuk-heading-xl"
           data-fb-content-id="page[heading]"
-          data-fb-content-type="element">
+          data-fb-content-type="element"
+          data-fb-default-value="<%= default_page_title(@page.type) %>">
         <%= @page.heading %>
       </h1>
 

--- a/app/views/metadata_presenter/page/exit.html.erb
+++ b/app/views/metadata_presenter/page/exit.html.erb
@@ -6,7 +6,8 @@
 
       <h1 class="fb-editable govuk-heading-xl"
           data-fb-content-id="page[heading]"
-          data-fb-content-type="element">
+          data-fb-content-type="element"
+          data-fb-default-value="<%= default_page_title(@page.type) %>">
         <%= @page.heading %>
       </h1>
 

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -11,7 +11,9 @@
           <div class="fb-editable"
                data-fb-content-type="<%= component._type %>"
                data-fb-content-id="<%= "page[components[#{index}]]" %>"
-               data-fb-content-data="<%= component.to_json %>">
+               data-fb-content-data="<%= component.to_json %>"
+               data-fb-default-value="<%= default_title(component.type) %>"
+               data-fb-default-item-value="<%= default_item_title(component.type) %>">
             <%= render partial: component, locals: {
               component: component,
               f: f,

--- a/app/views/metadata_presenter/page/standalone.html.erb
+++ b/app/views/metadata_presenter/page/standalone.html.erb
@@ -19,7 +19,8 @@
        <% if @page.heading %>
          <h1 class="fb-editable govuk-heading-xl"
              data-fb-content-id="page[heading]"
-             data-fb-content-type="element">
+             data-fb-content-type="element"
+             data-fb-default-value="<%= t("presenter.footer.#{@page.id.gsub!('page.','')}.heading") %>">
            <%= @page.heading %>
          </h1>
        <% end %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0.6'.freeze
+  VERSION = '3.0.7'.freeze
 end


### PR DESCRIPTION
In order to allow the editor app to have different behaviour depending on whether the fields contain a default placeholder (e.g. [optional heading here]) or a default value (e.g. question)

We need to send the default values through to the editor via data attributes.

This PR adds a helper to access the default values from the metadata, and insert it into the components.