### PR TITLE
Standalone pages notification banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.11] - 2023-07-03
+### Added 
+ - Added notification banners to accessibility and privacy standalone pages.
+
 ## [3.0.10] - 2023-06-30
 ### Added
  - Added nonces to the GA scripts for CSP violations.

--- a/app/views/metadata_presenter/page/standalone.html.erb
+++ b/app/views/metadata_presenter/page/standalone.html.erb
@@ -3,7 +3,11 @@
     <div class="govuk-grid-column-two-thirds">
 
      <% if @page.id == 'page.cookies' %>
-
+        <% if editable? %>
+          <%= govuk_notification_banner(title_text: t('notification_banners.important')) do |nb|
+              nb.with_heading(text: t('notification_banners.cookies.heading'))
+          end %>
+        <% end %>
        <%# TEMPORARY WORKAROUND: Centralise Cookie page content %>
        <h1 class="govuk-heading-xl">
          <%= t('presenter.footer.cookies.heading') %>
@@ -14,13 +18,21 @@
        </div>
 
      <% else %>
-
+        <% if editable? %>
+          <%= govuk_notification_banner(title_text: t('notification_banners.important')) do |nb|
+            nb.with_heading(
+              text: t("notification_banners.#{@page.id.gsub('page.','')}.heading"),
+              link_text: t("notification_banners.#{@page.id.gsub('page.','')}.link_text"),
+              link_href: t("notification_banners.#{@page.id.gsub('page.','')}.link_href")
+            )
+          end %>
+        <% end %>
        <%# ORIGINAL TEMPLATE: Uses content from form metadata %>
        <% if @page.heading %>
          <h1 class="fb-editable govuk-heading-xl"
              data-fb-content-id="page[heading]"
              data-fb-content-type="element"
-             data-fb-default-value="<%= t("presenter.footer.#{@page.id.gsub!('page.','')}.heading") %>">
+             data-fb-default-value="<%= t("presenter.footer.#{@page.id.gsub('page.','')}.heading") %>">
            <%= @page.heading %>
          </h1>
        <% end %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0.10'.freeze
+  VERSION = '3.0.11'.freeze
 end


### PR DESCRIPTION
Adds notification banners onto the accessibility and privacy standalone pages with information for form editors.

![image](https://github.com/ministryofjustice/fb-metadata-presenter/assets/595564/2e5c7319-2e2a-455d-999c-c6b6095a2840)

![image](https://github.com/ministryofjustice/fb-metadata-presenter/assets/595564/b84ea18f-c154-42ac-857f-4fe855e53d64)
