### PR TITLE
Evaluate content conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.2.1] - 2023-07-28
+### Added
+- Add logic to evaluate the content conditionals
+- Content components will always show if no conditionals are present or if in the editor preview mode
+
 ## [3.2.0] - 2023-07-25
 ### Added
  - Update content component schema to accept conditionals and expressions

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -114,9 +114,21 @@ module MetadataPresenter
     helper_method :external_or_relative_link
 
     def load_conditional_content
-      show_components(@page).compact
+      if @page.content_component_present?
+        if components_without_conditionals(@page).present?
+          return components_without_conditionals(@page) + show_components(@page).compact
+        end
+
+        show_components(@page).compact
+      end
     end
     helper_method :load_conditional_content
+
+    def components_without_conditionals(page)
+      page.content_components.select { |component|
+        component.conditionals.blank?
+      }.map(&:uuid)
+    end
 
     def show_components(page)
       return @page.content_components.map(&:uuid) if editor_preview?

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -113,6 +113,23 @@ module MetadataPresenter
     end
     helper_method :external_or_relative_link
 
+    def load_conditional_content
+      show_components(@page).compact
+    end
+    helper_method :load_conditional_content
+
+    def show_components(page)
+      return @page.content_components.map(&:uuid) if editor_preview?
+
+      page.content_components.map do |content_component|
+        EvaluateContentConditionals.new(
+          service:,
+          component: content_component,
+          user_data: load_user_data
+        ).show_component
+      end
+    end
+
     private
 
     def not_found

--- a/app/controllers/metadata_presenter/pages_controller.rb
+++ b/app/controllers/metadata_presenter/pages_controller.rb
@@ -8,6 +8,7 @@ module MetadataPresenter
       @page ||= service.find_page_by_url(request.env['PATH_INFO'])
       if @page
         load_autocomplete_items
+        load_conditional_content
 
         @page_answers = PageAnswers.new(@page, @user_data)
         render template: @page.template

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -82,6 +82,12 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
     metadata.max_files.presence || '0'
   end
 
+  def conditionals
+    Array(metadata['conditionals']).map do |conditional_metadata|
+      MetadataPresenter::Conditional.new(conditional_metadata)
+    end
+  end
+
   private
 
   def validation_bundle_key

--- a/app/models/metadata_presenter/evaluate_branch_conditionals.rb
+++ b/app/models/metadata_presenter/evaluate_branch_conditionals.rb
@@ -1,5 +1,5 @@
 module MetadataPresenter
-  class EvaluateConditionals
+  class EvaluateBranchConditionals
     include ActiveModel::Model
     attr_accessor :service, :flow, :user_data
 

--- a/app/models/metadata_presenter/evaluate_content_conditionals.rb
+++ b/app/models/metadata_presenter/evaluate_content_conditionals.rb
@@ -1,0 +1,35 @@
+module MetadataPresenter
+  class EvaluateContentConditionals
+    include ActiveModel::Model
+    attr_accessor :service, :component, :user_data
+
+    def show_component
+      component_uuid
+    end
+
+    def component_uuid
+      @results ||=
+        conditionals.map do |conditional|
+          evaluated_expressions = conditional.expressions.map do |expression|
+            expression.service = service
+
+            Operator.new(
+              expression.operator
+            ).evaluate(
+              expression.field_label,
+              user_data[expression.expression_component.id]
+            )
+          end
+
+          if conditional.type == 'or' && evaluated_expressions.any?
+            component.uuid
+          elsif evaluated_expressions.all?
+            component.uuid
+          end
+        end
+      @results.flatten.compact.first
+    end
+
+    delegate :conditionals, to: :component
+  end
+end

--- a/app/models/metadata_presenter/next_page.rb
+++ b/app/models/metadata_presenter/next_page.rb
@@ -7,7 +7,7 @@ module MetadataPresenter
       return check_answers_page if return_to_check_your_answer?
 
       if conditionals?
-        evaluate_conditionals
+        evaluate_branch_conditionals
       else
         service.find_page_by_uuid(current_page_flow.default_next)
       end
@@ -66,8 +66,8 @@ module MetadataPresenter
         next_flow_branch_object?
     end
 
