### PR TITLE
Update json-schema gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 log/*.log
 pkg/
 
-spec/dummy/db/*.sqlite3
-spec/dummy/db/*.sqlite3-journal
+spec/dummy/db/*.sqlite3*
 spec/dummy/db/log/*.log
 spec/dummy/log/*.log
 spec/dummy/tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ All notable changes to this project will be documented in this file.
 ## [3.3.0] - 2023-11-02
 ### Changed
 - Use latest `json-schema` version (4.1.1) which performs (since version 3.0.0) validation of `const` attributes.
+- Removed `_id` const in page schema as pages inherit already an `_id` of type string from `definition.data`
 ### Fixed
 - Attribute `_type` (const) in _radios_, _checkboxes_ and _date_ components was being wrongly validated against a
   duplicated `_type` inherited from `definition.fieldset`. Removed this attribute from the fieldset definition.
-- Attribute `_id` in page schema changed from const to string as it is derived from user input and cannot be a constant.
-- All pages now have this `_id` attribute validated (before only a few pages had this).
+- Added missing `page.exit` to list of allowed types in base schema.
 - Fixed warning "character class has '-' without escape" in a pattern regexp.
 
 ## [3.2.11] - 2023-10-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Attribute `_type` (const) in _radios_, _checkboxes_ and _date_ components was being wrongly validated against a
   duplicated `_type` inherited from `definition.fieldset`. Removed this attribute from the fieldset definition.
+- Attribute `_id` in page schema changed from const to string as it is derived from user input and cannot be a constant.
+- All pages now have this `_id` attribute validated (before only a few pages had this).
 - Fixed warning "character class has '-' without escape" in a pattern regexp.
 
 ## [3.2.11] - 2023-10-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.0] - 2023-11-02
+### Changed
+- Use latest `json-schema` version (4.1.1) which performs (since version 3.0.0) validation of `const` attributes.
+### Fixed
+- Attribute `_type` (const) in _radios_, _checkboxes_ and _date_ components was being wrongly validated against a
+  duplicated `_type` inherited from `definition.fieldset`. Removed this attribute from the fieldset definition.
+- Fixed warning "character class has '-' without escape" in a pattern regexp.
+
 ## [3.2.11] - 2023-10-23
 ### Changed
 - Updated the presenter logic for conditional content 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.2.11'.freeze
+  VERSION = '3.3.0'.freeze
 end

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency 'govuk_design_system_formbuilder', '>= 2.1.5'
-  spec.add_dependency 'json-schema', '2.8.1'
+  spec.add_dependency 'json-schema', '~> 4.1.1'
   spec.add_dependency 'kramdown', '>= 2.4.0'
   spec.add_dependency 'govspeak', '~> 7.1'
   spec.add_dependency 'rails', '>=7.0.0'

--- a/schemas/definition/fieldset.json
+++ b/schemas/definition/fieldset.json
@@ -9,9 +9,6 @@
     "fieldset"
   ],
   "properties": {
-    "_type": {
-      "const": "fieldset"
-    },
     "legend": {
       "title": "Legend",
       "description": "Text to use in fieldset legend",

--- a/schemas/definition/name.json
+++ b/schemas/definition/name.json
@@ -8,7 +8,7 @@
       "title": "Input name",
       "description": "Used by system to identify user's answer - also used as the component's HTML name property.",
       "type": "string",
-      "pattern": "^[a-zA-Z0-9-_]+$",
+      "pattern": "^[a-zA-Z0-9_-]+$",
       "processInput": true,
       "category": [
         "userinput"

--- a/schemas/definition/page.json
+++ b/schemas/definition/page.json
@@ -8,12 +8,6 @@
       "title": "Unique identifier of the page",
       "description": "Used internally in the editor and the runner."
     },
-    "_id": {
-      "title": "Page ID",
-      "description": "A short name in the form of 'page.xyz' derived from user input",
-      "type": "string",
-      "pattern": "^page\\.[a-z0-9._-]+$"
-    },
     "url": {
       "title": "URL",
       "description": "The page’s relative url - it must not contain any spaces",

--- a/schemas/definition/page.json
+++ b/schemas/definition/page.json
@@ -8,6 +8,12 @@
       "title": "Unique identifier of the page",
       "description": "Used internally in the editor and the runner."
     },
+    "_id": {
+      "title": "Page ID",
+      "description": "A short name in the form of 'page.xyz' derived from user input",
+      "type": "string",
+      "pattern": "^page\\.[a-z0-9._-]+$"
+    },
     "url": {
       "title": "URL",
       "description": "The page’s relative url - it must not contain any spaces",

--- a/schemas/page/confirmation.json
+++ b/schemas/page/confirmation.json
@@ -5,9 +5,6 @@
   "description": "Confirm to users that they’ve completed their answers",
   "type": "object",
   "properties": {
-    "_id": {
-      "const": "page.confirmation"
-    },
     "_type": {
       "const": "page.confirmation"
     },

--- a/schemas/page/start.json
+++ b/schemas/page/start.json
@@ -5,9 +5,6 @@
   "description": "Let users start using a service",
   "type": "object",
   "properties": {
-    "_id": {
-      "const": "page.start"
-    },
     "_type": {
       "const": "page.start"
     },

--- a/schemas/service/base.json
+++ b/schemas/service/base.json
@@ -43,6 +43,9 @@
             "$ref": "page.start"
           },
           {
+            "$ref": "page.exit"
+          },
+          {
             "$ref": "page.checkanswers"
           },
           {


### PR DESCRIPTION
Use latest `json-schema` version (4.1.1).

Since version 3.0.0, the gem also performs validation of `const` attributes.

Attribute `_type` (const) in _radios_, _checkboxes_ and _date_ components was being wrongly validated against a
  duplicated `_type` inherited from `definition.fieldset`. Removed this attribute from the fieldset definition.

Added missing `page.exit` to allowed page types in base schema.

Fixed warning "character class has '-' without escape" in a pattern regexp.