### PR TITLE
Fix 404 when resuming form with custom CYA page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.12] - 2023-07-06
+### Fixed
+ - Fixed an issue where save and return would 404 if using a custom check your answers page.
+
 ## [3.0.11] - 2023-07-03
 ### Added 
  - Added notification banners to accessibility and privacy standalone pages.

--- a/app/controllers/metadata_presenter/save_and_return_controller.rb
+++ b/app/controllers/metadata_presenter/save_and_return_controller.rb
@@ -156,7 +156,7 @@ module MetadataPresenter
     def resume_progress
       @user_data = load_user_data
 
-      @page ||= service.find_page_by_url('check-answers')
+      @page ||= service.checkanswers_page
 
       if @page
         @page_answers = PageAnswers.new(@page, @answered_pages)

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0.11'.freeze
+  VERSION = '3.0.12'.freeze
 end


### PR DESCRIPTION
Save and return would fail if the form had a custom check answers page as it was being looked up by URL, where it should be looked up by type.

Working in dev on the pentest form
<img width="1682" alt="image" src="https://github.com/ministryofjustice/fb-metadata-presenter/assets/7647632/93737158-ddc6-44e5-9ccb-76f69725e380">
