### PR TITLE
Update seesion reset modal for accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.2] - 2023-11-16
+ - Update the text in the session reset modal to only contain one line in order
+   to pass WCAG accessibility criteria
+
 ## [3.3.1] - 2023-11-08
 ### Changed
 - Updated the id attribute on content areas to enable tehm to be correcly

--- a/app/views/metadata_presenter/session/_timeout_warning_modal.html.erb
+++ b/app/views/metadata_presenter/session/_timeout_warning_modal.html.erb
@@ -5,7 +5,6 @@
      data-minutes-modal-visible="5"
      data-url-redirect="/session/reset"
      data-timer-text="<%= t('presenter.session_timeout_warning.timer') %>"
-     data-timer-extra-text="<%= t('presenter.session_timeout_warning.timer_extra') %>"
      data-timer-redirect-text="<%= t('presenter.session_timeout_warning.redirect') %>">
 
      <div id="timeout-warning-modal"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,9 +22,8 @@ en:
       maintenance_page_content: "If you were in the middle of completing the form, your data has not been saved.\r\n\r\nThe form will be available again from 9am on Monday 19 November 2018.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nContact us if your application is urgent \r\n\r\nEmail:  \r\nTelephone:  \r\nMonday to Friday, 9am to 5pm  \r\n[Find out about call charges](https://www.gov.uk/call-charges)"
     session_timeout_warning:
       heading: Do you need more time?
-      timer: We will reset your form and clear your answers if you do not continue in
-      timer_fallback: We will reset your form if you do not complete the page and press continue by
-      timer_extra:  This is to protect your personal information.
+      timer: We will reset your form and delete your information if you do not continue in
+      timer_fallback: We will reset your form and delete your information if you do not complete the page and press continue by
       redirect: You are about to be redirected
       close_button: Close
       button: Continue

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.1'.freeze
+  VERSION = '3.3.2'.freeze
 end


### PR DESCRIPTION
Small PR to update the session reset modal text contents.  

We've simplified the content into one sentence.  With 2 sentences the second has to be hidden from screenreaders to prevent issues/repeated reading,  however this was raised as a failure in the audit as there is text visible on screen that is inaccessible to the screenreader.

The sinlge sentence conveys all the important information the user needs, and passes WCAG criteria 👍