-    def evaluate_conditionals
-      EvaluateConditionals.new(
+    def evaluate_branch_conditionals
+      EvaluateBranchConditionals.new(
         service:,
         flow: next_flow,
         user_data:

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -141,6 +141,10 @@ module MetadataPresenter
       end
     end
 
+    def content_component_present?
+      components.any?(&:content?)
+    end
+
     private
 
     def heading?

--- a/app/models/metadata_presenter/traversed_pages.rb
+++ b/app/models/metadata_presenter/traversed_pages.rb
@@ -28,7 +28,7 @@ module MetadataPresenter
     private
 
     def evaluated_page(flow_object)
-      EvaluateConditionals.new(
+      EvaluateBranchConditionals.new(
         service:,
         flow: flow_object,
         user_data:

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -1,5 +1,5 @@
 <% components.each_with_index do |component, index| %>
-  <% if component.type == 'content' %>
+  <% if component.type == 'content' && (component.uuid).in?(load_conditional_content) %>
     <editable-content id="<%= "page[#{component.collection}[#{index}]]" %>"
                       class="fb-editable govuk-!-margin-top-8"
                       type="<%= component.type %>"
@@ -9,7 +9,9 @@
                       data-config="<%= component.to_json %>">
         <%= to_html(component.content) %>
     </editable-content>
-  <% else %>
+  <% end %>
+
+  <% unless component.type == 'content' %>
     <div class="fb-editable govuk-!-margin-top-8"
          id="<%= component.id %>"
          data-fb-content-type="<%= component.type %>"

--- a/fixtures/conditional-content.json
+++ b/fixtures/conditional-content.json
@@ -1,0 +1,678 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "07635f6d-34a8-45c8-884f-87696eba6a1f": {
+      "next": {
+        "default": "e2b45429-5a5e-45c1-95f8-8970af92790a"
+      },
+      "_type": "flow.page"
+    },
+    "432d2b1c-4242-466a-8978-2657f96e63d9": {
+      "next": {
+        "default": "e6df0eaa-76a7-494a-9468-68b093e111ce"
+      },
+      "_type": "flow.page"
+    },
+    "93b54d92-4fbf-44aa-8f5d-d94cb72a10e8": {
+      "next": {
+        "default": "be656508-ffa1-4c40-815e-ca1859c9514f"
+      },
+      "_type": "flow.page"
+    },
+    "be656508-ffa1-4c40-815e-ca1859c9514f": {
+      "next": {
+        "default": "fcbdca1e-2a09-485b-951b-5b596115defc"
+      },
+      "_type": "flow.page"
+    },
+    "c5525c09-c817-4280-9812-8c70b309b073": {
+      "next": {
+        "default": "07635f6d-34a8-45c8-884f-87696eba6a1f"
+      },
+      "_type": "flow.page"
+    },
+    "d0f7b265-17c9-4c22-8739-d7c46d6d1426": {
+      "next": {
+        "default": "c5525c09-c817-4280-9812-8c70b309b073"
+      },
+      "_type": "flow.page"
+    },
+    "e2b45429-5a5e-45c1-95f8-8970af92790a": {
+      "next": {
+        "default": "432d2b1c-4242-466a-8978-2657f96e63d9"
+      },
+      "_type": "flow.page"
+    },
+    "e6df0eaa-76a7-494a-9468-68b093e111ce": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "fcbdca1e-2a09-485b-951b-5b596115defc": {
+      "next": {
+        "default": "d0f7b265-17c9-4c22-8739-d7c46d6d1426"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to apply for a service or contact us about a case.\r\n\r\n## Before you start\r\nYou will need:\r\n\r\n* your 8-digit reference number\r\n* a copy of your photo ID\r\n* something else\r\n\r\nThis form will take around 5 minutes to complete. We will reply within 10 working days.",
+      "_type": "page.start",
+      "_uuid": "93b54d92-4fbf-44aa-8f5d-d94cb72a10e8",
+      "heading": "Service name goes here",
+      "before_you_start": "## Other ways to get in touch\r\nYou can also apply or contact us about your case by:\r\n\r\n* telephone: 01234 567889\r\n* email: <example.service@justice.gov.uk>\r\n\r\nThis form is also [available in Welsh (Cymraeg)](https://example-service.form.service.justice.gov.uk/)."
+    },
+    {
+      "_id": "page.ice-cream",
+      "url": "ice-cream",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "be656508-ffa1-4c40-815e-ca1859c9514f",
+      "heading": "",
+      "components": [
+        {
+          "_id": "ice-cream_checkboxes_1",
+          "hint": "",
+          "name": "ice-cream_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "ea13126a-7ae2-45a5-a08f-949bd1953877",
+          "items": [
+            {
+              "_id": "ice-cream_checkboxes_1_item_1",
+              "hint": "",
+              "name": "ice-cream_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "acbfc0d8-7dbf-437f-8d9b-3c140140958e",
+              "label": "Chocolate",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "ice-cream_checkboxes_1_item_2",
+              "hint": "",
+              "name": "ice-cream_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "3bf08f98-ad1f-4a9d-b150-9ae917c4f711",
+              "label": "Hokey Pokey",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "ice-cream_checkboxes_1_item_3",
+              "hint": "",
+              "name": "ice-cream_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "d14b0d78-3977-4c58-8c05-2c2853d4dbbb",
+              "label": "Mango",
+              "value": "value-3",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "ice-cream_checkboxes_1_item_4",
+              "hint": "",
+              "name": "ice-cream_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "b8571aa4-a208-4c8c-92e6-4fdffbba9d48",
+              "label": "Pistachio",
+              "value": "value-4",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Checkbox",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.flavours",
+      "url": "flavours",
+      "body": "",
+      "lede": "",
+      "_type": "page.content",
+      "_uuid": "fcbdca1e-2a09-485b-951b-5b596115defc",
+      "heading": "Ice cream flavours",
+      "components": [
+        {
+          "_id": "flavours_content_1",
+          "name": "flavours_content_1",
+          "_type": "content",
+          "_uuid": "b4b7fae6-cc1a-4ed6-b7e2-89ae6da74ffb",
+          "content": "Chocolate, Hokey Pokey, Mango and Pistachio. All of the flavours.",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "and",
+              "_uuid": "98cfd843-7c02-4534-9055-201487e9be16",
+              "expressions": [
+                {
+                  "page": "be656508-ffa1-4c40-815e-ca1859c9514f",
+                  "field": "acbfc0d8-7dbf-437f-8d9b-3c140140958e",
+                  "operator": "contains",
+                  "component": "ea13126a-7ae2-45a5-a08f-949bd1953877"
+                },
+                {
+                  "page": "be656508-ffa1-4c40-815e-ca1859c9514f",
+                  "field": "3bf08f98-ad1f-4a9d-b150-9ae917c4f711",
+                  "operator": "contains",
+                  "component": "ea13126a-7ae2-45a5-a08f-949bd1953877"
+                },
+                {
+                  "page": "be656508-ffa1-4c40-815e-ca1859c9514f",
+                  "field": "d14b0d78-3977-4c58-8c05-2c2853d4dbbb",
+                  "operator": "contains",
+                  "component": "ea13126a-7ae2-45a5-a08f-949bd1953877"
+                },
+                {
+                  "page": "be656508-ffa1-4c40-815e-ca1859c9514f",
+                  "field": "b8571aa4-a208-4c8c-92e6-4fdffbba9d48",
+                  "operator": "contains",
+                  "component": "ea13126a-7ae2-45a5-a08f-949bd1953877"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "flavours_content_2",
+          "name": "flavours_content_2",
+          "_type": "content",
+          "_uuid": "02826f69-13e7-4f65-a636-366ee1f08655",
+          "content": "You didn't choose Mango.",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "98cfd843-7c02-4534-9055-201487e9be16",
+              "expressions": [
+                {
+                  "page": "be656508-ffa1-4c40-815e-ca1859c9514f",
+                  "field": "d14b0d78-3977-4c58-8c05-2c2853d4dbbb",
+                  "operator": "does_not_contain",
+                  "component": "ea13126a-7ae2-45a5-a08f-949bd1953877"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "add_component": "content",
+      "section_heading": ""
+    },
+    {
+      "_id": "page.colours",
+      "url": "colours",
+      "body": "",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "d0f7b265-17c9-4c22-8739-d7c46d6d1426",
+      "heading": "",
+      "components": [
+        {
+          "_id": "colours_radios_1",
+          "hint": "",
+          "name": "colours_radios_1",
+          "_type": "radios",
+          "_uuid": "bfa711a6-e937-4d73-acbd-be19cc334645",
+          "items": [
+            {
+              "_id": "colours_radios_1_item_1",
+              "hint": "",
+              "name": "colours_radios_1",
+              "_type": "radio",
+              "_uuid": "2d62e730-dbf4-45ee-b91f-266170b2bb29",
+              "label": "red",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Colours",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "colours_radios_1_item_2",
+              "hint": "",
+              "name": "colours_radios_1",
+              "_type": "radio",
+              "_uuid": "bf7b849d-550a-48bd-b31e-9331242703f5",
+              "label": "yellow",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "colours_radios_1_item_3",
+              "hint": "",
+              "name": "colours_radios_1",
+              "_type": "radio",
+              "_uuid": "8ec6802d-6a5e-4b5f-bea3-e7418584acad",
+              "label": "blue",
+              "value": "value-3",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Colours",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "432d2b1c-4242-466a-8978-2657f96e63d9",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+        {
+          "_id": "check-answers_content_2",
+          "name": "check-answers_content_2",
+          "_type": "content",
+          "_uuid": "a0f2a2e1-dccf-4a36-aeae-b8d593f7118f",
+          "content": "### No conditionals on this component\nThis content should always show because there are no conditionals attached to it.",
+          "collection": "components"
+        }
+      ],
+      "send_heading": "Now send your application",
+      "add_component": "content",
+      "extra_components": [
+        {
+          "_id": "check-answers_content_1",
+          "name": "check-answers_content_1",
+          "_type": "content",
+          "_uuid": "f5ce7110-33c5-487d-9b2e-b96b10b6ef84",
+          "content": "Your pet is a turtle",
+          "collection": "extra_components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "ac914bb1-c4b8-44a0-bacd-2d23a6597f1a",
+              "expressions": [
+                {
+                  "page": "07635f6d-34a8-45c8-884f-87696eba6a1f",
+                  "field": "46c218d5-018a-482a-a66d-0d84be80f543",
+                  "operator": "is",
+                  "component": "612f5bc2-8766-4296-9b9c-47f92bdc4b62"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "add_extra_component": "content"
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "e6df0eaa-76a7-494a-9468-68b093e111ce",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.show-colours",
+      "url": "show-colours",
+      "body": "",
+      "lede": "",
+      "_type": "page.content",
+      "_uuid": "c5525c09-c817-4280-9812-8c70b309b073",
+      "heading": "Show choosen colour",
+      "components": [
+        {
+          "_id": "show-colours_content_1",
+          "name": "show-colours_content_1",
+          "_type": "content",
+          "_uuid": "d53f1548-3cda-4002-9d00-5e61f854334f",
+          "content": "You choose YELLOW",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_uuid": "ecd60ac9-c3ea-47b1-8f79-c4e42df9a9dd",
+              "_type": "if",
+              "expressions": [
+                {
+                  "operator": "is",
+                  "page": "d0f7b265-17c9-4c22-8739-d7c46d6d1426",
+                  "component": "bfa711a6-e937-4d73-acbd-be19cc334645",
+                  "field": "bf7b849d-550a-48bd-b31e-9331242703f5"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "show-colours_content_2",
+          "name": "show-colours_content_2",
+          "_type": "content",
+          "_uuid": "514cfee1-9bc1-4232-b52a-d151d05752bb",
+          "content": "You choose BLUE",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_uuid": "ecd60ac9-c3ea-47b1-8f79-c4e42df9a9dd",
+              "_type": "if",
+              "expressions": [
+                {
+                  "operator": "is",
+                  "page": "d0f7b265-17c9-4c22-8739-d7c46d6d1426",
+                  "component": "bfa711a6-e937-4d73-acbd-be19cc334645",
+                  "field": "8ec6802d-6a5e-4b5f-bea3-e7418584acad"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "show-colours_content_3",
+          "name": "show-colours_content_3",
+          "_type": "content",
+          "_uuid": "c343502a-3d4b-4c99-9da3-69eb83c1d3ff",
+          "content": "Show RED",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_uuid": "ecd60ac9-c3ea-47b1-8f79-c4e42df9a9dd",
+              "_type": "if",
+              "expressions": [
+                {
+                  "operator": "is",
+                  "page": "d0f7b265-17c9-4c22-8739-d7c46d6d1426",
+                  "component": "bfa711a6-e937-4d73-acbd-be19cc334645",
+                  "field": "2d62e730-dbf4-45ee-b91f-266170b2bb29"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "show-colours_content_4",
+          "name": "show-colours_content_4",
+          "_type": "content",
+          "_uuid": "eb40d6c7-6c07-4c64-8891-f0b4d36ca517",
+          "content": "You choose a chocolate ice cream or the colour RED",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "ad9e5a31-8a83-4089-94d4-a1e14d2dc42a",
+              "expressions": [
+                {
+                  "page": "be656508-ffa1-4c40-815e-ca1859c9514f",
+                  "field": "acbfc0d8-7dbf-437f-8d9b-3c140140958e",
+                  "operator": "is",
+                  "component": "ea13126a-7ae2-45a5-a08f-949bd1953877"
+                }
+              ]
+            },
+            {
+              "_type": "if",
+              "_uuid": "935ba547-35c1-40cb-bbb9-e7768564a80d",
+              "expressions": [
+                {
+                  "page": "d0f7b265-17c9-4c22-8739-d7c46d6d1426",
+                  "field": "2d62e730-dbf4-45ee-b91f-266170b2bb29",
+                  "operator": "contains",
+                  "component": "bfa711a6-e937-4d73-acbd-be19cc334645"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "add_component": "content",
+      "section_heading": ""
+    },
+    {
+      "_id": "page.pets",
+      "url": "pets",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "07635f6d-34a8-45c8-884f-87696eba6a1f",
+      "heading": "",
+      "components": [
+        {
+          "_id": "pets_radios_1",
+          "hint": "",
+          "name": "pets_radios_1",
+          "_type": "radios",
+          "_uuid": "612f5bc2-8766-4296-9b9c-47f92bdc4b62",
+          "items": [
+            {
+              "_id": "pets_radios_1_item_1",
+              "hint": "",
+              "name": "pets_radios_1",
+              "_type": "radio",
+              "_uuid": "9364d7e0-98ca-4375-8334-c5f9a26c7b0d",
+              "label": "Dog",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "pets_radios_1_item_2",
+              "hint": "",
+              "name": "pets_radios_1",
+              "_type": "radio",
+              "_uuid": "7f856bb3-d079-4dd2-a10d-4a9ed310a9bd",
+              "label": "Cat",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "pets_radios_1_item_3",
+              "hint": "",
+              "name": "pets_radios_1",
+              "_type": "radio",
+              "_uuid": "46c218d5-018a-482a-a66d-0d84be80f543",
+              "label": "Turtle",
+              "value": "value-3",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Pet choice",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.furry",
+      "url": "furry",
+      "_type": "page.multiplequestions",
+      "_uuid": "e2b45429-5a5e-45c1-95f8-8970af92790a",
+      "heading": "Furry Pet",
+      "components": [
+        {
+          "_id": "furry_content_1",
+          "name": "furry_content_1",
+          "_type": "content",
+          "_uuid": "46a49bb2-349d-47f2-bb75-eaed3892d5d7",
+          "content": "Your pet is furry land dwelling pet",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "ac914bb1-c4b8-44a0-bacd-2d23a6597f1a",
+              "expressions": [
+                {
+                  "page": "07635f6d-34a8-45c8-884f-87696eba6a1f",
+                  "field": "46c218d5-018a-482a-a66d-0d84be80f543",
+                  "operator": "is_not",
+                  "component": "612f5bc2-8766-4296-9b9c-47f92bdc4b62"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "furry_email_1",
+          "hint": "",
+          "name": "furry_email_1",
+          "_type": "email",
+          "_uuid": "c533f44d-5d38-4258-883e-22b5653a59b1",
+          "label": "Email address question",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "email": true,
+            "required": true,
+            "max_length": 256
+          }
+        }
+      ],
+      "add_component": "email",
+      "section_heading": ""
+    }
+  ],
+  "locale": "en",
+  "created_at": "2023-07-12T14:56:50Z",
+  "created_by": "b7eff904-9fec-4c48-b6ac-4572b490a040",
+  "service_id": "9427e585-9f60-4c9a-b1a9-95dc304fbff2",
+  "version_id": "520ba187-894b-4601-972c-ffc8c7efff30",
+  "service_name": "conditional component test",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "This form saves small files (known as 'cookies') onto your device.\r\n \r\nCookies are used to:\r\n \r\n* remember your progress\r\n* measure how you use the form so it can be updated and improved based on your needs\r\n \r\nThese cookies are not used to identify you personally.\r\n \r\nYou will normally see a message on the form before we store a cookie on your computer. Essential cookies are necessary for the form to work but you can still complete the form if you choose not to accept analytics cookies.\r\n \r\nFind out more about [how to manage cookies](https://www.aboutcookies.org/).\r\n \r\n## Essential cookies\r\n \r\nEssential cookies are required to make this form work and keep your information secure while you use it.\r\n \r\nWe use the following essential cookies: \r\n \r\n| Name | Purpose | Expires |\r\n|---|---|---|\r\n| \\_fb\\_runner\\_session | Saves your current progress on this computer and tracks inactivity periods | After 30 minutes of inactivity or when you close your browser |\r\n| analytics | Remembers whether you accept or reject analytics cookies on this form | After 1 year |\r\n \r\n## Analytics cookies\r\n \r\nAnalytics cookies collect information about how you use this form. This helps us make sure the form is meeting the needs of its users and to help us make improvements.\r\n \r\nWe use Google Analytics to learn about:\r\n \r\n* the pages you visit\r\n* how long you spend on each page\r\n* how you got to the form\r\n* what you click on while you are using the form\r\n \r\nWe do not collect or store your personal information (for example your name or address) so this information can't be used to identify who you are. We do not allow third parties to use or share our analytics data.\r\n \r\nThis form may use different versions of Google Analytics and could save some or all of the following cookies:\r\n \r\n| Name | Purpose | Expires |\r\n|---|---|---|\r\n| \\_ga | Helps us count how many people visit this form | 2 years |\r\n| \\_gid | Helps us count how many people visit this form | 1 day   |\r\n| \\_ga\\_\\<container-id> | Used to persist session state | 2 years |\r\n| \\_gac\\_gb\\_\\<container-id> | Contains campaign-related information | 90 days |\r\n| \\_gat | Used to throttle request rate | 1 minute |\r\n| \\_dc\\_gtm\\_\\<property-id>| Used to throttle request rate | 1 minute |\r\n| AMP\\_TOKEN | Contains a token that can be used to retrieve a Client ID from AMP Client ID service | 30 seconds to 1 year |\r\n| \\_gac\\_\\<property-id> | Contains campaign related information | 90 days |\r\n \r\nYou can use a browser addon to [opt out of Google Analytics cookies](https://tools.google.com/dlpage/gaoptout) on all websites.",
+      "_type": "page.standalone",
+      "_uuid": "80d0ae4f-08bf-4fb5-bb76-7372485d9609",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "[[Guidance notes on completing this notice](https://intranet.justice.gov.uk/documents/2018/03/privacy-notice-guidance.pdf) - delete before publishing]\r\n\r\n##[Name of your form or service]\r\n\r\nThe Ministry of Justice (MoJ) is committed to the protection and security of your personal information.\r\n\r\nIt is important that you read this notice so that you are aware of how and why we are using such information. This privacy notice describes how we collect and use personal information during and after your relationship with us, in accordance with data protection law. \r\n\r\n[Insert name – delete if not an EA or ALB] is an Executive Agency/Arm’s Length Body of the MoJ. MoJ is the data controller for the personal data used for the purposes of [Insert overarching purpose].\r\n\r\n###The type of personal data we process\r\n\r\nWe currently collect and use the following information:\r\n\r\n[list the type of personal data used e.g. name, address, contact details etc]\r\n\r\nWe also collect special categories of information, such as [delete this section if not applicable]:\r\n\r\n* race or ethnicity \r\n* political opinions\r\n* religious or philosophical beliefs\r\n* trade union membership\r\n* health, sex life or sexual orientation \r\n* genetics or biometrics\r\n* criminal convictions\r\n\r\n\r\n###How we get your personal data and why we have it\r\n\r\nMost of the personal information we process is provided to us directly by you for one of the following reasons: [List reasons e.g. providing an online service]\r\n\r\nWe also receive personal information indirectly, from the following sources in the following scenarios: [Include details of the source of the personal data unless the data is collected directly from the data subject]\r\n\r\nWe use the personal data we receive in order to: [list how you use the personal data] \r\n\r\nWe may share this information with: [enter organisations or individuals]\r\n\r\nUnder the UK General Data Protection Regulation (UK GDPR), the lawful bases we rely on for processing this information are: [delete as appropriate]\r\n\r\n* Your consent. You may withdraw your consent at any time by contacting [enter contact details].\r\n* We have a contractual obligation.\r\n* We have a legal obligation.\r\n* We have a vital interest.\r\n* We need it to perform a public task.\r\n* We have a legitimate interest.\r\n\r\n[Explain the purpose and lawful basis for processing the personal data you collect. If lawful basis is a legal obligation or public task, explain what this is e.g. refer to legislation or policy.]  \r\n\r\nThe legal bases on which the MoJ processes special categories of information you have provided, is on the basis of: [delete this section if not applicable]\r\n\r\n* Your explicit consent. You may withdraw your consent at any time by contacting [insert contact details].\r\n* The processing being necessary for the MoJ in the field of employment, social security and social protection law.\r\n* The information being manifestly made public by you.\r\n* The processing being necessary for the establishment, exercise or defence of legal claims.\r\n* The substantial public interest in the MoJ [tailor as required and choose relevant [substantial public interest condition](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/special-category-data/what-are-the-substantial-public-interest-conditions/)]. \r\n* The processing is necessary for historical research purposes/statistical purposes.\r\n\r\n###International data transfers\r\n\r\n[Delete one of the following paragraphs as appropriate]\r\n\r\nPersonal data is transferred to [insert name of country] for the purpose of [insert purpose]. This international transfer complies with UK data protection law [delete as appropriate].\r\n\r\n\r\nThere are no international transfers.\r\n\r\n###How we store your personal data\r\n\r\n[set out how long the information is retained, or the criteria used to determine how long the information is retained]\r\n\r\nPersonal data is stored securely and in accordance with our data retention schedule [insert link to the schedule or details of retention periods]. At the end of this period your data is [insert with it is retained as a public record or whether it is disposed of].\r\n\r\n###Your rights\r\n\r\n[This section lists all data subject rights found in the UKGDPR and the Data Protection Act 2018. You should only include those relevant to your lawful basis for processing. [Find out more about which rights apply and when](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/)]\r\n\r\n* Your right of access - You have the right to ask us for copies of your personal information. \r\n* Your right to rectification - You have the right to ask us to rectify personal information you think is inaccurate. You also have the right to ask us to complete information you think is incomplete. \r\n* Your right to erasure - You have the right to ask us to erase your personal information in certain circumstances. \r\n* Your right to restriction of processing - You have the right to ask us to restrict the processing of your personal information in certain circumstances. \r\n* Your right to object to processing - You have the right to object to the processing of your personal information in certain circumstances. \r\n* Your right to data portability - You have the right to ask that we transfer the personal information you gave us to another organisation, or to you, in certain circumstances. \r\n\r\nDepending on the lawful basis on which your personal data is being processed, not all rights will apply.\r\n\r\nYou are not required to pay any charge for exercising your rights. If you make a request, we have one month to respond to you. If you wish to exercise your data protection rights please contact one of these teams.\r\n\r\nIf you have ever been convicted of a criminal offence, contact:\r\n\r\n\r\nBranston Registry<br> \r\nBuilding 16, S & T Store<br> \r\nBurton Road<br>\r\nBranston<br>\r\nBurton-on-Trent<br> \r\nStaffordshire<br>\r\nDE14 3EG\r\nEmail: <data.access1@justice.gov.uk>\r\n\r\nOtherwise, contact:\r\n\r\n\r\nDisclosure Team<br>\r\nPost point 10.38<br>\r\n102 petty France<br>\r\nLondon<br>\r\nSW1H 9AJ\r\nEmail: <data.access@justice.gov.uk> \r\n\r\n###How to complain\r\n\r\nIf you have any concerns about our use of your personal data, you can contact the MoJ data protection officer:\r\n\r\nData Protection Officer<br>\r\nMinistry of Justice<br>\r\n3rd Floor, Post Point 3.20<br>\r\n10 South Colonnades<br>\r\nCanary Wharf<br>\r\nLondon<br>\r\nE14 4PU\r\n\r\nEmail: <dpo@justice.gov.uk> \r\n\r\n\r\nYou can also complain to the Information Commissioner’s Office (ICO) if you are unhappy with how we have used your data:\r\n\r\n\r\nInformation Commissioner’s Office<br>\r\nWycliffe House<br>\r\nWater Lane<br>\r\nWilmslow<br>\r\nCheshire<br>\r\nSK9 5AF\r\n\r\nTelephone: 0303 123 1113<br>\r\n[ICO website](https://www.ico.org.uk)\r\n\r\nDate of last review: [Insert publication or update date]",
+      "_type": "page.standalone",
+      "_uuid": "d22ddf83-8803-4efd-a2d8-1f9b483d481d",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "This accessibility statement applies to [describe your form here - for example, the general enquiries form for the CICA]. There is a separate [accessibility statement for the main GOV.UK website](https://www.gov.uk/help/accessibility-statement).\r\n\r\n###Using this online form\r\n\r\nThis form was built using MoJ Forms, a tool developed by the Ministry of Justice, and uses components from the [GOV.UK Design System](https://design-system.service.gov.uk/).\r\n\r\n[insert your organisation here] is responsible for the content of this online form. The Ministry of Justice is responsible for its technical aspects.\r\n\r\nWe want as many people as possible to be able to use this online form. For example, that means you should be able to:\r\n\r\n- change colours, contrast levels and fonts\r\n- zoom in up to 300% without the text spilling off the screen\r\n- navigate the form using just a keyboard\r\n- navigate the form using speech recognition software\r\n- listen to the form using a screen reader (including recent versions of JAWS, NVDA and VoiceOver)\r\n\r\nWe’ve also made the text as simple as possible to understand.\r\n\r\n[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.\r\n\r\n###Feedback and contact information\r\n\r\nIf you need information on this website in a different format:\r\n\r\n[insert your contact details for user requests here - add other channels, such as text phones or Relay UK, as required]\r\n\r\n- email: [your email address]\r\n- call: [your telephone number]\r\n- [Hours - e.g. Monday to Friday, 9am to 5pm]\r\n\r\nWe'll consider your request and get back to you in [add your SLA - e.g. a week or 5 working days].\r\n\r\n###Reporting accessibility problems with this form\r\n\r\nWe’re always looking to improve the accessibility of this form. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact:\r\n\r\n[insert your contact details for user feedback here - add other channels, such as text phones or Relay UK, as required]\r\n\r\n- email: [your email address]\r\n- call: [your telephone number]\r\n- [Hours - e.g. Monday to Friday, 9am to 5pm]\r\n\r\n###Enforcement procedure\r\n\r\nThe Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the [Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).\r\n\r\n###Technical information about this online form’s accessibility\r\n\r\nWe are committed to making our online forms and services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.\r\n\r\n####Compliance status\r\n\r\nThis online form is fully compliant with the [Web Content Accessibility Guidelines version 2.1 AA standard](https://www.w3.org/TR/WCAG21/)\r\n\r\n###Preparation of this accessibility statement\r\n\r\nThis statement was prepared on [date when it was first published]. It was last reviewed on [date when it was last reviewed].\r\n\r\nThis form was last tested on [date when you performed your basic accessibility check].\r\n\r\nIn order to test the compliance of all forms built using the MoJ Forms tool, the Ministry of Justice commissioned The Digital Accessibility Centre (DAC) to carry out a WCAG 2.1 AA level audit of a sample form. This included extensive testing by users with a wide range of disabilities. The audit was performed on 8 April 2021. The audit highlighted a number of non-compliance issues which were fixed on 11 May 2021.\r\n\r\nIn addition, this form was tested by [insert team or organisation here]. It was tested using the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) following guidance from the Ministry of Justice and the Government Digital Service (GDS).\r\n\r\n###What we’re doing to improve accessibility\r\n\r\nWe will monitor the accessibility of this website on an ongoing basis and fix any accessibility issues reported to us.",
+      "_type": "page.standalone",
+      "_uuid": "1539fd9b-efb7-42d4-a1b7-618116fa30d8",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/fixtures/conditional_content.json
+++ b/fixtures/conditional_content.json
@@ -397,28 +397,6 @@
           ]
         },
         {
-          "_id": "show-colours_content_2",
-          "name": "show-colours_content_2",
-          "_type": "content",
-          "_uuid": "514cfee1-9bc1-4232-b52a-d151d05752bb",
-          "content": "You choose BLUE",
-          "collection": "components",
-          "conditionals": [
-            {
-              "_uuid": "ecd60ac9-c3ea-47b1-8f79-c4e42df9a9dd",
-              "_type": "if",
-              "expressions": [
-                {
-                  "operator": "is",
-                  "page": "d0f7b265-17c9-4c22-8739-d7c46d6d1426",
-                  "component": "bfa711a6-e937-4d73-acbd-be19cc334645",
-                  "field": "8ec6802d-6a5e-4b5f-bea3-e7418584acad"
-                }
-              ]
-            }
-          ]
-        },
-        {
           "_id": "show-colours_content_3",
           "name": "show-colours_content_3",
           "_type": "content",
@@ -449,7 +427,7 @@
           "collection": "components",
           "conditionals": [
             {
-              "_type": "if",
+              "_type": "or",
               "_uuid": "ad9e5a31-8a83-4089-94d4-a1e14d2dc42a",
               "expressions": [
                 {
@@ -457,13 +435,7 @@
                   "field": "acbfc0d8-7dbf-437f-8d9b-3c140140958e",
                   "operator": "is",
                   "component": "ea13126a-7ae2-45a5-a08f-949bd1953877"
-                }
-              ]
-            },
-            {
-              "_type": "if",
-              "_uuid": "935ba547-35c1-40cb-bbb9-e7768564a80d",
-              "expressions": [
+                },
                 {
                   "page": "d0f7b265-17c9-4c22-8739-d7c46d6d1426",
                   "field": "2d62e730-dbf4-45ee-b91f-266170b2bb29",

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -689,7 +689,21 @@
           "_type": "content",
           "_uuid": "b065ff4f-90c5-4ba2-b4ac-c984a9dd2470",
           "content": "Take the cannoli.",
-          "collection": "components"
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "98cfd843-7c02-4534-9055-201487e9be16",
+              "expressions": [
+                {
+                  "page": "68fbb180-9a2a-48f6-9da6-545e28b8d35a",
+                  "field": "c5571937-9388-4411-b5fa-34ddf9bc4ca0",
+                  "operator": "is",
+                  "component": "ac41be35-914e-4b22-8683-f5477716b7d4"
+                }
+              ]
+            }
+          ]
         }
       ],
       "send_heading": "Now send your application",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.2.0'.freeze
+  VERSION = '3.2.1'.freeze
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -300,4 +300,40 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
       end
     end
   end
+
+  describe '#show_components' do
+    context 'when page should show conditional content' do
+      let(:page) { service.find_page_by_url('check-answers') }
+      let(:load_user_data) do
+        {
+          'do-you-like-star-wars_radios_1' => 'Only on weekends'
+        }
+      end
+
+      before do
+        allow_any_instance_of(MetadataPresenter::EngineController).to receive(:load_user_data).and_return(load_user_data)
+      end
+
+      it 'returns the component uuids without conditionals' do
+        expect(controller.show_components(page)).to eq(['b065ff4f-90c5-4ba2-b4ac-c984a9dd2470', nil])
+      end
+    end
+
+    context 'when page should not show the conditional content' do
+      let(:page) { service.find_page_by_url('check-answers') }
+      let(:load_user_data) do
+        {
+          'do-you-like-star-wars_radios_1' => 'Hell no!'
+        }
+      end
+
+      before do
+        allow_any_instance_of(MetadataPresenter::EngineController).to receive(:load_user_data).and_return(load_user_data)
+      end
+
+      it 'returns the component uuids without conditionals' do
+        expect(controller.show_components(page)).to eq([nil, nil])
+      end
+    end
+  end
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -336,4 +336,14 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
       end
     end
   end
+
+  describe '#components_without_conditionals' do
+    context 'when page has content components' do
+      let(:page) { service.find_page_by_url('check-answers') }
+
+      it 'returns the component uuids without conditionals' do
+        expect(controller.components_without_conditionals(page)).to eq(%w[3e6ef27e-91a6-402f-8291-b7ce669e824e])
+      end
+    end
+  end
 end

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -254,4 +254,43 @@ RSpec.describe MetadataPresenter::Component do
       end
     end
   end
+
+  describe '#conditionals' do
+    context 'when there are conditionals' do
+      let(:component) do
+        service.find_page_by_url('check-answers').components.first
+      end
+
+      it 'returns conditionals' do
+        expect(component.conditionals).to eq(
+          [
+            MetadataPresenter::Conditional.new(
+              {
+                "_type": 'if',
+                "_uuid": '98cfd843-7c02-4534-9055-201487e9be16',
+                "expressions": [
+                  {
+                    "page": '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
+                    "field": 'c5571937-9388-4411-b5fa-34ddf9bc4ca0',
+                    "operator": 'is',
+                    "component": 'ac41be35-914e-4b22-8683-f5477716b7d4'
+                  }
+                ]
+              }
+            )
+          ]
+        )
+      end
+    end
+
+    context 'when there are no conditionals' do
+      let(:component) do
+        service.find_page_by_url('how-many-lights').components.first
+      end
+
+      it 'returns empty' do
+        expect(component.conditionals).to eq([])
+      end
+    end
+  end
 end

--- a/spec/models/evaluate_branch_conditionals_spec.rb
+++ b/spec/models/evaluate_branch_conditionals_spec.rb
@@ -1,5 +1,5 @@
-RSpec.describe MetadataPresenter::EvaluateConditionals do
-  subject(:evaluate_conditionals) do
+RSpec.describe MetadataPresenter::EvaluateBranchConditionals do
+  subject(:evaluate_branch_conditionals) do
     described_class.new(
       service:,
       flow:,
@@ -9,7 +9,7 @@ RSpec.describe MetadataPresenter::EvaluateConditionals do
   let(:service_metadata) { metadata_fixture(:branching) }
 
   describe '#page' do
-    subject(:page) { evaluate_conditionals.page }
+    subject(:page) { evaluate_branch_conditionals.page }
 
     context 'when simple if conditional' do
       let(:flow) { service.flow_object('09e91fd9-7a46-4840-adbc-244d545cfef7') }

--- a/spec/models/evaluate_content_conditionals_spec.rb
+++ b/spec/models/evaluate_content_conditionals_spec.rb
@@ -1,0 +1,181 @@
+RSpec.describe MetadataPresenter::EvaluateContentConditionals do
+  subject(:evaluate_content_conditionals) do
+    described_class.new(
+      service:,
+      component:,
+      user_data:
+    )
+  end
+  let(:service_metadata) { metadata_fixture(:conditional_content) }
+
+  describe '#show_component' do
+    subject(:show_component) { evaluate_content_conditionals.show_component }
+
+    context 'when the question is a checkbox' do
+      let(:component) { service.find_page_by_url('flavours').components.last }
+
+      context 'when single expression is met' do
+        let(:user_data) do
+          {
+            'ice-cream_checkboxes_1' => ['Chocolate', 'Hokey Pokey']
+          }
+        end
+
+        it 'returns the content component uuid' do
+          expect(show_component).to eq(component.uuid)
+        end
+      end
+
+      context 'when multiple conditions are met' do
+        let(:component) { service.find_page_by_url('flavours').components.first }
+        let(:user_data) do
+          {
+            'ice-cream_checkboxes_1' => ['Chocolate', 'Hokey Pokey', 'Mango', 'Pistachio']
+          }
+        end
+
+        it 'returns the content component uuid' do
+          expect(show_component).to eq(component.uuid)
+        end
+      end
+
+      context 'when conditions are not met' do
+        let(:user_data) do
+          {
+            'ice-cream_checkboxes_1' => %w[Mango]
+          }
+        end
+
+        it 'does not return the content component uuid' do
+          expect(show_component).to eq(nil)
+        end
+      end
+    end
+
+    context 'when the question is a radio' do
+      let(:component) { service.find_page_by_url('show-colours').components.first }
+
+      context 'when yellow condition is met' do
+        let(:user_data) do
+          {
+            'colours_radios_1' => 'yellow'
+          }
+        end
+
+        it 'returns the component uuid' do
+          expect(show_component).to eq(component.uuid)
+        end
+      end
+
+      context 'when red condition is met' do
+        let(:component) { service.find_page_by_url('show-colours').components.last }
+        let(:user_data) do
+          {
+            'colours_radios_1' => 'red'
+          }
+        end
+
+        it 'returns the component uuid' do
+          expect(show_component).to eq(component.uuid)
+        end
+      end
+
+      context 'when none of the conditions are met' do
+        let(:user_data) do
+          {
+            'colours_radios_1' => 'blue'
+          }
+        end
+
+        it 'returns the component uuid' do
+          expect(show_component).to eq(nil)
+        end
+      end
+    end
+
+    context 'when multiple conditionals' do
+      context 'when multiple expressions with "OR" statement' do
+        let(:component) { service.find_page_by_url('show-colours').components.last }
+
+        context 'when choosing one option' do
+          let(:user_data) do
+            {
+              'ice-cream_checkboxes_1' => %w[Chocolate]
+            }
+          end
+
+          it 'returns the component uuid' do
+            expect(show_component).to eq(component.uuid)
+          end
+        end
+
+        context 'when choosing another option' do
+          let(:user_data) do
+            {
+              'colours_radios_1' => 'red'
+            }
+          end
+
+          it 'returns the component uuid' do
+            expect(show_component).to eq(component.uuid)
+          end
+        end
+
+        context 'when choosing one option' do
+          let(:user_data) do
+            {
+              'ice-colours_radios_1' => 'blue'
+            }
+          end
+
+          it 'returns the component uuid' do
+            expect(show_component).to eq(nil)
+          end
+        end
+      end
+
+      context 'when multiple expressions with "AND" statement' do
+        let(:component) { service.find_page_by_url('flavours').components.first }
+
+        context 'when the expressions are met' do
+          let(:user_data) do
+            {
+              'ice-cream_checkboxes_1' => ['Chocolate', 'Mango', 'Hokey Pokey', 'Pistachio']
+            }
+          end
+
+          it 'returns the content component uuid' do
+            expect(show_component).to eq(component.uuid)
+          end
+        end
+
+        context 'when the expressions are not met' do
+          let(:user_data) do
+            {
+              'ice-cream_checkboxes_1' => %w[Chocolate Mango]
+            }
+          end
+
+          it 'returns the content component uuid' do
+            expect(show_component).to eq(nil)
+          end
+        end
+      end
+    end
+
+    context 'when the question is optional' do
+      context 'and the question is unanswered' do
+        let(:component) { service.find_page_by_url('show-colours').components.first }
+        let(:user_data) do
+          {
+            'colours_radios_1' => ''
+          }
+        end
+
+        it 'does not show the conditional component' do
+          expect(show_component).to eq(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -411,4 +411,22 @@ RSpec.describe MetadataPresenter::Page do
       end
     end
   end
+
+  describe '#content_component_present?' do
+    context 'when page contains content components' do
+      let(:page) { service.find_page_by_url('check-answers') }
+
+      it 'should return true' do
+        expect(page.content_component_present?).to be_truthy
+      end
+    end
+
+    context 'when page does not contain content components' do
+      let(:page) { service.find_page_by_url('holiday') }
+
+      it 'should return false' do
+        expect(page.content_component_present?).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Add logic that evaluates content conditionals
This PR adds the logic to evaluate any conditionals injected into a content component.
An example of a simple conditional content component:
```
{
  "_id": "check-answers_content_2",
  "name": "check-answers_content_2",
  "_type": "content",
  "_uuid": "b065ff4f-90c5-4ba2-b4ac-c984a9dd2470",
  "content": "Take the cannoli.",
  "collection": "components",
  "conditionals": [
    {
      "_type": "if",
      "_uuid": "98cfd843-7c02-4534-9055-201487e9be16",
      "expressions": [
        {
          "page": "68fbb180-9a2a-48f6-9da6-545e28b8d35a",
          "field": "c5571937-9388-4411-b5fa-34ddf9bc4ca0",
          "operator": "is",
          "component": "ac41be35-914e-4b22-8683-f5477716b7d4"
        }
      ]
    }
  ]
}
```
We use the existing `Conditional`, `Expression` and `Operator` classes to help with evaluating the content conditionals.
On each page load, we check if there are any content components, and if so, whether there are any conditionals on them. If there are conditionals, we evaluate them by comparing each expression in the conditional with the user's answers. We keep track of the content component uuids associated with any conditions that are met to be shown on the page.

We will always show the content component if: 
- there are no conditionals present on the component
- we are in editor preview mode

The only way a conditional can be injected into a content component will be via the editor, we will add a feature flag to prevent any users from adding conditionals while we actively develop this feature.

### Bump presenter v3.2.1