### PR TITLE
Implement address postcode format validation

### DIFF
--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -176,8 +176,13 @@ module MetadataPresenter
       %w[.jfif .jpg].include?(file_extension)
     end
 
+    # NOTE: Address component is different to other components in the sense it can
+    # produce different validation errors in different fields, and we need to track
+    # those errors between page renders, thus needing memoisation.
     def address_answer(component_id)
-      @address_answer ||= MetadataPresenter::AddressFieldset.new(
+      @address_answer ||= {}
+
+      @address_answer[component_id] ||= MetadataPresenter::AddressFieldset.new(
         answers.fetch(component_id, {})
       )
     end

--- a/app/validators/metadata_presenter/address_validator.rb
+++ b/app/validators/metadata_presenter/address_validator.rb
@@ -16,7 +16,6 @@ module MetadataPresenter
       return true if allow_blank?
 
       validate_required_fields
-      # TODO: validate_postcode
 
       user_answer.errors.empty?
     end

--- a/app/validators/metadata_presenter/postcode_validator.rb
+++ b/app/validators/metadata_presenter/postcode_validator.rb
@@ -1,0 +1,53 @@
+module MetadataPresenter
+  class PostcodeValidator < BaseValidator
+    require 'uk_postcode'
+
+    VALIDATABLE_COUNTRIES = [
+      'UK',
+      'U.K.',
+      'England',
+      'United Kingdom',
+      'Scotland',
+      'Wales',
+      'Cymru',
+      'Channel Islands',
+      'Isle of Man',
+      'Northern Ireland'
+    ].freeze
+
+    def valid?
+      validate_postcode if postcode.present?
+
+      user_answer.errors.empty?
+    end
+
+    private
+
+    def country
+      user_answer.country
+    end
+
+    def postcode
+      user_answer.postcode
+    end
+
+    def parsed_postcode
+      @parsed_postcode ||= UKPostcode.parse(postcode)
+    end
+
+    def valid_postcode?
+      parsed_postcode.full_valid?
+    end
+
+    def validatable_country?
+      VALIDATABLE_COUNTRIES.grep(/\A#{country}\z/i).any?
+    end
+
+    def validate_postcode
+      return if !validatable_country? || valid_postcode?
+
+      page_answers.errors.add([component.id, :postcode].join('.'), default_error_message)
+      user_answer.errors.add(:postcode, default_error_message)
+    end
+  end
+end

--- a/app/views/metadata_presenter/component/_address.html.erb
+++ b/app/views/metadata_presenter/component/_address.html.erb
@@ -1,4 +1,4 @@
-<% hint_id = f.field_id(component.id, [:hint]).tr('_', '-') %>
+<% hint_id = f.field_id(component.id, [:hint]).tr('_', '-') if component.hint.present? %>
 
 <%= f.govuk_fieldset legend: { text: input_title }, described_by: hint_id do %>
   <%= f.fields_for component.id, f.object.send(component.id) do |a| %>

--- a/app/views/metadata_presenter/component/_address.html.erb
+++ b/app/views/metadata_presenter/component/_address.html.erb
@@ -11,36 +11,36 @@
     <%=
       a.govuk_text_field :address_line_one,
                          label: { text: MetadataPresenter::AddressFieldset.human_attribute_name('address_line_one') },
-                         autocorrect: 'off'
+                         autocorrect: 'off', autocomplete: 'address-line1'
     %>
     <%=
       a.govuk_text_field :address_line_two,
                          label: { text: MetadataPresenter::AddressFieldset.human_attribute_name('address_line_two') },
-                         autocorrect: 'off'
+                         autocorrect: 'off', autocomplete: 'address-line2'
     %>
     <%=
       a.govuk_text_field :city,
                          label: { text: MetadataPresenter::AddressFieldset.human_attribute_name('city') },
                          width: 'two-thirds',
-                         autocorrect: 'off'
+                         autocorrect: 'off', autocomplete: 'address-level2'
     %>
     <%=
       a.govuk_text_field :county,
                          label: { text: MetadataPresenter::AddressFieldset.human_attribute_name('county') },
                          width: 'two-thirds',
-                         autocorrect: 'off'
+                         autocorrect: 'off', autocomplete: 'address-level1'
     %>
     <%=
       a.govuk_text_field :postcode,
                          label: { text: MetadataPresenter::AddressFieldset.human_attribute_name('postcode') },
                          width: 'one-quarter',
-                         autocorrect: 'off'
+                         autocorrect: 'off', autocomplete: 'postal-code'
     %>
     <%=
       a.govuk_text_field :country,
                          label: { text: MetadataPresenter::AddressFieldset.human_attribute_name('country') },
                          width: 'one-quarter',
-                         autocorrect: 'off'
+                         autocorrect: 'off', autocomplete: 'country-name'
     %>
   <% end %>
 <% end %>

--- a/app/views/metadata_presenter/component/_address.html.erb
+++ b/app/views/metadata_presenter/component/_address.html.erb
@@ -1,5 +1,13 @@
-<%= f.govuk_fieldset legend: { text: input_title } do %>
+<% hint_id = f.field_id(component.id, [:hint]).tr('_', '-') %>
+
+<%= f.govuk_fieldset legend: { text: input_title }, described_by: hint_id do %>
   <%= f.fields_for component.id, f.object.send(component.id) do |a| %>
+    <% if component.hint.present? %>
+      <div class="govuk-hint govuk-!-margin-bottom-6" id="<%= hint_id %>" data-fb-default-text="<%= default_text('hint') %>">
+        <%= component.hint %>
+      </div>
+    <% end %>
+
     <%=
       a.govuk_text_field :address_line_one,
                          label: { text: MetadataPresenter::AddressFieldset.human_attribute_name('address_line_one') },

--- a/config/initializers/supported_components.rb
+++ b/config/initializers/supported_components.rb
@@ -17,11 +17,11 @@ Rails.application.config.supported_components =
       content: %w(content)
     },
     multiplequestions: {
-      input: %w(text textarea email number date radios checkboxes address),
+      input: %w(text textarea email number date address radios checkboxes),
       content: %w(content)
     },
     singlequestion: {
-      input: %w(text textarea number date radios checkboxes email upload multiupload autocomplete address),
+      input: %w(text textarea number date address radios checkboxes email upload multiupload autocomplete),
       content: %w()
      }
   })

