### PR TITLE
New gem version with address component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.9] - 2024-01-23
+### Added
+- Address component release.
+
 ## [3.3.8] - 2023-12-15
 ### Changed
 - Minor change to pin versions to minor updates

--- a/app/models/metadata_presenter/address_fieldset.rb
+++ b/app/models/metadata_presenter/address_fieldset.rb
@@ -20,7 +20,7 @@ module MetadataPresenter
       FIELDS.each do |field|
         next unless address[field]
 
-        instance_variable_set(:"@#{field}", sanitize(address[field]))
+        instance_variable_set(:"@#{field}", conform(address[field]))
       end
 
       @country ||= DEFAULT_COUNTRY
@@ -28,6 +28,10 @@ module MetadataPresenter
 
     def to_a
       instance_values.values_at(*FIELDS).compact_blank
+    end
+
+    def conform(address_field)
+      sanitize(address_field, tags: [], attributes: []).strip
     end
   end
 end

--- a/app/validators/metadata_presenter/address_validator.rb
+++ b/app/validators/metadata_presenter/address_validator.rb
@@ -40,7 +40,7 @@ module MetadataPresenter
     end
 
     def translated_field(field)
-      MetadataPresenter::AddressFieldset.human_attribute_name(field)
+      MetadataPresenter::AddressFieldset.human_attribute_name(field).downcase
     end
   end
 end

--- a/default_metadata/string/error.address.json
+++ b/default_metadata/string/error.address.json
@@ -2,5 +2,5 @@
   "_id": "error.address",
   "_type": "string.error",
   "description": "Input (address) is blank",
-  "value": "Enter a \"%{field}\" for \"%{control}\""
+  "value": "Enter %{field} for \"%{control}\""
 }

--- a/default_metadata/string/error.address.json
+++ b/default_metadata/string/error.address.json
@@ -2,5 +2,5 @@
   "_id": "error.address",
   "_type": "string.error",
   "description": "Input (address) is blank",
-  "value": "Enter an answer for \"%{field}\" of \"%{control}\""
+  "value": "Enter a \"%{field}\" for \"%{control}\""
 }

--- a/default_metadata/string/error.postcode.json
+++ b/default_metadata/string/error.postcode.json
@@ -2,5 +2,5 @@
   "_id": "error.postcode",
   "_type": "string.error",
   "description": "Postcode format is not valid",
-  "value": "Enter a full UK postcode for \"%{control}\""
+  "value": "Enter a valid UK postcode for \"%{control}\""
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.8'.freeze
+  VERSION = '3.3.9'.freeze
 end

--- a/spec/models/address_fieldset_spec.rb
+++ b/spec/models/address_fieldset_spec.rb
@@ -18,6 +18,25 @@ RSpec.describe MetadataPresenter::AddressFieldset do
         expect(subject.country).to eq(described_class::DEFAULT_COUNTRY)
       end
     end
+
+    context 'sanitize and strip spaces from fields' do
+      let(:metadata) do
+        super().merge(
+          {
+            'city' => "<div> some tag <img src='test.jpg'>",
+            'country' => '  UK   '
+          }
+        )
+      end
+
+      it 'removes the tags' do
+        expect(subject.city).to eq('some tag')
+      end
+
+      it 'removes leading and trailing spaces' do
+        expect(subject.country).to eq('UK')
+      end
+    end
   end
 
   describe '#to_a' do

--- a/spec/validators/address_validator_spec.rb
+++ b/spec/validators/address_validator_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe MetadataPresenter::AddressValidator do
 
   context 'error messages' do
     let(:postcode) { '' }
-    let(:expected_error) { 'Enter a "Postcode" for "Confirm your postal address"' }
+    let(:expected_error) { 'Enter postcode for "Confirm your postal address"' }
 
     before do
       validator.valid?

--- a/spec/validators/address_validator_spec.rb
+++ b/spec/validators/address_validator_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe MetadataPresenter::AddressValidator do
 
   context 'error messages' do
     let(:postcode) { '' }
-    let(:expected_error) { 'Enter an answer for "Postcode" of "Confirm your postal address"' }
+    let(:expected_error) { 'Enter a "Postcode" for "Confirm your postal address"' }
 
     before do
       validator.valid?

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe MetadataPresenter::PostcodeValidator do
 
   context 'error messages' do
     let(:postcode) { 'XY1 2EN' } # invalid postcode
-    let(:expected_error) { 'Enter a full UK postcode for "Confirm your postal address"' }
+    let(:expected_error) { 'Enter a valid UK postcode for "Confirm your postal address"' }
 
     before do
       validator.valid?


### PR DESCRIPTION
This PR bumps the version of the gem in preparation for release of the address component.

The new version will be able to be used in editor and runner safely, as address component will be put behind a feature flag on the editor for the time being until we are ready to release.

This PR also includes a few minor tweaks raised as part of the QA testing.