### PR TITLE
Fix content component rendering on check answers page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+
+## [3.2.7] - 2023-08-18
+## Fixed
+ - Fixed a bug where load_conditional_components was returning `nil` causing pages to not render
+
 ## [3.2.5] - 2023-08-10
 ## Fixed
  - Fixed a bug where saving and returning could cause an error rendering invalid dates

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -1,5 +1,5 @@
 <% components.each_with_index do |component, index| %>
-  <% if component.type == 'content' && (component.uuid).in?(load_conditional_content) %>
+  <% if component.type == 'content' %>
     <editable-content id="<%= "page[#{component.collection}[#{index}]]" %>"
                       class="fb-editable govuk-!-margin-top-8"
                       type="<%= component.type %>"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.2.6'.freeze
+  VERSION = '3.2.7'.freeze
 end


### PR DESCRIPTION
### Remove load_conditional_components

This is causing an error to throw as load_conditional_components is nil.
Remove for now as there are no conditional components in the wild.

### Bump to version 3.2.7

Co-authored-by: Steven Leighton <[steven.leighton@digital.justice.gov.uk](mailto:steven.leighton@digital.justice.gov.uk)>