### PR TITLE
Change id attribute on content areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.1] - 2023-11-08
+### Changed
+- Updated the id attribute on content areas to enable tehm to be correcly
+focused in the editor
+
 ## [3.3.0] - 2023-11-02
 ### Changed
 - Use latest `json-schema` version (4.1.1) which performs (since version 3.0.0) validation of `const` attributes.
@@ -19,7 +24,7 @@ All notable changes to this project will be documented in this file.
 
 ## [3.2.11] - 2023-10-23
 ### Changed
-- Updated the presenter logic for conditional content 
+- Updated the presenter logic for conditional content
 - Added tests and tests fixtures for unit tests and editor acceptance tests
 
 ## [3.2.10] - 2023-08-24

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -3,7 +3,7 @@
   <% if component.type == 'content' %>
     <% next unless (editable? || @page.show_conditional_component?(component.uuid) || single_page_preview?) %>
 
-    <editable-content id="<%= "page[#{component.collection}[#{index}]]" %>"
+    <editable-content id="<%= component.id %>"
                       class="fb-editable govuk-!-margin-top-8"
                       type="<%= component.type %>"
                       default-content="<%= default_text('content') %>"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.0'.freeze
+  VERSION = '3.3.1'.freeze
 end


### PR DESCRIPTION
This PR changes the `id` attribute of editable content areas.  This matches the same id format used for other components on multiquestion pages.  

This allows the code in the editor that focuses a component after it has been added to the page to work for content areas as well as question components