### PR TITLE
Improve test coverage

### DIFF
--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -8,34 +8,44 @@ module MetadataPresenter
     before_action :show_maintenance_page
 
     def reload_user_data
+      # :nocov:
       if defined? super
         super
+        # :nocov:
       else
         load_user_data
       end
     end
 
     def save_form_progress
+      # :nocov:
       if defined? super
         super
+        # :nocov:
       end
     end
 
     def get_saved_progress(uuid)
+      # :nocov:
       if defined? super
         super(uuid)
+        # :nocov:
       end
     end
 
     def increment_record_counter(uuid)
+      # :nocov:
       if defined? super
         super(uuid)
+        # :nocov:
       end
     end
 
     def invalidate_record(uuid)
+      # :nocov:
       if defined? super
         super(uuid)
+        # :nocov:
       end
     end
 

--- a/app/controllers/metadata_presenter/submissions_controller.rb
+++ b/app/controllers/metadata_presenter/submissions_controller.rb
@@ -33,9 +33,11 @@ module MetadataPresenter
       # So in the Runner we defined the #create_save_and_return_submission in the parent
       # controller and in the Editor we don't.
       #
+      # :nocov:
       if defined?(super)
         super
       end
+      # :nocov:
     end
   end
 end

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -88,12 +88,6 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
     end
   end
 
-  def find_conditional_content_by_uuid(uuid)
-    metadata['conditionals'].select do |conditional|
-      conditional['_uuid'] == uuid
-    end
-  end
-
   private
 
   def validation_bundle_key

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -53,5 +53,11 @@ RSpec.describe MetadataPresenter::AnswersController, type: :controller do
 
       expect(page_answers.uploaded_files.first.errors.first.attribute.to_s).to eq('invalid.multiupload')
     end
+
+    it 'uploads files in the editor preview' do
+      allow(controller).to receive(:editor_preview?).and_return(true)
+      expect_any_instance_of(MetadataPresenter::FileUploader).to receive(:upload).and_return(uploaded_file)
+      controller.upload_multiupload_new_files
+    end
   end
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -326,4 +326,23 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
       end
     end
   end
+
+  describe '#load_autocomplete_items' do
+    let(:page) { MetadataPresenter::Page.new(service.pages.first) }
+    let(:items) { { 'component_id' => [{ 'text' => 'abc', 'value' => '123' }] } }
+    let(:autocomplete_items) { items }
+
+    context 'when there is an autocomplete component on the page' do
+      before do
+        allow(page).to receive(:autocomplete_component_present?).and_return(true)
+        allow(page).to receive(:assign_autocomplete_items)
+        controller.instance_variable_set(:@page, page)
+      end
+
+      it 'load the autocomplete items' do
+        expect(controller).to receive(:autocomplete_items)
+        controller.load_autocomplete_items
+      end
+    end
+  end
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -300,4 +300,30 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
       end
     end
   end
+
+  describe '#answered?' do
+    let(:page) { MetadataPresenter::Page.new(service.pages.first) }
+    let(:component_id) { 'text_text_1' }
+    let(:page_answers) { MetadataPresenter::PageAnswers.new(page, answers) }
+
+    before do
+      controller.instance_variable_set(:@page_answers, page_answers)
+    end
+
+    context 'when component has an answer' do
+      let(:answers) { { component_id => 'pouf' } }
+
+      it 'returns true' do
+        expect(controller.answered?(component_id)).to be_truthy
+      end
+    end
+
+    context 'when component has no answer' do
+      let(:answers) { { component_id => '' } }
+
+      it 'returns false' do
+        expect(controller.answered?(component_id)).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -43,4 +43,54 @@ RSpec.describe MetadataPresenter::PagesController do
       end
     end
   end
+
+  describe '#show_save_and_return' do
+    let(:page) { double(MetadataPresenter::Page) }
+
+    before do
+      allow(page).to receive(:upload_components).and_return(upload_components)
+      controller.instance_variable_set(:@page, page)
+    end
+
+    context 'when there are no upload components' do
+      let(:upload_components) { {} }
+
+      it 'shows save and return' do
+        expect(controller.show_save_and_return).to be_truthy
+      end
+    end
+
+    context 'when there are upload components' do
+      let(:upload_components) { ['A', 'B'] }
+
+      it 'does not show save and return' do
+        expect(controller.show_save_and_return).to be_falsey
+      end
+    end
+  end
+
+  describe '#conditional_components_present?' do
+    let(:page) { double(MetadataPresenter::Page) }
+
+    before do
+      allow(page).to receive(:conditional_components).and_return(conditional_components)
+      controller.instance_variable_set(:@page, page)
+    end
+
+    context 'when there are no conditional components' do
+      let(:conditional_components) { {} }
+
+      it 'checks there are no conditional component' do
+        expect(controller.conditional_components_present?).to be_falsey
+      end
+    end
+
+    context 'when there are upload components' do
+      let(:conditional_components) { ['if', 'or', 'and'] }
+
+      it 'does not show save and return' do
+        expect(controller.conditional_components_present?).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MetadataPresenter::PagesController do
     context 'when page exists' do
       let(:page) { double(MetadataPresenter::Page) }
       let(:template_page) { 'metadata_presenter/page/start' }
-      let(:a_response) { {status: 'OK'} }
+      let(:a_response) { { status: 'OK' } }
 
       before do
         allow(page).to receive(:template).and_return(template_page)
@@ -61,7 +61,7 @@ RSpec.describe MetadataPresenter::PagesController do
     end
 
     context 'when there are upload components' do
-      let(:upload_components) { ['A', 'B'] }
+      let(:upload_components) { %w[A B] }
 
       it 'does not show save and return' do
         expect(controller.show_save_and_return).to be_falsey
@@ -86,7 +86,7 @@ RSpec.describe MetadataPresenter::PagesController do
     end
 
     context 'when there are upload components' do
-      let(:conditional_components) { ['if', 'or', 'and'] }
+      let(:conditional_components) { %w[if or and] }
 
       it 'does not show save and return' do
         expect(controller.conditional_components_present?).to be_truthy

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -10,4 +10,37 @@ RSpec.describe MetadataPresenter::PagesController do
       controller.pages_presenters
     end
   end
+
+  describe '#show' do
+    context 'when page exists' do
+      let(:page) { double(MetadataPresenter::Page) }
+      let(:template_page) { 'metadata_presenter/page/start' }
+      let(:a_response) { {status: 'OK'} }
+
+      before do
+        allow(page).to receive(:template).and_return(template_page)
+        allow(page).to receive(:autocomplete_component_present?).and_return(false)
+        allow(page).to receive(:load_all_content)
+        allow(page).to receive(:load_conditional_content)
+        controller.instance_variable_set(:@page, page)
+        allow_any_instance_of(ActionController::Instrumentation).to receive(:render).and_return(a_response)
+      end
+
+      it 'renders a template with conditional content' do
+        expect(controller).to receive(:render)
+        controller.show
+      end
+    end
+
+    context 'when page does not exist' do
+      before do
+        allow_any_instance_of(MetadataPresenter::Service).to receive(:find_page_by_url).and_return(nil)
+      end
+
+      it 'renders the not found template' do
+        expect(controller).to receive(:not_found)
+        controller.show
+      end
+    end
+  end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe MetadataPresenter::PagesController do
-  describe '#page_answers_presenters' do
+  describe '#page_presenters' do
     let(:user_data) { { 'han' => 'Let the Wookiee win' } }
     before do
       controller.instance_variable_set(:@user_data, user_data)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -247,6 +247,40 @@ RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
         expect(default_item_title(component_type)).to eq('Option')
       end
     end
+  end
 
+  describe '#files_to_render' do
+    let(:page) { OpenStruct.new(components: [component]) }
+    let(:component) do
+      OpenStruct.new({ id: 'upload_multiupload_1', type: 'multiupload', validation: { 'max_files' => '2' } })
+    end
+
+    let(:page_answers) { double(MetadataPresenter::PageAnswers) }
+    let(:uploaded_files) do
+      [
+        {
+          'original_filename' => 'computer_says_no.gif',
+          'content_type' => 'image/gif',
+          'tempfile' => 'filepath'
+        },
+        {
+          'original_filename' => 'diagram.png',
+          'content_type' => 'image/png',
+          'tempfile' => 'another_filepath'
+        }
+      ]
+    end
+    let(:upload_component) { { 'upload_multiupload_1' => uploaded_files } }
+
+    before do
+      allow(page_answers).to receive(:uploaded_files).and_return([])
+      allow(page_answers).to receive(:upload_multiupload_1).and_return(upload_component)
+      controller.instance_variable_set(:@page, page)
+      controller.instance_variable_set(:@page_answers, page_answers)
+    end
+
+    it 'list the files to render' do
+      expect(helper.files_to_render).to eq(uploaded_files)
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -222,4 +222,31 @@ RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
       expect(helper.timeout_fallback(time.to_s)).to eq(time.to_s)
     end
   end
