### PR TITLE
Only update minor versions automatically in presenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 ## [3.3.7] - 2023-12-12
 ### Changed
+- Minor change to pin versions to minor updates
+
+## [3.3.7] - 2023-12-12
+### Changed
 - Minor copy change to the accessibility statement.
 
 ## [3.3.6] - 2023-12-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
-## [3.3.7] - 2023-12-12
+## [3.3.8] - 2023-12-15
 ### Changed
 - Minor change to pin versions to minor updates
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.7'.freeze
+  VERSION = '3.3.8'.freeze
 end

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
     'README.md'
   ]
 
-  spec.add_dependency 'govuk_design_system_formbuilder', '>= 2.1.5'
+  spec.add_dependency 'govuk_design_system_formbuilder', '~> 4.1.1'
   spec.add_dependency 'json-schema', '~> 4.1.1'
-  spec.add_dependency 'kramdown', '>= 2.4.0'
+  spec.add_dependency 'kramdown', '~> 2.4.0'
   spec.add_dependency 'govspeak', '~> 7.1'
-  spec.add_dependency 'rails', '>=7.0.0'
+  spec.add_dependency 'rails', '~> 7.0.0'
   spec.add_dependency 'sassc-rails', '2.1.2'
   spec.add_dependency 'sprockets-rails'
   spec.add_dependency 'sprockets'


### PR DESCRIPTION
Just gives us a bit more control over potentially breaking changes as these get pulled in as dependencies in multiple other components