--- a/default_metadata/component/address.json
+++ b/default_metadata/component/address.json
@@ -7,6 +7,7 @@
   "name": "component-name",
   "validation": {
     "required": true,
-    "address": true
+    "address": true,
+    "postcode": true
   }
 }

--- a/default_metadata/component/address.json
+++ b/default_metadata/component/address.json
@@ -2,7 +2,7 @@
   "_id": "component.address",
   "_type": "address",
   "errors": {},
-  "label": "Address question",
+  "legend": "Address question",
   "hint": "",
   "name": "component-name",
   "validation": {

--- a/default_metadata/string/error.postcode.json
+++ b/default_metadata/string/error.postcode.json
@@ -1,0 +1,6 @@
+{
+  "_id": "error.postcode",
+  "_type": "string.error",
+  "description": "Postcode format is not valid",
+  "value": "Enter a full UK postcode for \"%{control}\""
+}

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -696,14 +696,13 @@
           "name": "postal-address_address_1",
           "_type": "address",
           "_uuid": "f72db038-d1cd-4c0d-baea-570b3e4863f5",
-          "label": "Address question",
-          "errors": {
-          },
+          "errors": {},
           "legend": "Confirm your postal address",
           "collection": "components",
           "validation": {
             "address": true,
-            "required": true
+            "required": true,
+            "postcode": true
           }
         }
       ],

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sassc-rails', '2.1.2'
   spec.add_dependency 'sprockets-rails'
   spec.add_dependency 'sprockets'
+  spec.add_dependency 'uk_postcode'
 
 
   spec.add_development_dependency 'better_errors'

--- a/spec/validators/address_validator_spec.rb
+++ b/spec/validators/address_validator_spec.rb
@@ -7,27 +7,27 @@ RSpec.describe MetadataPresenter::AddressValidator do
   let(:component) { page.components.first }
   let(:page_answers) { MetadataPresenter::PageAnswers.new(page, answers) }
 
+  let(:address_line_one) { 'most beautiful road' }
+  let(:address_line_two) { 'of the most beautiful hamlet' }
+  let(:city) { 'far far from the city' }
+  let(:county) { 'in a far far away county' }
+  let(:postcode) { '999' }
+  let(:country) { 'Great country' }
+
+  let(:answers) do
+    {
+      component.id => {
+        address_line_one:,
+        address_line_two:,
+        city:,
+        county:,
+        postcode:,
+        country:
+      }.stringify_keys
+    }
+  end
+
   describe '#valid?' do
