### PR TITLE
Add nonces in scripts for CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.10] - 2023-06-30
+### Added
+ - Added nonces to the GA scripts for CSP violations.
+
 ## [3.0.9] - 2023-06-28
 ### Added
  - Added a list of placeholders to the standalone pages, so wee can determine

--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -24,7 +24,7 @@
   </head>
 
   <body class="govuk-template__body">
-    <script>
+    <script nonce=<%= request.content_security_policy_nonce %>>
      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 

--- a/app/views/metadata_presenter/analytics/_ga4.html.erb
+++ b/app/views/metadata_presenter/analytics/_ga4.html.erb
@@ -1,7 +1,7 @@
 <!-- Form Owner Google Analytics 4 -->
 <% if Rails.application.config.respond_to?(:global_ga4) %>
   <%# Global Google Analytics (GA4) should be included before this point so we only need a config setting %>
-  <script>
+  <script nonce=<%= request.content_security_policy_nonce %>>
     gtag('config', '<%= measurement_id %>');
   </script>
 <% end %>

--- a/app/views/metadata_presenter/analytics/_global_analytics.html.erb
+++ b/app/views/metadata_presenter/analytics/_global_analytics.html.erb
@@ -1,6 +1,6 @@
 <!-- Global MoJ Forms site tag (gtag.js) - Google Analytics 4 -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=#{global_measurement_id}"></script>
-<script>
+<script nonce=<%= request.content_security_policy_nonce %>>
   var manual_global_analytics_properties = {
     <%= yield :manual_global_analytics_properties %>
   }

--- a/app/views/metadata_presenter/analytics/_gtm.html.erb
+++ b/app/views/metadata_presenter/analytics/_gtm.html.erb
@@ -1,5 +1,5 @@
 <!-- Google Tag Manager for Form Owner -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+<script nonce=<%= request.content_security_policy_nonce %>>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);

--- a/app/views/metadata_presenter/analytics/_ua.html.erb
+++ b/app/views/metadata_presenter/analytics/_ua.html.erb
@@ -1,5 +1,5 @@
 <!-- Google Universal Analytics for Form Owner -->
-<script>
+<script nonce=<%= request.content_security_policy_nonce %>>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0.9'.freeze
+  VERSION = '3.0.10'.freeze
 end


### PR DESCRIPTION
There are 3 main ways to amend inline script CSP violations:
- Move the scripts to their own JS file
- Hash the script and add the hash to an allowlist
- Add a nonce to the script

We decided to go with the nonce option here since:
- The inline scripts in this PR cannot be moved out easily as they require in page ruby vars. We also want the analytics scripts to run quickly, since inline scripts do not need to be bundled with other code, they are able to run quickly.
- For hashes each character in the script are hashed (including whitespace), this means if a script changes it will need to be rehashed and re-added to the allow list. Making this option difficult to maintain over time.

Further information on nonces can be found on the [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce)