### PR TITLE
Fix issues with trim_pointers method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.6] - 2023-12-07
+### Fixed
+- Fixed issues with the `trim_pointers` method on the grid. It now runs if there
+are no branches, and correctly trims pointers on the `@ordered` array.
+
 ## [3.3.5] - 2023-12-04
 ### Changed
 - Updated accessibility statement standalone page body.

--- a/app/models/metadata_presenter/grid.rb
+++ b/app/models/metadata_presenter/grid.rb
@@ -112,7 +112,7 @@ module MetadataPresenter
         destinations_count = service.branches.map do |branch|
           exiting_destinations_from_branch(branch).count
         end
-        destinations_count.sum
+        [destinations_count.sum, 1].max # ensure there is always 1 row
       end
     end
 
@@ -294,12 +294,12 @@ module MetadataPresenter
     # Therefore replace any Pointers after the first one with Spacers.
     def trim_to_first_pointer
       max_potential_rows.times do |row|
-        first_index_of = first_pointer(row)
-        next unless first_index_of
+        index_of_first_pointer = first_pointer(row)
+        next unless index_of_first_pointer
 
-        next_column = first_index_of + 1
-        @ordered.drop(next_column).each do |column|
-          column[row] = MetadataPresenter::Spacer.new
+        starting_column = index_of_first_pointer + 1
+        @ordered.drop(starting_column).each.with_index(starting_column) do |_, column_index|
+          @ordered[column_index][row] = MetadataPresenter::Spacer.new
         end
       end
     end

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -44,7 +44,8 @@ module MetadataPresenter
 
       return {} unless file_details
 
-      if file_details.is_a?(ActionController::Parameters)
+      case file_details
+      when ActionController::Parameters
         unless file_details.permitted?
           Rails.logger.warn("[PageAnswers#upload_answer] Permitting unfiltered params in component `#{component_id}`")
           file_details.permit!
@@ -53,7 +54,7 @@ module MetadataPresenter
         file_details.merge(
           'original_filename' => sanitize_filename(file_details['original_filename'])
         )
-      elsif file_details.is_a?(Hash)
+      when Hash
         file_details.merge(
           'original_filename' => sanitize_filename(file_details['original_filename'])
         )

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.5'.freeze
+  VERSION = '3.3.6'.freeze
 end


### PR DESCRIPTION
In attempting to resolve issues with nil pointers in the editor it was found that code attempting to resolve multiple pointers was not working as intended and causing issues. On investigation, it transpired that there was code to do this in the metadata presenter - the `grid` has a `trim pointers` method, but it wasn't functioning as it should. This PR fixes the issues within the `trim_pointers` method.

**Issue 1: max_potential_rows** 
If there are no branches, the method returns `0` this means that no iterations are run within the `trim_pointers` method.  `max_potential_rows` should always return at minimum a value of `1`

**Issue 2: incorrect array modification**
Array.drop returns a new array, so the initial code in `trim_pointers` replaced pointers with spacers in a new array not in the `@ordered` array.

