### PR TITLE
Component schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.2.0] - 2023-07-25
+### Added
+ - Update content component schema to accept conditionals and expressions
+ - Update content page and check answers page schemas to remove 'body' attribute as we can not make this attribute conditional
+ - Show 'body' HTML on content or check answers page only if it has been modified
+
 ## [3.1.0] - 2023-07-24
 ### Added
  - Multifile upload component release
@@ -29,7 +35,7 @@ All notable changes to this project will be documented in this file.
  - Fixed an issue where save and return would 404 if using a custom check your answers page.
 
 ## [3.0.11] - 2023-07-03
-### Added 
+### Added
  - Added notification banners to accessibility and privacy standalone pages.
 
 ## [3.0.10] - 2023-06-30

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -37,7 +37,9 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+     <% unless @page.body == default_text('body') %>
       <%= render 'metadata_presenter/attribute/body' %>
+      <% end %>
 
       <%= render partial: 'metadata_presenter/component/components',
                  locals: {

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -12,7 +12,10 @@
       </h1>
 
       <%= render 'metadata_presenter/attribute/lede' %>
-      <%= render 'metadata_presenter/attribute/body' %>
+
+      <% unless @page.body == default_text('body') %>
+        <%= render 'metadata_presenter/attribute/body' %>
+      <% end %>
 
       <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
 

--- a/default_metadata/page/content.json
+++ b/default_metadata/page/content.json
@@ -4,7 +4,6 @@
   "section_heading": "",
   "heading": "Title",
   "lede": "",
-  "body": "[Optional content]",
   "components": [],
   "url": ""
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.2.0'.freeze
 end

--- a/schemas/component/content.json
+++ b/schemas/component/content.json
@@ -42,35 +42,7 @@
             ]
           },
           "expressions": {
-            "$ref": "#/definitions/expressions"
-          }
-        }
-      }
-    },
-    "expressions": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "operator": {
-            "type": "string",
-            "enum": [
-              "is",
-              "is_not",
-              "is_answered",
-              "is_not_answered",
-              "contains",
-              "does_not_contain"
-            ],
-            "page": {
-              "type": "string"
-            },
-            "component": {
-              "type": "string"
-            },
-            "field": {
-              "type": "string"
-            }
+            "$ref": "definition.expressions"
           }
         }
       }

--- a/schemas/component/content.json
+++ b/schemas/component/content.json
@@ -17,6 +17,63 @@
       "type": "string",
       "content": true,
       "multiline": true
+    },
+    "conditionals": {
+      "$ref": "#/definitions/conditionals"
+    }
+  },
+  "definitions": {
+    "conditionals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "_uuid": {
+            "type": "string",
+            "title": "Unique identifier of the conditional",
+            "description": "Used internally in the editor and the runner"
+          },
+          "_type": {
+            "type": "string",
+            "enum": [
+              "if",
+              "and",
+              "or"
+            ]
+          },
+          "expressions": {
+            "$ref": "#/definitions/expressions"
+          }
+        }
+      }
+    },
+    "expressions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "operator": {
+            "type": "string",
+            "enum": [
+              "is",
+              "is_not",
+              "is_answered",
+              "is_not_answered",
+              "contains",
+              "does_not_contain"
+            ],
+            "page": {
+              "type": "string"
+            },
+            "component": {
+              "type": "string"
+            },
+            "field": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   },
   "allOf": [

--- a/schemas/definition/expression_item.json
+++ b/schemas/definition/expression_item.json
@@ -1,0 +1,36 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/expression_item",
+  "_name": "definition.expression_item",
+  "title": "Expression item",
+  "description": "Component that provides an expression item",
+  "type": "object",
+  "properties": {
+    "operator": {
+      "type": "string",
+      "enum": [
+        "is",
+        "is_not",
+        "is_answered",
+        "is_not_answered"
+      ],
+      "page": {
+        "type": "string"
+      },
+      "component": {
+        "type": "string"
+      },
+      "field": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "operator",
+    "page",
+    "component",
+    "field"
+  ],
+  "category": [
+    "expression_item"
+  ]
+}

--- a/schemas/definition/expressions.json
+++ b/schemas/definition/expressions.json
@@ -1,0 +1,15 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/expressions",
+  "_name": "definition.expressions",
+  "title": "Expressions",
+  "type": "array",
+  "items": {
+    "$ref": "definition.expression_item"
+  },
+  "required": [
+    "items"
+  ],
+  "category": [
+    "expression"
+  ]
+}

--- a/schemas/flow/branch.json
+++ b/schemas/flow/branch.json
@@ -48,33 +48,7 @@
             "type": "string"
           },
           "expressions": {
-            "$ref": "#/definitions/expressions"
-          }
-        }
-      }
-    },
-    "expressions": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "operator": {
-            "type": "string",
-            "enum": [
-              "is",
-              "is_not",
-              "is_answered",
-              "is_not_answered"
-            ],
-            "page": {
-              "type": "string"
-            },
-            "component": {
-              "type": "string"
-            },
-            "field": {
-              "type": "string"
-            }
+            "$ref": "definition.expressions"
           }
         }
       }

--- a/schemas/page/confirmation.json
+++ b/schemas/page/confirmation.json
@@ -14,9 +14,6 @@
     "heading": {
       "multiline": true
     },
-    "body": {
-      "multiline": true
-    },
     "lede": {
       "multiline": true
     },


### PR DESCRIPTION
## Add conditionals and expressions in the content component schema
As part of the conditional content visibility work, the content components will need to accept the `conditionals` key and, within that,`expressions` key.
Adding these into the content component schema in preparation for when we start injecting conditional metadata into these components.
Since the presence of `conditionals` or `expressions` attributes are not required in the content component schemas this should not affect existing content components.

## Remove the `body` attribute from Content Pages and Confirmation Pages
When a user creates either a Content page or a confirmation page, a default body attribute with the value '[Optional content]' is created. From the UI, this looks like a content component, but it is actually the body attribute.
Since it is not a content component in the metadata, any content in this 'body' attribute cannot be made conditional.

To reduce any confusion on these pages, the 'body' attribute has been removed so any newly created content pages or confirmation pages will not have the default '[Optional content]'. This will force the form editor to create a content component.

In terms of existing content or confirmation pages, if the form editor has not modified the 'body' (ie: it is still set as '[Optional content]') it will not be rendered. If the body attribute has been modified by the form editor, the content will be shown in both the runner and the editor.

### Content Page - Before
<img width="1028" alt="Screenshot 2023-07-25 at 12 44 02" src="https://github.com/ministryofjustice/fb-metadata-presenter/assets/29227502/8821f819-1abb-4c8b-a963-a4f569f4f9e0">

### Content Page - After
<img width="997" alt="Screenshot 2023-07-25 at 12 42 50" src="https://github.com/ministryofjustice/fb-metadata-presenter/assets/29227502/cbe6f0f4-9463-4110-8dc6-ad4f3540b605">

### Confirmation Page - Before
<img width="1085" alt="Screenshot 2023-07-25 at 12 52 42" src="https://github.com/ministryofjustice/fb-metadata-presenter/assets/29227502/e76f23c1-62b1-4525-922e-f11efd2efc44">

### Confirmation Page - After
<img width="1091" alt="Screenshot 2023-07-25 at 12 53 26" src="https://github.com/ministryofjustice/fb-metadata-presenter/assets/29227502/5faacdcf-c4e2-4a23-98e3-b41f17e60591">

## Bump to presenter version 3.2.0