-    let(:address_line_one) { 'most beautiful road' }
-    let(:address_line_two) { 'of the most beautiful hamlet' }
-    let(:city) { 'far far from the city' }
-    let(:county) { 'in a far far away county' }
-    let(:postcode) { '999' }
-    let(:country) { 'Great country' }
-
-    let(:answers) do
-      {
-        component.id => {
-          address_line_one:,
-          address_line_two:,
-          city:,
-          county:,
-          postcode:,
-          country:
-        }.stringify_keys
-      }
-    end
-
     context 'when address fields are all filled properly' do
       it { expect(validator).to be_valid }
     end
@@ -48,6 +48,27 @@ RSpec.describe MetadataPresenter::AddressValidator do
           it { expect(validator).to be_valid }
         end
       end
+    end
+  end
+
+  context 'error messages' do
+    let(:postcode) { '' }
+    let(:expected_error) { 'Enter an answer for "Postcode" of "Address question"' }
+
+    before do
+      validator.valid?
+    end
+
+    it 'adds an error to the page answers' do
+      expect(
+        page_answers.errors[:'postal-address_address_1.postcode']
+      ).to include(expected_error)
+    end
+
+    it 'adds an error to user answer' do
+      expect(
+        subject.user_answer.errors[:postcode]
+      ).to include(expected_error)
     end
   end
 end

--- a/spec/validators/address_validator_spec.rb
+++ b/spec/validators/address_validator_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe MetadataPresenter::AddressValidator do
 
   context 'error messages' do
     let(:postcode) { '' }
-    let(:expected_error) { 'Enter an answer for "Postcode" of "Address question"' }
+    let(:expected_error) { 'Enter an answer for "Postcode" of "Confirm your postal address"' }
 
     before do
       validator.valid?

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe MetadataPresenter::PostcodeValidator do
+  subject(:validator) do
+    described_class.new(page_answers:, component:)
+  end
+
+  let(:page) { service.find_page_by_url('/postal-address') }
+  let(:component) { page.components.first }
+  let(:page_answers) { MetadataPresenter::PageAnswers.new(page, answers) }
+
+  let(:postcode) { 'SW1H 9EA' }
+  let(:country) { 'United Kingdom' }
+
+  let(:answers) do
+    {
+      component.id => {
+        postcode:,
+        country:
+      }.stringify_keys
+    }
+  end
+
+  describe '#valid?' do
+    context 'when postcode is not entered' do
+      let(:postcode) { '' }
+
+      it { expect(validator).to be_valid }
+    end
+
+    context 'when country is not one of the validatable countries' do
+      let(:country) { 'Denmark' }
+
+      it { expect(validator).to be_valid }
+    end
+
+    context 'when country is one of the validatable countries' do
+      context 'when postcode is in a valid format' do
+        it { expect(validator).to be_valid }
+      end
+
+      context 'when country is lowercase but validatable, it still triggers validation' do
+        let(:country) { 'uk' }
+        let(:postcode) { 'XY1 2EN' } # invalid postcode
+
+        it { expect(validator).not_to be_valid }
+      end
+
+      context 'when postcode is not in a valid format' do
+        let(:postcode) { 'XY1 2EN' } # invalid postcode
+
+        it { expect(validator).not_to be_valid }
+      end
+    end
+  end
+
+  context 'error messages' do
+    let(:postcode) { 'XY1 2EN' } # invalid postcode
+    let(:expected_error) { 'Enter a full UK postcode for "Address question"' }
+
+    before do
+      validator.valid?
+    end
+
+    it 'adds an error to the page answers' do
+      expect(
+        page_answers.errors[:'postal-address_address_1.postcode']
+      ).to include(expected_error)
+    end
+
+    it 'adds an error to user answer' do
+      expect(
+        subject.user_answer.errors[:postcode]
+      ).to include(expected_error)
+    end
+  end
+end

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe MetadataPresenter::PostcodeValidator do
 
   context 'error messages' do
     let(:postcode) { 'XY1 2EN' } # invalid postcode
-    let(:expected_error) { 'Enter a full UK postcode for "Address question"' }
+    let(:expected_error) { 'Enter a full UK postcode for "Confirm your postal address"' }
 
     before do
       validator.valid?


### PR DESCRIPTION
First pass on a postcode format validator to complement the address mandatory fields validator.

It uses a gem. There's a distinction between validity and existence. The gem validates the format of a postcode, but not whether it actually refers to a location.