### PR TITLE
Save and return invalid date fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 ## [3.2.5] - 2023-08-10
+## Fixed
+ - Fixed a bug where saving and returning could cause an error rendering invalid dates
+
+## [3.2.5] - 2023-08-10
 ## Changed
  - Updated copy within timeout modal to ensure that screenreader announcements
      are clear that answers will be deleted

--- a/app/presenters/metadata_presenter/page_answers_presenter.rb
+++ b/app/presenters/metadata_presenter/page_answers_presenter.rb
@@ -71,10 +71,7 @@ module MetadataPresenter
         format: '%d %B %Y'
       )
     rescue Date::Error
-      I18n.l(
-        Date.civil(1900, 1, 1),
-        format: '%d %B %Y'
-      )
+      ''
     end
 
     def textarea(value)

--- a/app/presenters/metadata_presenter/page_answers_presenter.rb
+++ b/app/presenters/metadata_presenter/page_answers_presenter.rb
@@ -70,6 +70,11 @@ module MetadataPresenter
         Date.civil(value.year.to_i, value.month.to_i, value.day.to_i),
         format: '%d %B %Y'
       )
+    rescue Date::Error
+      I18n.l(
+        Date.civil(1900, 1, 1),
+        format: '%d %B %Y'
+      )
     end
 
     def textarea(value)

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.2.5'.freeze
+  VERSION = '3.2.6'.freeze
 end

--- a/spec/presenters/page_answers_presenter_spec.rb
+++ b/spec/presenters/page_answers_presenter_spec.rb
@@ -78,6 +78,21 @@ RSpec.describe MetadataPresenter::PageAnswersPresenter do
           expect(presenter.answer).to eq('')
         end
       end
+
+      # shouldn't happen, but save and return bypasses validation
+      context 'when presenting an invalid date' do
+        let(:answers) do
+          {
+            "#{component.id}(3i)" => '35',
+            "#{component.id}(2i)" => '35',
+            "#{component.id}(1i)" => '2021'
+          }
+        end
+
+        it 'returns empty string' do
+          expect(presenter.answer).to eq('')
+        end
+      end
     end
 
     context 'when component is a checkbox' do


### PR DESCRIPTION
Saving progress skips validation, so if an invalid date is saved it will cause a 500 error when rendering the resume progress page.
This prevents the error with an empty string.