### PR TITLE
Disable file upload save and return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.0.14] - 2023-07-10
+### Added
+ - Disable save and return on file upload components
+
 ## [3.0.13] - 2023-07-10
 ### Added
  - Makes the notification banners on standalone pages only display if the page

--- a/app/controllers/metadata_presenter/pages_controller.rb
+++ b/app/controllers/metadata_presenter/pages_controller.rb
@@ -26,6 +26,11 @@ module MetadataPresenter
     end
     helper_method :pages_presenters
 
+    def show_save_and_return
+      @page.upload_components.none?
+    end
+    helper_method :show_save_and_return
+
     def answered_pages
       TraversedPages.new(service, load_user_data, @page).all
     end

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -19,7 +19,7 @@
         %>
         <div class="govuk-button-group">
           <%= f.govuk_submit(disabled: editable?) %>
-          <% if save_and_return_enabled? %>
+          <% if save_and_return_enabled? && show_save_and_return %>
             <% if editor_preview? || editable? %>
               <%= button_to t('presenter.save_and_return.save'), '/', params: { page_slug:request.env['PATH_INFO'] }, method: :post, class: "govuk-button govuk-button--secondary", name: 'save_for_later', disabled: true %>
             <% else %>

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -25,7 +25,7 @@
         <div class="govuk-button-group">
           <%= f.govuk_submit(disabled: editable?) %>
 
-          <% if save_and_return_enabled? %>
+          <% if save_and_return_enabled? && show_save_and_return %>
             <% if editor_preview? || editable? %>
               <%= button_to t('presenter.save_and_return.save'), '/', params: { page_slug:request.env['PATH_INFO'] }, method: :post, class: "govuk-button govuk-button--secondary", name: 'save_for_later', disabled: true %>
             <% else %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.0.13'.freeze
+  VERSION = '3.0.14'.freeze
 end


### PR DESCRIPTION
Temp measure to prevent an issue where files can be uploaded without a reference which will create issues with the submission - with the new multifile upload we'll resolve the root cause and revert this.