### PR TITLE
Conditional content deletion prevention additions

### DIFF
--- a/app/models/metadata_presenter/service.rb
+++ b/app/models/metadata_presenter/service.rb
@@ -21,6 +21,14 @@ class MetadataPresenter::Service < MetadataPresenter::Metadata
     branches.map(&:conditionals).flatten
   end
 
+  def content_expressions
+    content_conditionals.flat_map(&:expressions)
+  end
+
+  def content_conditionals
+    pages.flat_map(&:content_components).flat_map(&:conditionals)
+  end
+
   def flow_object(uuid)
     MetadataPresenter::Flow.new(uuid, metadata.flow[uuid])
   rescue StandardError

--- a/fixtures/conditional_content_2.json
+++ b/fixtures/conditional_content_2.json
@@ -1,0 +1,1208 @@
+          {
+  "_id": "service.base",
+  "flow": {
+    "062c7a19-a676-4976-b3a6-8aac3313b963": {
+      "next": {
+        "default": "a8c7e96a-0c81-4202-806a-13a1e17e3618"
+      },
+      "_type": "flow.page"
+    },
+    "0a528350-3fa0-49e5-837e-b82c70991e6e": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "3bb45d12-7625-48a4-8b5f-0340f81f8eae": {
+      "next": {
+        "default": "bb72a6a3-5f75-4874-90c3-ac7a6b83e9e5",
+        "conditionals": [
+          {
+            "next": "bd365ada-2a2a-47b6-a04e-874e300e7b03",
+            "_type": "if",
+            "_uuid": "e73c4413-8b33-4d91-a4c0-d5d7cc47c35a",
+            "expressions": [
+              {
+                "page": "fa925598-c4b9-4494-a42b-01ed5390ad7d",
+                "field": "8a32d8d8-1934-4b53-84bb-e4586c2f0709",
+                "operator": "is",
+                "component": "67e3461a-c5f8-42d3-8239-fb1e8dd2694e"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 2"
+    },
+    "3df5937c-8e6e-4e4e-8108-c3b62ad8c91a": {
+      "next": {
+        "default": "e0188b41-c029-4d50-82c3-c75e6d82634c"
+      },
+      "_type": "flow.page"
+    },
+    "59c0cfa6-5100-478b-8c80-22f1557c3db0": {
+      "next": {
+        "default": "3df5937c-8e6e-4e4e-8108-c3b62ad8c91a",
+        "conditionals": [
+          {
+            "next": "744dd0ec-fc61-4974-a669-9530d4ae9f76",
+            "_type": "if",
+            "_uuid": "a508e355-c9ca-4b18-bad9-1269cdcb436d",
+            "expressions": [
+              {
+                "page": "5da94f10-5824-4739-8fe3-7dc9a4eae727",
+                "field": "4837b9a7-0e1b-459e-83cd-93e8897e3e3a",
+                "operator": "is",
+                "component": "3a774926-249e-4440-8abf-202404ede1a2"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 1"
+    },
+    "5da94f10-5824-4739-8fe3-7dc9a4eae727": {
+      "next": {
+        "default": "59c0cfa6-5100-478b-8c80-22f1557c3db0"
+      },
+      "_type": "flow.page"
+    },
+    "744dd0ec-fc61-4974-a669-9530d4ae9f76": {
+      "next": {
+        "default": "3df5937c-8e6e-4e4e-8108-c3b62ad8c91a"
+      },
+      "_type": "flow.page"
+    },
+    "88ce3bb5-bd9f-493b-85c5-d2e93466415e": {
+      "next": {
+        "default": "bb63913a-90a0-490b-9d55-56f32f4c360b"
+      },
+      "_type": "flow.page"
+    },
+    "8da36bb1-830d-49f3-bd31-a0568dba5490": {
+      "next": {
+        "default": "bb63913a-90a0-490b-9d55-56f32f4c360b"
+      },
+      "_type": "flow.page"
+    },
+    "a8c7e96a-0c81-4202-806a-13a1e17e3618": {
+      "next": {
+        "default": "fa925598-c4b9-4494-a42b-01ed5390ad7d"
+      },
+      "_type": "flow.page"
+    },
+    "bb63913a-90a0-490b-9d55-56f32f4c360b": {
+      "next": {
+        "default": "0a528350-3fa0-49e5-837e-b82c70991e6e"
+      },
+      "_type": "flow.page"
+    },
+    "bb72a6a3-5f75-4874-90c3-ac7a6b83e9e5": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "bd365ada-2a2a-47b6-a04e-874e300e7b03": {
+      "next": {
+        "default": "5da94f10-5824-4739-8fe3-7dc9a4eae727"
+      },
+      "_type": "flow.page"
+    },
+    "e0188b41-c029-4d50-82c3-c75e6d82634c": {
+      "next": {
+        "default": "bb63913a-90a0-490b-9d55-56f32f4c360b",
+        "conditionals": [
+          {
+            "next": "88ce3bb5-bd9f-493b-85c5-d2e93466415e",
+            "_type": "if",
+            "_uuid": "664752f8-0138-43bd-a32b-76c6202f9175",
+            "expressions": [
+              {
+                "page": "3df5937c-8e6e-4e4e-8108-c3b62ad8c91a",
+                "field": "f1443897-cf2f-401b-ac97-41711a8f9388",
+                "operator": "is",
+                "component": "37bc88a2-26c9-42c7-a4b4-3803a4a313a1"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 3"
+    },
+    "fa925598-c4b9-4494-a42b-01ed5390ad7d": {
+      "next": {
+        "default": "3bb45d12-7625-48a4-8b5f-0340f81f8eae"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to apply for a service or contact us about a case.\r\n\r\n## Before you start\r\nYou will need:\r\n\r\n* your 8-digit reference number\r\n* a copy of your photo ID\r\n* something else\r\n\r\nThis form will take around 5 minutes to complete. We will reply within 10 working days.",
+      "_type": "page.start",
+      "_uuid": "062c7a19-a676-4976-b3a6-8aac3313b963",
+      "heading": "Service name goes here",
+      "before_you_start": "## Other ways to get in touch\r\nYou can also apply or contact us about your case by:\r\n\r\n* telephone: 01234 567889\r\n* email: <example.service@justice.gov.uk>\r\n\r\nThis form is also [available in Welsh (Cymraeg)](https://example-service.form.service.justice.gov.uk/)."
+    },
+    {
+      "_id": "page.name",
+      "url": "name",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "a8c7e96a-0c81-4202-806a-13a1e17e3618",
+      "heading": "",
+      "components": [
+        {
+          "_id": "name_text_1",
+          "hint": "",
+          "name": "name_text_1",
+          "_type": "text",
+          "_uuid": "5d77e46c-f9d0-46d1-9246-1ae54219515b",
+          "label": "What is your name?",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.chocolate",
+      "url": "chocolate",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "fa925598-c4b9-4494-a42b-01ed5390ad7d",
+      "heading": "",
+      "components": [
+        {
+          "_id": "chocolate_radios_1",
+          "hint": "",
+          "name": "chocolate_radios_1",
+          "_type": "radios",
+          "_uuid": "67e3461a-c5f8-42d3-8239-fb1e8dd2694e",
+          "items": [
+            {
+              "_id": "chocolate_radios_1_item_1",
+              "hint": "",
+              "name": "chocolate_radios_1",
+              "_type": "radio",
+              "_uuid": "8a32d8d8-1934-4b53-84bb-e4586c2f0709",
+              "label": "yes",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "chocolate_radios_1_item_2",
+              "hint": "",
+              "name": "chocolate_radios_1",
+              "_type": "radio",
+              "_uuid": "bb4d6ee7-c503-48d4-a72d-bc7e39b72573",
+              "label": "no",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "chocolate_radios_1_item_3",
+              "hint": "",
+              "name": "chocolate_radios_1",
+              "_type": "radio",
+              "_uuid": "aa0c6ac9-6c65-466f-9a74-7786ae55655a",
+              "label": "maybe",
+              "value": "value-3",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Do you like chocolate?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.marmite",
+      "url": "marmite",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "bd365ada-2a2a-47b6-a04e-874e300e7b03",
+      "heading": "",
+      "components": [
+        {
+          "_id": "marmite_radios_1",
+          "hint": "",
+          "name": "marmite_radios_1",
+          "_type": "radios",
+          "_uuid": "8bfde8c8-3075-4879-b3b1-aea875915da9",
+          "items": [
+            {
+              "_id": "marmite_radios_1_item_1",
+              "hint": "",
+              "name": "marmite_radios_1",
+              "_type": "radio",
+              "_uuid": "b0cc81fe-06e2-44d0-94a1-37766027b212",
+              "label": "yes",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "marmite_radios_1_item_2",
+              "hint": "",
+              "name": "marmite_radios_1",
+              "_type": "radio",
+              "_uuid": "2383955c-d9d5-4001-8675-fa198aff8622",
+              "label": "no",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "marmite_radios_1_item_3",
+              "hint": "",
+              "name": "marmite_radios_1",
+              "_type": "radio",
+              "_uuid": "797c2262-17bd-4b9d-990a-fee05937875f",
+              "label": "never tried it",
+              "value": "value-3",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Do you like marmite?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.coffee",
+      "url": "coffee",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "5da94f10-5824-4739-8fe3-7dc9a4eae727",
+      "heading": "",
+      "components": [
+        {
+          "_id": "coffee_radios_1",
+          "hint": "",
+          "name": "coffee_radios_1",
+          "_type": "radios",
+          "_uuid": "3a774926-249e-4440-8abf-202404ede1a2",
+          "items": [
+            {
+              "_id": "coffee_radios_1_item_1",
+              "hint": "",
+              "name": "coffee_radios_1",
+              "_type": "radio",
+              "_uuid": "4837b9a7-0e1b-459e-83cd-93e8897e3e3a",
+              "label": "yes",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "coffee_radios_1_item_2",
+              "hint": "",
+              "name": "coffee_radios_1",
+              "_type": "radio",
+              "_uuid": "4360be95-f9fa-4f9c-90a3-ca4b9eba9256",
+              "label": "no",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Do you like coffee?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.multiple",
+      "url": "multiple",
+      "_type": "page.multiplequestions",
+      "_uuid": "3df5937c-8e6e-4e4e-8108-c3b62ad8c91a",
+      "heading": "Mulitple",
+      "components": [
+        {
+          "_id": "multiple_radios_1",
+          "hint": "",
+          "name": "multiple_radios_1",
+          "_type": "radios",
+          "_uuid": "9e898dd1-2811-46b8-8fc2-ccc89e24a187",
+          "items": [
+            {
+              "_id": "multiple_radios_1_item_1",
+              "hint": "",
+              "name": "multiple_radios_1",
+              "_type": "radio",
+              "_uuid": "ce6f0744-4046-4335-a2ef-8bb1153b07a0",
+              "label": "cheddar",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "multiple_radios_1_item_2",
+              "hint": "",
+              "name": "multiple_radios_1",
+              "_type": "radio",
+              "_uuid": "69e84518-369f-434d-a1a0-67d9561939c5",
+              "label": "wensleydale",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "multiple_radios_1_item_3",
+              "hint": "",
+              "name": "multiple_radios_1",
+              "_type": "radio",
+              "_uuid": "fbbe3268-2523-425e-ad25-955114d90021",
+              "label": "brie",
+              "value": "value-3",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "multiple_radios_1_item_4",
+              "hint": "",
+              "name": "multiple_radios_1",
+              "_type": "radio",
+              "_uuid": "72bfcd17-74ab-4a41-a1b2-f2be4da255fe",
+              "label": "stilton",
+              "value": "value-4",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "What is your favourite cheese?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "_id": "multiple_content_1",
+          "name": "multiple_content_1",
+          "_type": "content",
+          "_uuid": "e03e5c74-f719-4310-ab04-0705357cb159",
+          "content": "You said that you liked marmite. ",
+          "display": "conditional",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "ee144540-bd30-493d-8797-bb530f8e05f4",
+              "expressions": [
+                {
+                  "page": "bd365ada-2a2a-47b6-a04e-874e300e7b03",
+                  "field": "b0cc81fe-06e2-44d0-94a1-37766027b212",
+                  "operator": "is",
+                  "component": "8bfde8c8-3075-4879-b3b1-aea875915da9"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "multiple_checkboxes_1",
+          "hint": "",
+          "name": "multiple_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "aa895578-c9fc-48e8-ac71-802d7cf61cca",
+          "items": [
+            {
+              "_id": "multiple_checkboxes_1_item_1",
+              "hint": "",
+              "name": "multiple_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "b4053846-9e8c-4d0f-baae-f88a4a919fdb",
+              "label": "Cheese and onion",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "multiple_checkboxes_1_item_2",
+              "hint": "",
+              "name": "multiple_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "25ee9b2e-da5d-4ccc-ba96-c62e5e3446da",
+              "label": "Prawn cocktail",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "multiple_checkboxes_1_item_3",
+              "hint": "",
+              "name": "multiple_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "c37511ed-d37f-4807-85f1-ff5102a1306d",
+              "label": "Roast chicken",
+              "value": "value-3",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "multiple_checkboxes_1_item_4",
+              "hint": "",
+              "name": "multiple_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "384ff4cb-5efd-4226-9e2a-c5aca77e51af",
+              "label": "Salt and vinegar",
+              "value": "value-4",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "multiple_checkboxes_1_item_5",
+              "hint": "",
+              "name": "multiple_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "551e9363-354d-4bce-8b21-34a1e74e5aaa",
+              "label": "Ready salted",
+              "value": "value-5",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Choose your top 3 crisp flavours",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "_id": "multiple_radios_2",
+          "hint": "",
+          "name": "multiple_radios_2",
+          "_type": "radios",
+          "_uuid": "37bc88a2-26c9-42c7-a4b4-3803a4a313a1",
+          "items": [
+            {
+              "_id": "multiple_radios_2_item_1",
+              "hint": "",
+              "name": "multiple_radios_2",
+              "_type": "radio",
+              "_uuid": "f1443897-cf2f-401b-ac97-41711a8f9388",
+              "label": "Jelly babies",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "multiple_radios_2_item_2",
+              "hint": "",
+              "name": "multiple_radios_2",
+              "_type": "radio",
+              "_uuid": "29f577cc-8dff-4bd3-a5e6-1f06c25d187c",
+              "label": "Pear drops",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "multiple_radios_2_item_3",
+              "hint": "",
+              "name": "multiple_radios_2",
+              "_type": "radio",
+              "_uuid": "80f6fc5f-d141-4810-ab36-dd37b6078837",
+              "label": "Liquorice",
+              "value": "value-3",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Which is the best sweet?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "add_component": "radios",
+      "section_heading": ""
+    },
+    {
+      "_id": "page.conditional-content",
+      "url": "conditional-content",
+      "lede": "",
+      "_type": "page.content",
+      "_uuid": "8da36bb1-830d-49f3-bd31-a0568dba5490",
+      "heading": "Conditional content",
+      "components": [
+        {
+          "_id": "conditional-content_content_1",
+          "name": "conditional-content_content_1",
+          "_type": "content",
+          "_uuid": "fe502342-5396-4d5a-b882-b1e76c3ed462",
+          "content": "You will always see this text",
+          "display": "always",
+          "collection": "components"
+        },
+        {
+          "_id": "conditional-content_content_2",
+          "name": "conditional-content_content_2",
+          "_type": "content",
+          "_uuid": "30933d3f-6fc6-4562-ba0b-9c7fc7bb1f6e",
+          "content": "You will never see this bit of text",
+          "display": "never",
+          "collection": "components",
+          "conditionals": [
+
+          ]
+        },
+        {
+          "_id": "conditional-content_content_3",
+          "name": "conditional-content_content_3",
+          "_type": "content",
+          "_uuid": "65ae10d6-4bdc-459e-93f7-408e2845d073",
+          "content": "You like black coffee",
+          "display": "conditional",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "and",
+              "_uuid": "f907e199-1780-4657-9272-2b1b60a34dd4",
+              "expressions": [
+                {
+                  "page": "5da94f10-5824-4739-8fe3-7dc9a4eae727",
+                  "field": "4837b9a7-0e1b-459e-83cd-93e8897e3e3a",
+                  "operator": "is",
+                  "component": "3a774926-249e-4440-8abf-202404ede1a2"
+                },
+                {
+                  "page": "744dd0ec-fc61-4974-a669-9530d4ae9f76",
+                  "field": "6af85117-2353-436e-9945-b5ac96728240",
+                  "operator": "contains",
+                  "component": "1c3bc32c-46d3-4393-98eb-d35b4de50a4f"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "conditional-content_content_4",
+          "name": "conditional-content_content_4",
+          "_type": "content",
+          "_uuid": "f1df3f4b-f6ab-4c1e-897c-acaf1d79d96e",
+          "content": "You like milky coffee",
+          "display": "conditional",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "and",
+              "_uuid": "c49acc3a-7626-4b62-82e5-138c521ef3d8",
+              "expressions": [
+                {
+                  "page": "5da94f10-5824-4739-8fe3-7dc9a4eae727",
+                  "field": "4837b9a7-0e1b-459e-83cd-93e8897e3e3a",
+                  "operator": "is",
+                  "component": "3a774926-249e-4440-8abf-202404ede1a2"
+                },
+                {
+                  "page": "744dd0ec-fc61-4974-a669-9530d4ae9f76",
+                  "field": "143ccfe3-33e6-4bd9-a548-ae9b42154f62",
+                  "operator": "contains",
+                  "component": "1c3bc32c-46d3-4393-98eb-d35b4de50a4f"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "conditional-content_content_5",
+          "name": "conditional-content_content_5",
+          "_type": "content",
+          "_uuid": "1954627c-1a6f-4cac-b4be-6802561fb81a",
+          "content": "You like sweet coffee",
+          "display": "conditional",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "and",
+              "_uuid": "00c0ec18-62a9-4cdd-98fb-f8aeb311f9d8",
+              "expressions": [
+                {
+                  "page": "5da94f10-5824-4739-8fe3-7dc9a4eae727",
+                  "field": "4837b9a7-0e1b-459e-83cd-93e8897e3e3a",
+                  "operator": "is",
+                  "component": "3a774926-249e-4440-8abf-202404ede1a2"
+                },
+                {
+                  "page": "744dd0ec-fc61-4974-a669-9530d4ae9f76",
+                  "field": "a5a4e3c9-db26-4bb1-823b-088a52d5ff32",
+                  "operator": "contains",
+                  "component": "1c3bc32c-46d3-4393-98eb-d35b4de50a4f"
+                }
+              ]
+            },
+            {
+              "_type": "and",
+              "_uuid": "d6d153ce-b06f-411c-a145-907a0f0ed9b1",
+              "expressions": [
+                {
+                  "page": "5da94f10-5824-4739-8fe3-7dc9a4eae727",
+                  "field": "4837b9a7-0e1b-459e-83cd-93e8897e3e3a",
+                  "operator": "is",
+                  "component": "3a774926-249e-4440-8abf-202404ede1a2"
+                },
+                {
+                  "page": "744dd0ec-fc61-4974-a669-9530d4ae9f76",
+                  "field": "4865a3a4-9531-4070-a99e-eff079596b99",
+                  "operator": "contains",
+                  "component": "1c3bc32c-46d3-4393-98eb-d35b4de50a4f"
+                }
+              ]
+            },
+            {
+              "_type": "and",
+              "_uuid": "7e0c7c5a-8f51-4b25-9097-a54cf7197b10",
+              "expressions": [
+                {
+                  "page": "5da94f10-5824-4739-8fe3-7dc9a4eae727",
+                  "field": "4837b9a7-0e1b-459e-83cd-93e8897e3e3a",
+                  "operator": "is",
+                  "component": "3a774926-249e-4440-8abf-202404ede1a2"
+                },
+                {
+                  "page": "744dd0ec-fc61-4974-a669-9530d4ae9f76",
+                  "field": "3b0f6941-a824-4677-ad14-cbc5a53f788c",
+                  "operator": "contains",
+                  "component": "1c3bc32c-46d3-4393-98eb-d35b4de50a4f"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "conditional-content_content_6",
+          "name": "conditional-content_content_6",
+          "_type": "content",
+          "_uuid": "7cd89b4e-bbb9-4395-a1d3-a64300d3cc85",
+          "content": "You like marmite, but not stilton",
+          "display": "conditional",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "and",
+              "_uuid": "1448a447-3754-4596-a4f1-cbb49b68ef8a",
+              "expressions": [
+                {
+                  "page": "bd365ada-2a2a-47b6-a04e-874e300e7b03",
+                  "field": "b0cc81fe-06e2-44d0-94a1-37766027b212",
+                  "operator": "is",
+                  "component": "8bfde8c8-3075-4879-b3b1-aea875915da9"
+                },
+                {
+                  "page": "3df5937c-8e6e-4e4e-8108-c3b62ad8c91a",
+                  "field": "72bfcd17-74ab-4a41-a1b2-f2be4da255fe",
+                  "operator": "is_not",
+                  "component": "9e898dd1-2811-46b8-8fc2-ccc89e24a187"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "conditional-content_content_7",
+          "name": "conditional-content_content_7",
+          "_type": "content",
+          "_uuid": "6cf9f6ef-450c-43af-8b24-e61bd45a3cbd",
+          "content": "I wonder what happens if you haven't answered the question the conditional content depends upon?  In this case, this content depends on the what do you put on your coffee question.... ",
+          "display": "conditional",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "797be8b3-f756-487b-a975-d7361f748c43",
+              "expressions": [
+                {
+                  "page": "744dd0ec-fc61-4974-a669-9530d4ae9f76",
+                  "field": "143ccfe3-33e6-4bd9-a548-ae9b42154f62",
+                  "operator": "contains",
+                  "component": "1c3bc32c-46d3-4393-98eb-d35b4de50a4f"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "conditional-content_content_8",
+          "name": "conditional-content_content_8",
+          "_type": "content",
+          "_uuid": "b872d971-28eb-4aca-826a-5a44d52cead5",
+          "content": "You either like marmite or brie",
+          "display": "conditional",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "c3b3fd2d-fe70-464d-9cf1-8ea174676aea",
+              "expressions": [
+                {
+                  "page": "bd365ada-2a2a-47b6-a04e-874e300e7b03",
+                  "field": "b0cc81fe-06e2-44d0-94a1-37766027b212",
+                  "operator": "is",
+                  "component": "8bfde8c8-3075-4879-b3b1-aea875915da9"
+                }
+              ]
+            },
+            {
+              "_type": "if",
+              "_uuid": "34923068-c0e9-4f50-a6dc-663a992f71f5",
+              "expressions": [
+                {
+                  "page": "3df5937c-8e6e-4e4e-8108-c3b62ad8c91a",
+                  "field": "fbbe3268-2523-425e-ad25-955114d90021",
+                  "operator": "is",
+                  "component": "9e898dd1-2811-46b8-8fc2-ccc89e24a187"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "add_component": "content",
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "bb63913a-90a0-490b-9d55-56f32f4c360b",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "0a528350-3fa0-49e5-837e-b82c70991e6e",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.coffee-additions",
+      "url": "coffee-additions",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "744dd0ec-fc61-4974-a669-9530d4ae9f76",
+      "heading": "",
+      "components": [
+        {
+          "_id": "coffee-additions_checkboxes_1",
+          "hint": "",
+          "name": "coffee-additions_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "1c3bc32c-46d3-4393-98eb-d35b4de50a4f",
+          "items": [
+            {
+              "_id": "coffee-additions_checkboxes_1_item_1",
+              "hint": "",
+              "name": "coffee-additions_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "6af85117-2353-436e-9945-b5ac96728240",
+              "label": "nothing, I like it black",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "coffee-additions_checkboxes_1_item_2",
+              "hint": "",
+              "name": "coffee-additions_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "143ccfe3-33e6-4bd9-a548-ae9b42154f62",
+              "label": "milk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "coffee-additions_checkboxes_1_item_3",
+              "hint": "",
+              "name": "coffee-additions_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "a5a4e3c9-db26-4bb1-823b-088a52d5ff32",
+              "label": "sugar",
+              "value": "value-3",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "coffee-additions_checkboxes_1_item_4",
+              "hint": "",
+              "name": "coffee-additions_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "4865a3a4-9531-4070-a99e-eff079596b99",
+              "label": "sweetener",
+              "value": "value-4",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "coffee-additions_checkboxes_1_item_5",
+              "hint": "",
+              "name": "coffee-additions_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "3b0f6941-a824-4677-ad14-cbc5a53f788c",
+              "label": "syrup",
+              "value": "value-5",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "What do you put in your coffee?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.bye",
+      "url": "bye",
+      "lede": "Sorry, but we can only accept people who like chocolate.",
+      "_type": "page.exit",
+      "_uuid": "bb72a6a3-5f75-4874-90c3-ac7a6b83e9e5",
+      "heading": "Bye",
+      "components": [
+        {
+          "_id": "bye_content_1",
+          "name": "bye_content_1",
+          "_type": "content",
+          "_uuid": "baac6887-78ac-4bf4-856b-4ebd850c7424",
+          "content": "At least your decisive.  Decisive, but wrong!",
+          "display": "conditional",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "bc8b284b-8d49-4761-8f0b-ac2048de50cb",
+              "expressions": [
+                {
+                  "page": "fa925598-c4b9-4494-a42b-01ed5390ad7d",
+                  "field": "bb4d6ee7-c503-48d4-a72d-bc7e39b72573",
+                  "operator": "is",
+                  "component": "67e3461a-c5f8-42d3-8239-fb1e8dd2694e"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "_id": "bye_content_2",
+          "name": "bye_content_2",
+          "_type": "content",
+          "_uuid": "1ffc91c5-bbe9-45d5-8848-528e567e8d66",
+          "content": "How can you be uncertain?",
+          "display": "conditional",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "4d28592a-24d9-4a9d-b5a7-8b9707aabe5e",
+              "expressions": [
+                {
+                  "page": "fa925598-c4b9-4494-a42b-01ed5390ad7d",
+                  "field": "aa0c6ac9-6c65-466f-9a74-7786ae55655a",
+                  "operator": "is",
+                  "component": "67e3461a-c5f8-42d3-8239-fb1e8dd2694e"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "add_component": "content",
+      "section_heading": ""
+    },
+    {
+      "_id": "page.approval",
+      "url": "approval",
+      "lede": "You have good taste in sweets.",
+      "_type": "page.content",
+      "_uuid": "88ce3bb5-bd9f-493b-85c5-d2e93466415e",
+      "heading": "Good choice",
+      "components": [
+        {
+          "_id": "approval_content_1",
+          "name": "approval_content_1",
+          "_type": "content",
+          "_uuid": "80bc39c5-b7dd-4e45-90d3-e74e74113f81",
+          "content": "Everyone loves jelly babies!",
+          "display": "conditional",
+          "collection": "components",
+          "conditionals": [
+            {
+              "_type": "if",
+              "_uuid": "0e8b3e3b-e480-450a-8898-6e539394e69e",
+              "expressions": [
+                {
+                  "page": "3df5937c-8e6e-4e4e-8108-c3b62ad8c91a",
+                  "field": "f1443897-cf2f-401b-ac97-41711a8f9388",
+                  "operator": "is",
+                  "component": "37bc88a2-26c9-42c7-a4b4-3803a4a313a1"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "add_component": "content",
+      "section_heading": ""
+    }
+  ],
+  "locale": "en",
+  "created_at": "2023-09-28T13:36:34Z",
+  "created_by": "339d8726-a6e7-4084-a3ad-0a8300093c40",
+  "service_id": "c1740b93-b99d-4b91-8ab1-12a508f546d2",
+  "version_id": "d3212816-943b-4d88-b75e-1c63377ba359",
+  "service_name": "Conditional Content Test",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "This form saves small files (known as 'cookies') onto your device.\r\n \r\nCookies are used to:\r\n \r\n* remember your progress\r\n* measure how you use the form so it can be updated and improved based on your needs\r\n \r\nThese cookies are not used to identify you personally.\r\n \r\nYou will normally see a message on the form before we store a cookie on your computer. Essential cookies are necessary for the form to work but you can still complete the form if you choose not to accept analytics cookies.\r\n \r\nFind out more about [how to manage cookies](https://www.aboutcookies.org/).\r\n \r\n## Essential cookies\r\n \r\nEssential cookies are required to make this form work and keep your information secure while you use it.\r\n \r\nWe use the following essential cookies: \r\n \r\n| Name | Purpose | Expires |\r\n|---|---|---|\r\n| \\_fb\\_runner\\_session | Saves your current progress on this computer and tracks inactivity periods | After 30 minutes of inactivity or when you close your browser |\r\n| analytics | Remembers whether you accept or reject analytics cookies on this form | After 1 year |\r\n \r\n## Analytics cookies\r\n \r\nAnalytics cookies collect information about how you use this form. This helps us make sure the form is meeting the needs of its users and to help us make improvements.\r\n \r\nWe use Google Analytics to learn about:\r\n \r\n* the pages you visit\r\n* how long you spend on each page\r\n* how you got to the form\r\n* what you click on while you are using the form\r\n \r\nWe do not collect or store your personal information (for example your name or address) so this information can't be used to identify who you are. We do not allow third parties to use or share our analytics data.\r\n \r\nThis form may use different versions of Google Analytics and could save some or all of the following cookies:\r\n \r\n| Name | Purpose | Expires |\r\n|---|---|---|\r\n| \\_ga | Helps us count how many people visit this form | 2 years |\r\n| \\_gid | Helps us count how many people visit this form | 1 day   |\r\n| \\_ga\\_\\<container-id> | Used to persist session state | 2 years |\r\n| \\_gac\\_gb\\_\\<container-id> | Contains campaign-related information | 90 days |\r\n| \\_gat | Used to throttle request rate | 1 minute |\r\n| \\_dc\\_gtm\\_\\<property-id>| Used to throttle request rate | 1 minute |\r\n| AMP\\_TOKEN | Contains a token that can be used to retrieve a Client ID from AMP Client ID service | 30 seconds to 1 year |\r\n| \\_gac\\_\\<property-id> | Contains campaign related information | 90 days |\r\n \r\nYou can use a browser addon to [opt out of Google Analytics cookies](https://tools.google.com/dlpage/gaoptout) on all websites.",
+      "_type": "page.standalone",
+      "_uuid": "cac8b411-d50d-47b4-ae6d-9009256f249a",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "[[Guidance notes on completing this notice](https://intranet.justice.gov.uk/documents/2018/03/privacy-notice-guidance.pdf) - delete before publishing]\r\n\r\n## [Name of your form or service]\r\n\r\nThe Ministry of Justice (MoJ) is committed to the protection and security of your personal information.\r\n\r\nIt is important that you read this notice so that you are aware of how and why we are using such information. This privacy notice describes how we collect and use personal information during and after your relationship with us, in accordance with data protection law. \r\n\r\n[Insert name – delete if not an EA or ALB] is an Executive Agency/Arm’s Length Body of the MoJ. MoJ is the data controller for the personal data used for the purposes of [Insert overarching purpose].\r\n\r\n### The type of personal data we process\r\n\r\nWe currently collect and use the following information:\r\n\r\n[list the type of personal data used e.g. name, address, contact details etc]\r\n\r\nWe also collect special categories of information, such as [delete this section if not applicable]:\r\n\r\n* race or ethnicity \r\n* political opinions\r\n* religious or philosophical beliefs\r\n* trade union membership\r\n* health, sex life or sexual orientation \r\n* genetics or biometrics\r\n* criminal convictions\r\n\r\n\r\n### How we get your personal data and why we have it\r\n\r\nMost of the personal information we process is provided to us directly by you for one of the following reasons: [List reasons e.g. providing an online service]\r\n\r\nWe also receive personal information indirectly, from the following sources in the following scenarios: [Include details of the source of the personal data unless the data is collected directly from the data subject]\r\n\r\nWe use the personal data we receive in order to: [list how you use the personal data] \r\n\r\nWe may share this information with: [enter organisations or individuals]\r\n\r\nUnder the UK General Data Protection Regulation (UK GDPR), the lawful bases we rely on for processing this information are: [delete as appropriate]\r\n\r\n* Your consent. You may withdraw your consent at any time by contacting [enter contact details].\r\n* We have a contractual obligation.\r\n* We have a legal obligation.\r\n* We have a vital interest.\r\n* We need it to perform a public task.\r\n* We have a legitimate interest.\r\n\r\n[Explain the purpose and lawful basis for processing the personal data you collect. If lawful basis is a legal obligation or public task, explain what this is e.g. refer to legislation or policy.]  \r\n\r\nThe legal bases on which the MoJ processes special categories of information you have provided, is on the basis of: [delete this section if not applicable]\r\n\r\n* Your explicit consent. You may withdraw your consent at any time by contacting [insert contact details].\r\n* The processing being necessary for the MoJ in the field of employment, social security and social protection law.\r\n* The information being manifestly made public by you.\r\n* The processing being necessary for the establishment, exercise or defence of legal claims.\r\n* The substantial public interest in the MoJ [tailor as required and choose relevant [substantial public interest condition](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/special-category-data/what-are-the-substantial-public-interest-conditions/)]. \r\n* The processing is necessary for historical research purposes/statistical purposes.\r\n\r\n### International data transfers\r\n\r\n[Delete one of the following paragraphs as appropriate]\r\n\r\nPersonal data is transferred to [insert name of country] for the purpose of [insert purpose]. This international transfer complies with UK data protection law [delete as appropriate].\r\n\r\n\r\nThere are no international transfers.\r\n\r\n### How we store your personal data\r\n\r\n[set out how long the information is retained, or the criteria used to determine how long the information is retained]\r\n\r\nPersonal data is stored securely and in accordance with our data retention schedule [insert link to the schedule or details of retention periods]. At the end of this period your data is [insert with it is retained as a public record or whether it is disposed of].\r\n\r\n### Your rights\r\n\r\n[This section lists all data subject rights found in the UKGDPR and the Data Protection Act 2018. You should only include those relevant to your lawful basis for processing. [Find out more about which rights apply and when](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/)]\r\n\r\n* Your right of access - You have the right to ask us for copies of your personal information. \r\n* Your right to rectification - You have the right to ask us to rectify personal information you think is inaccurate. You also have the right to ask us to complete information you think is incomplete. \r\n* Your right to erasure - You have the right to ask us to erase your personal information in certain circumstances. \r\n* Your right to restriction of processing - You have the right to ask us to restrict the processing of your personal information in certain circumstances. \r\n* Your right to object to processing - You have the right to object to the processing of your personal information in certain circumstances. \r\n* Your right to data portability - You have the right to ask that we transfer the personal information you gave us to another organisation, or to you, in certain circumstances. \r\n\r\nDepending on the lawful basis on which your personal data is being processed, not all rights will apply.\r\n\r\nYou are not required to pay any charge for exercising your rights. If you make a request, we have one month to respond to you. If you wish to exercise your data protection rights please contact one of these teams.\r\n\r\nIf you have ever been convicted of a criminal offence, contact:\r\n\r\n\r\nBranston Registry<br> \r\nBuilding 16, S & T Store<br> \r\nBurton Road<br>\r\nBranston<br>\r\nBurton-on-Trent<br> \r\nStaffordshire<br>\r\nDE14 3EG\r\nEmail: <data.access1@justice.gov.uk>\r\n\r\nOtherwise, contact:\r\n\r\n\r\nDisclosure Team<br>\r\nPost point 10.38<br>\r\n102 petty France<br>\r\nLondon<br>\r\nSW1H 9AJ\r\nEmail: <data.access@justice.gov.uk> \r\n\r\n### How to complain\r\n\r\nIf you have any concerns about our use of your personal data, you can contact the MoJ data protection officer:\r\n\r\nData Protection Officer<br>\r\nMinistry of Justice<br>\r\n3rd Floor, Post Point 3.20<br>\r\n10 South Colonnades<br>\r\nCanary Wharf<br>\r\nLondon<br>\r\nE14 4PU\r\n\r\nEmail: <dpo@justice.gov.uk> \r\n\r\n\r\nYou can also complain to the Information Commissioner’s Office (ICO) if you are unhappy with how we have used your data:\r\n\r\n\r\nInformation Commissioner’s Office<br>\r\nWycliffe House<br>\r\nWater Lane<br>\r\nWilmslow<br>\r\nCheshire<br>\r\nSK9 5AF\r\n\r\nTelephone: 0303 123 1113<br>\r\n[ICO website](https://www.ico.org.uk)\r\n\r\nDate of last review: [Insert publication or update date]",
+      "_type": "page.standalone",
+      "_uuid": "d57f759a-4123-4ef7-a6db-f2f619a2a52f",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "This accessibility statement applies to [describe your form here - for example, the general enquiries form for the CICA]. There is a separate [accessibility statement for the main GOV.UK website](https://www.gov.uk/help/accessibility-statement).\r\n\r\n### Using this online form\r\n\r\nThis form was built using MoJ Forms, a tool developed by the Ministry of Justice, and uses components from the [GOV.UK Design System](https://design-system.service.gov.uk/).\r\n\r\n[insert your organisation here] is responsible for the content of this online form. The Ministry of Justice is responsible for its technical aspects.\r\n\r\nWe want as many people as possible to be able to use this online form. For example, that means you should be able to:\r\n\r\n- change colours, contrast levels and fonts\r\n- zoom in up to 300% without the text spilling off the screen\r\n- navigate the form using just a keyboard\r\n- navigate the form using speech recognition software\r\n- listen to the form using a screen reader (including recent versions of JAWS, NVDA and VoiceOver)\r\n\r\nWe’ve also made the text as simple as possible to understand.\r\n\r\n[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.\r\n\r\n### Feedback and contact information\r\n\r\nIf you need information on this website in a different format:\r\n\r\n[insert your contact details for user requests here - add other channels, such as text phones or Relay UK, as required]\r\n\r\n- email: [your email address]\r\n- call: [your telephone number]\r\n- [Hours - e.g. Monday to Friday, 9am to 5pm]\r\n\r\nWe'll consider your request and get back to you in [add your SLA - e.g. a week or 5 working days].\r\n\r\n### Reporting accessibility problems with this form\r\n\r\nWe’re always looking to improve the accessibility of this form. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, contact:\r\n\r\n[insert your contact details for user feedback here - add other channels, such as text phones or Relay UK, as required]\r\n\r\n- email: [your email address]\r\n- call: [your telephone number]\r\n- [Hours - e.g. Monday to Friday, 9am to 5pm]\r\n\r\n### Enforcement procedure\r\n\r\nThe Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the [Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).\r\n\r\n### Technical information about this online form’s accessibility\r\n\r\nWe are committed to making our online forms and services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.\r\n\r\n#### Compliance status\r\n\r\nThis online form is fully compliant with the [Web Content Accessibility Guidelines version 2.1 AA standard](https://www.w3.org/TR/WCAG21/)\r\n\r\n### Preparation of this accessibility statement\r\n\r\nThis statement was prepared on [date when it was first published]. It was last reviewed on [date when it was last reviewed].\r\n\r\nThis form was last tested on [date when you performed your basic accessibility check].\r\n\r\nIn order to test the compliance of all forms built using the MoJ Forms tool, the Ministry of Justice commissioned The Digital Accessibility Centre (DAC) to carry out a WCAG 2.1 AA level audit of a sample form. This included extensive testing by users with a wide range of disabilities. The audit was performed on 8 April 2021. The audit highlighted a number of non-compliance issues which were fixed on 11 May 2021.\r\n\r\nIn addition, this form was tested by [insert team or organisation here]. It was tested using the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) following guidance from the Ministry of Justice and the Government Digital Service (GDS).\r\n\r\n### What we’re doing to improve accessibility\r\n\r\nWe will monitor the accessibility of this website on an ongoing basis and fix any accessibility issues reported to us.",
+      "_type": "page.standalone",
+      "_uuid": "9a784d9d-1ade-4e76-a3a6-de459fb9f17f",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}
+        


### PR DESCRIPTION
* Adds in a conditional content fixture to be used by editor tests.
* Adds in `content_expressions` and `content_conditionals` methods to the `service` model - these are used by the deletion prevention checks to check whether pages/questions/options are used in any content expressions across the service.