### PR TITLE
Only display banners if editing required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.13] - 2023-07-10
+### Added
+ - Makes the notification banners on standalone pages only display if the page
+     still requires edits
+
 ## [3.0.12] - 2023-07-06
 ### Fixed
  - Fixed an issue where save and return would 404 if using a custom check your answers page.

--- a/app/views/metadata_presenter/page/standalone.html.erb
+++ b/app/views/metadata_presenter/page/standalone.html.erb
@@ -18,7 +18,7 @@
        </div>
 
      <% else %>
-        <% if editable? %>
+        <% if editable? && @page.contains_placeholders? %>
           <%= govuk_notification_banner(title_text: t('notification_banners.important')) do |nb|
             nb.with_heading(
               text: t("notification_banners.#{@page.id.gsub('page.','')}.heading"),

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0.12'.freeze
+  VERSION = '3.0.13'.freeze
 end


### PR DESCRIPTION
The banners on the standalone page are only rerquired if the form editor still needs to edit them to remove placholder content.