### PR TITLE
Mitigate unfiltered params edge case and remove max files in number component

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,5 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - mattempty
-  - chrispymm
-  - H3ll3m4
-  - StevenLeighton21
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.4] - 2023-11-29
+### Fixed
+- Mitigate unfiltered params edge case. Adds logging and avoid user-facing errors.
+- Remove extraneous `max_files` validation in number component. This is only required 
+  in the multi file upload component.
+
 ## [3.3.3] - 2023-11-21
 ### Added
 - Baseline date year upper/lower bound validation to catch obvious typos / fat finger errors.

--- a/app/controllers/metadata_presenter/answers_controller.rb
+++ b/app/controllers/metadata_presenter/answers_controller.rb
@@ -133,7 +133,6 @@ module MetadataPresenter
     end
 
     def answers_params
-      params.permit(:page_slug, :save_for_later)
       params[:answers] ? params[:answers].permit! : {}
     end
 

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -105,13 +105,6 @@ module MetadataPresenter
 
       # uploading a new answer, this method will be called during multiple render operations
       if answers.incoming_answer.is_a?(ActionController::Parameters)
-        # :nocov:
-        unless answers.incoming_answer.permitted?
-          Rails.logger.warn("[PageAnswers#multiupload_answer] Permitting unfiltered params in component `#{component_id}`")
-          answers.incoming_answer.permit!
-        end
-        # :nocov:
-
         answers.incoming_answer[component_id].original_filename = sanitize_filename(answers.incoming_answer[component_id].original_filename)
       end
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.3'.freeze
+  VERSION = '3.3.4'.freeze
 end

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-govuk'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'simplecov-console'
-  spec.add_development_dependency 'site_prism', '4.0'
+  spec.add_development_dependency 'site_prism', '< 5.0'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'yard'
 end

--- a/schemas/validations/validations.json
+++ b/schemas/validations/validations.json
@@ -120,7 +120,7 @@
     },
     "max_files": {
       "title": "Maximum files",
-      "description": "The maximum number of fiels a user can upload",
+      "description": "The maximum number of files a user can upload",
       "type": "number",
       "minimum": 0
     },
@@ -464,9 +464,6 @@
             },
             "exclusive_minimum": {
               "$ref": "#/definitions/exclusive_minimum"
-            },
-            "max_files": {
-              "$ref": "#/definitions/max_files"
             }
           }
         },
@@ -486,9 +483,6 @@
             },
             "exclusive_minimum": {
               "$ref": "#/definitions/errors_exclusive_minimum"
-            },
-            "max_files": {
-              "$ref": "#/definitions/max_files"
             }
           }
         }
@@ -542,7 +536,7 @@
         "errors": {
           "properties": {
             "max_files": {
-              "$ref": "#/definitions/max_files"
+              "$ref": "#/definitions/errors_max_files"
             }
           }
         }

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -188,7 +188,6 @@ RSpec.describe MetadataPresenter::Component do
             maximum
             minimum
             multiple_of
-            max_files
           ]
         end
 


### PR DESCRIPTION
A new gem version release with a couple fixes for:

- Unfiltered params edge case.
- Max files validation showing up in number components. This is only relevant to multi upload components.

More details in the individual commits.

Also reduced dependabot noise by disabling version updates and just leaving security updates.

Closes #336.

**Before**
![Screenshot 2023-11-29 at 13 21 40](https://github.com/ministryofjustice/fb-metadata-presenter/assets/687910/578a4537-505f-4125-8a33-09db3de4b187)

**After**
![Screenshot 2023-11-29 at 13 22 34](https://github.com/ministryofjustice/fb-metadata-presenter/assets/687910/546a396c-8585-4986-93af-9bba4c8c8cf3)
