### PR TITLE
Revert back to using `|=` in the grid calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.8] - 2023-06-26
+### Changed
+ - Revert back to using `|=` in the grid route traversal calculations.
+    This was the original way we calculated the grid and produces the same result as the`concat` method.
+
 ## [3.0.7] - 2023-06-26
 ### Changed
  - Update Editable components to use custom element for simpler progressive

--- a/app/models/metadata_presenter/grid.rb
+++ b/app/models/metadata_presenter/grid.rb
@@ -150,7 +150,7 @@ module MetadataPresenter
         # this route is looping back, so we don't need to traverse the nested routes.
         route.traverse
         unless traversed_uuids.include?(route.flow_uuids.first)
-          routes_to_traverse.concat(route.routes)
+          routes_to_traverse |= route.routes
         end
         traversed_uuids.concat(route.flow_uuids)
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0.7'.freeze
+  VERSION = '3.0.8'.freeze
 end


### PR DESCRIPTION
This was the original way we calculated the grid route traversals. Changing this back to `|=` produced the same results as the `concat` method, in terms of number of routes traversed and total number of routes calculated.
Therefore, we decided to leave the calculations as it was.

Co-authored-by: Chris Pymm <chris.pymm@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>

### Bump to 3.0.8