### PR TITLE
Disclaimer risk confirmation email for multiple component pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,24 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.2.9] - 2023-08-24
+### Fixed
+- Disclaimer warning the user of the use of confirmation email is now being shown for multiple component page.
+
 ## [3.2.8] - 2023-08-18
-## Added
+### Added
  - Adding a disclaimer to inform form filler about the use of confirmation email
 
 ## [3.2.7] - 2023-08-18
-## Fixed
+### Fixed
  - Fixed a bug where load_conditional_components was returning `nil` causing pages to not render
 
 ## [3.2.5] - 2023-08-10
-## Fixed
+### Fixed
  - Fixed a bug where saving and returning could cause an error rendering invalid dates
 
 ## [3.2.5] - 2023-08-10
-## Changed
+### Changed
  - Updated copy within timeout modal to ensure that screenreader announcements
      are clear that answers will be deleted
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If it does not exist, we use the current method of parameterizing the `service_n
 
 `confirmation_email` method provides the confirmation email in the Runner or Editor app. For the Runner app confirmation email is being stored in the user data. In the Editor, confirmation email is only stored in session and called during preview.
 
-`is_confirmation_email_question?` method checks whether the page shown is a component used for confirmation email in the Runner or Editor app. For the Editor app confirmation email the component ID will be found in `ServiceConfiguration` table, while from the Runner the component ID is stored in the `ENV['CONFIRMATION_EMAIL_COMPONENT_ID']` variable.
+`is_confirmation_email_question?(component_id)` method checks whether the question shown has the same component_id used for confirmation email in the Runner or Editor app. For the Editor app the component ID used for confirmation email will be found in `ServiceConfiguration` table, while from the Runner it is stored in the `ENV['CONFIRMATION_EMAIL_COMPONENT_ID']` variable.
 ## Generate documentation
 
 Run `rake doc` and open the doc/index.html

--- a/app/views/metadata_presenter/component/_email.html.erb
+++ b/app/views/metadata_presenter/component/_email.html.erb
@@ -10,7 +10,7 @@
     autocomplete: "email"
 %>
 
-<% if is_confirmation_email_question? %>
+<% if is_confirmation_email_question?(component._id) %>
   <div class ="govuk-warning-text">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.2.8'.freeze
+  VERSION = '3.2.9'.freeze
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -64,6 +64,6 @@ class ApplicationController < ActionController::Base
   def confirmation_email; end
   helper_method :confirmation_email
 
-  def is_confirmation_email_question?; end
+  def is_confirmation_email_question?(component_id); end
   helper_method :is_confirmation_email_question?
 end


### PR DESCRIPTION
This is related to the PR to inform a form filler about the risk to provide a confirmation email. This is to fix the issue where the disclaimer is not being displayed for multiple component page.