### PR TITLE
Resolve per-form CSRF issue when JS disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.2.4] - 2023-08-09
+### Fixed
+ - Manually add in form_authenticity token field into form_for blocks.  This
+     makes the authenticity token valid for when javascript is disabled and
+     rails ujs is not duplicating the csrf meta tag into the form.
+
 ## [3.2.3] - 2023-08-07
  - Update header logo to link to GOV.UK in response to accessibility audit
 

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -9,8 +9,8 @@
         <%= @page.heading %>
       </h1>
 
-      <%= form_for @page, url: reserved_submissions_path, html: { id: 'answers-form' } do |f| %>
-
+      <%= form_for @page, url: reserved_submissions_path, authenticity_token: false, html: { id: 'answers-form' } do |f| %>
+        <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <%= render partial: 'metadata_presenter/component/components',
                    locals: {
                    f: f,

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -17,7 +17,8 @@
         <%= render 'metadata_presenter/attribute/body' %>
       <% end %>
 
-      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
+      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post, authenticity_token: false do |f| %>
+        <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
 
         <%= render partial: 'metadata_presenter/component/components',
                    locals: {

--- a/app/views/metadata_presenter/page/exit.html.erb
+++ b/app/views/metadata_presenter/page/exit.html.erb
@@ -13,7 +13,8 @@
 
       <%= render 'metadata_presenter/attribute/lede' %>
 
-      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
+      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post, authenticity_token: false do |f| %>
+        <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
 
         <%= render partial: 'metadata_presenter/component/components',
                    locals: {

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -5,7 +5,8 @@
       <%= render 'metadata_presenter/attribute/section_heading' %>
       <%= render 'metadata_presenter/attribute/heading' %>
 
-      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
+      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post, authenticity_token: false do |f| %>
+        <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <%= f.govuk_error_summary %>
 
         <%= render partial: 'metadata_presenter/component/components', locals: {

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -4,9 +4,9 @@
 
       <%= render 'metadata_presenter/attribute/section_heading' %>
 
-      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post do |f| %>
+      <%= form_for @page_answers, as: :answers, url: @page.url, method: :post, authenticity_token: false do |f| %>
         <%= f.govuk_error_summary %>
-
+<%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <% @page.components.each_with_index do |component, index| %>
           <div class="fb-editable"
                data-fb-content-type="<%= component._type %>"

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -5,7 +5,8 @@
       <%= render 'metadata_presenter/attribute/heading' %>
       <%= render 'metadata_presenter/attribute/body' %>
 
-      <%= form_tag(root_path, method: :post) do %>
+      <%= form_tag(root_path, method: :post, authenticity_token: false) do %>
+        <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <button <%= 'disabled' if editable? %> class='govuk-button govuk-button--start govuk-!-margin-top-2'>
           <%= t('presenter.actions.start') -%>
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.2.3'.freeze
+  VERSION = '3.2.4'.freeze
 end


### PR DESCRIPTION
## Issue
Without JS (or without rails-ujs being present in the bundle) the runner could not progress through a form.  It would raise `InvalidAuthenticityToken` errors.

## Explanation
Rails has two autheticity tokens, a CSRF token in the meta tags in the head, and then another second token generated for each form based on its action and method.

The JS, takes the first token from the <head> and replaces the per-form token with it, and this works.  (Although presumably losing the security benefits of per-form tokens)

However, with JS disabeld, the forms would submit their own automatically generated authenticity token, which for unknown reasons would be invalid.

## Solution
After a pretty deep dive into the internals of Rails' `request_forgery_protection` module turned up no obvious reasons that the token was invalid. 

The token is generated using the forms action and method parameters, and then on sumission another token is generated server side using the submission params, and they should match, but for some reason they didn't. 

As part of investigating, I manually added an uthenticity token to the form using the `form_authenticity_token` helper method.  This revealed that the autogenerated token and the manually added one were different when they shouldn't have been.  

Removing the autogenerated token, and using only the manually inserted one allowed forms to be successfully submitted without JS.

I don't know **why** this is the case, but it does work, and it solves the problem.

This also means we can probably now remove `@rails/ujs` from the runner JS, as it is not needed, now we no longer need to rely on it for duplicating the CSRF tag.

## Alternative
If we're not happy with this solution due to the uncertainty of why it works, another alternative would be to turn off per-form tokens in Rails, and add a CSP header for `form-action` which would resolve the same security issue by enforcing form actions to be within our domain.

