### PR TITLE
Update header logo to link to GOV.UK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.2.3] - 2023-08-07
+ - Update header logo to link to GOV.UK in response to accessibility audit
+
 ## [3.2.2] - 2023-08-03
 ### Added
 - Updated test app default config to 7.0, deleted settings initialiser. Just part of cleanup after upgrading everything to rails 7.

--- a/app/views/metadata_presenter/header/show.html.erb
+++ b/app/views/metadata_presenter/header/show.html.erb
@@ -3,7 +3,7 @@
 
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
-      <a href="/" class="govuk-header__link govuk-header__link--homepage">
+      <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">
           <svg
             aria-hidden="true"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.2.2'.freeze
+  VERSION = '3.2.3'.freeze
 end


### PR DESCRIPTION
Updates the logo in the header of forms to link to GOV.UK homepage.

This resolves an accessibility issues with duplicate links (the logo and form title linking to the same page?)
But also meets user expectations - it is reasonable to expect that the GOV.UK logo goes to the GOV.UK homepage (as it does everywhere else) and the alt text/label for the logo is "GOV.UK".