+
+  describe '#default_item_title' do
+    context 'when component is a not a checkbox nor a radio' do
+      let(:component_type) { 'text' }
+
+      it 'returns nil' do
+        expect(default_item_title(component_type)).to be_nil
+      end
+    end
+
+    context 'when component is a checkbox' do
+      let(:component_type) { 'checkboxes' }
+
+      it 'returns Option' do
+        expect(default_item_title(component_type)).to eq('Option')
+      end
+    end
+
+    context 'when component is a radio' do
+      let(:component_type) { 'radios' }
+
+      it 'returns Option' do
+        expect(default_item_title(component_type)).to eq('Option')
+      end
+    end
+
+  end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe MetadataPresenter::Page do
     end
   end
 
-  describe '#load_conditional_content' do
+  describe 'Conditional Content and Components' do
     let(:service_metadata) { metadata_fixture(:conditional_content) }
     let(:page) { service.find_page_by_url('content') }
     let(:user_data) do
@@ -421,18 +421,50 @@ RSpec.describe MetadataPresenter::Page do
         'multiple_checkboxes_1' => %w[2]
       }
     end
-    let(:expected_components) do
-      %w[
-        701f93e3-1d78-4a1f-9495-07e32b6e26fe
-        71bfc176-613d-42ec-8d53-63e50b696ec6
-        61139d00-53eb-4ff3-9227-6ecd0b80aac4
-        4d4d7ace-9ce2-4415-9edb-abcac75ed17b
-        6a3b4104-1d4c-4534-87d8-b81f5c764d43
-      ]
+
+    context '#load_conditional_content' do
+      let(:expected_components) do
+        %w[
+          701f93e3-1d78-4a1f-9495-07e32b6e26fe
+          71bfc176-613d-42ec-8d53-63e50b696ec6
+          61139d00-53eb-4ff3-9227-6ecd0b80aac4
+          4d4d7ace-9ce2-4415-9edb-abcac75ed17b
+          6a3b4104-1d4c-4534-87d8-b81f5c764d43
+        ]
+      end
+
+      before do
+        page.load_conditional_content(service, user_data)
+      end
+
+      it 'should return the right number of always display component' do
+        expect(page.conditional_content_to_show).to eq(expected_components)
+      end
+
+      it 'should show conditional component' do
+        expect(page.show_conditional_component?('701f93e3-1d78-4a1f-9495-07e32b6e26fe')).to be_truthy
+      end
     end
 
-    it 'should return the right number of always display component' do
-      expect(page.load_conditional_content(service, user_data)).to eq(expected_components)
+    context '#conditional_components' do
+      let(:expected_components) do
+        %w[
+          1ed7161c-b712-429c-b647-edd39f71b39f
+          2e8d0ad4-5640-4cd5-815c-4f4116a685d5
+          701f93e3-1d78-4a1f-9495-07e32b6e26fe
+          71bfc176-613d-42ec-8d53-63e50b696ec6
+          37a83516-20c3-4208-ae5f-752038113742
+          5ccc3681-4aa5-447a-8763-6fcdd257bfcc
+          61139d00-53eb-4ff3-9227-6ecd0b80aac4
+          4d4d7ace-9ce2-4415-9edb-abcac75ed17b
+          75fd4dd0-2be1-44d0-9153-d7ec5ceb2a55
+          b23d885d-5326-49f2-b4f4-5ac5d53a03da
+        ]
+      end
+
+      it 'should include the conditional components uuids' do
+        expect(Set.new(page.conditional_components)).to eq(Set.new(expected_components))
+      end
     end
   end
 end


### PR DESCRIPTION
Improving slightly code coverage for the presenter so all looks green. There are still some areas of potential improvements that will need to be looked at.

Before:
<img width="955" alt="Screenshot 2024-01-03 at 15 52 39" src="https://github.com/ministryofjustice/fb-metadata-presenter/assets/26165112/d32c2b46-ada5-4621-b0bb-50cff4286b6c">


After:
<img width="960" alt="Screenshot 2024-01-03 at 15 50 32" src="https://github.com/ministryofjustice/fb-metadata-presenter/assets/26165112/a88382eb-fc6e-4642-a50b-1df3375feee8">

