### PR TITLE
Support localised error messages

### DIFF
--- a/app/models/metadata_presenter/saved_form.rb
+++ b/app/models/metadata_presenter/saved_form.rb
@@ -21,9 +21,8 @@ module MetadataPresenter
                   :created_at,
                   :updated_at
 
-    validates :secret_question, :secret_answer, :page_slug, :service_version, :user_id, :user_token, presence: { message: 'Enter an answer for "%{attribute}"' }, allow_blank: false
-
-    def initialize; end
+    validates :secret_question, :secret_answer, :page_slug, :service_version, :user_id, :user_token,
+              presence: true, allow_blank: false
 
     def populate_param_values(params)
       self.email           = params['email']

--- a/app/validators/metadata_presenter/base_validator.rb
+++ b/app/validators/metadata_presenter/base_validator.rb
@@ -68,7 +68,7 @@ module MetadataPresenter
 
     # The default error message will be look using the schema key.
     # Assuming the schema key is 'grogu' then the default message
-    # will look for 'error.grogu.value'.
+    # will look for 'error.grogu.value:en' or 'error.grogu.value:cy'.
     #
     # @return [String] returns the default error message
     # @raise [MetadataPresenter::NoDefaultMessage] raises no default message if
@@ -80,9 +80,9 @@ module MetadataPresenter
                              .default_metadata[default_error_message_key]
 
       if default_message.present?
-        default_message['value'] % error_message_hash.merge(params)
+        default_message[error_key] % error_message_hash.merge(params)
       else
-        raise NoDefaultMessage, "No default message found for key '#{default_error_message_key}'."
+        raise NoDefaultMessage, "No default '#{error_key}' message found for key '#{default_error_message_key}'."
       end
     end
 
@@ -104,6 +104,16 @@ module MetadataPresenter
     #
     def schema_key
       @schema_key ||= self.class.name.demodulize.gsub('Validator', '').underscore
+    end
+
+    # The key to use when retrieving localised error messages.
+    # This key will be `value:locale` i.e. `value:en` for English or
+    # `value:cy` for Welsh.
+    #
+    # @return [String] value key to be looked in the default error metadata
+    #
+    def error_key
+      @error_key ||= ['value', I18n.locale].join(':').freeze
     end
 
     # Error message hash that will be interpolate with the custom message or

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -12,7 +12,7 @@
 
       <%= form_for @page_answers, as: :answers, url: @page.url, method: :post, authenticity_token: false do |f| %>
         <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
-        <%= f.govuk_error_summary %>
+        <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
 
         <%= render partial: 'metadata_presenter/component/components', locals: {
             f: f,

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -9,7 +9,7 @@
       <%= render 'metadata_presenter/attribute/section_heading' %>
 
       <%= form_for @page_answers, as: :answers, url: @page.url, method: :post, authenticity_token: false do |f| %>
-        <%= f.govuk_error_summary %>
+        <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
 <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <% @page.components.each_with_index do |component, index| %>
           <div class="fb-editable"

--- a/app/views/metadata_presenter/save_and_return/email_confirmation.html.erb
+++ b/app/views/metadata_presenter/save_and_return/email_confirmation.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-grid-column-two-thirds">
       <a class="govuk-back-link" href="<%= :back %>"><%= t('presenter.back') %></a>
       <%= form_for @email_confirmation do |f| %>
-        <%= f.govuk_error_summary %>
+        <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
         <div class="govuk-form-group">
           <%=
           f.govuk_email_field :email_confirmation,

--- a/app/views/metadata_presenter/save_and_return/return.html.erb
+++ b/app/views/metadata_presenter/save_and_return/return.html.erb
@@ -4,7 +4,7 @@
     <h1 id="page-heading" class="govuk-heading-xl"><%= t('presenter.save_and_return.resume.heading', service_name: get_service_name) %></h1>
     <p><%= t('presenter.save_and_return.resume.content') %></p>
     <%= form_for @resume_form do |f| %>
-      <%= f.govuk_error_summary %>
+      <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
       <%= f.hidden_field(:uuid, value: get_uuid) %>
       <div class="govuk-form-group">
       <%=

--- a/app/views/metadata_presenter/save_and_return/show.html.erb
+++ b/app/views/metadata_presenter/save_and_return/show.html.erb
@@ -5,7 +5,7 @@
     <p class="mojf-settings-screen__description"><%= t('presenter.save_and_return.show.description') %></p>
 
       <%= form_for @saved_form do |f| %>
-        <%= f.govuk_error_summary %>
+        <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
         <div class="govuk-form-group">
         <%= f.hidden_field(:page_slug, value: page_slug) %>
           <%=

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -16,6 +16,8 @@ cy:
       submit: (cy) Submit
       upload_options: (cy) Upload options
       change_html: (cy) Change <span class="govuk-visually-hidden">your answer for %{question}</span>
+    errors:
+      summary_heading: Mae yna broblem
     notification_banners:
       important: (cy) Important
       warning: (cy) Warning
@@ -159,7 +161,13 @@ cy:
         meta--link--3: Hygyrchedd
 
   activemodel:
+    errors:
+      messages:
+        blank: 'Rhowch ateb i "%{attribute}"'
     attributes:
+      metadata_presenter/saved_form:
+        secret_question: (cy) Secret question
+        secret_answer: (cy) Secret answer
       metadata_presenter/address_fieldset:
         address_line_one: (cy) Address line 1
         address_line_two: (cy) Address line 2 (optional)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,8 @@ en:
       submit: Submit
       upload_options: Upload options
       change_html: Change <span class="govuk-visually-hidden">your answer for %{question}</span>
+    errors:
+      summary_heading: There is a problem
     notification_banners:
       important: Important
       warning: Warning
@@ -189,7 +191,13 @@ en:
         except where otherwise stated
 
   activemodel:
+    errors:
+      messages:
+        blank: 'Enter an answer for "%{attribute}"'
     attributes:
+      metadata_presenter/saved_form:
+        secret_question: Secret question
+        secret_answer: Secret answer
       metadata_presenter/address_fieldset:
         address_line_one: Address line 1
         address_line_two: Address line 2 (optional)

--- a/default_metadata/string/error.accept.json
+++ b/default_metadata/string/error.accept.json
@@ -2,5 +2,6 @@
   "_id": "error.accept",
   "_type": "string.error",
   "description": "File uploaded is wrong type",
-  "value": "\"%{control}\" was not uploaded successfully as it is the wrong type"
+  "value:en": "\"%{control}\" was not uploaded successfully as it is the wrong type",
+  "value:cy": "(cy) \"%{control}\" was not uploaded successfully as it is the wrong type"
 }

--- a/default_metadata/string/error.address.json
+++ b/default_metadata/string/error.address.json
@@ -2,5 +2,6 @@
   "_id": "error.address",
   "_type": "string.error",
   "description": "Input (address) is blank",
-  "value": "Enter %{field} for \"%{control}\""
+  "value:en": "Enter %{field} for \"%{control}\"",
+  "value:cy": "(cy) Enter %{field} for \"%{control}\""
 }

--- a/default_metadata/string/error.autocomplete.json
+++ b/default_metadata/string/error.autocomplete.json
@@ -2,5 +2,6 @@
   "_id": "error.autocomplete",
   "_type": "string.error",
   "description": "Autocomplete item is not on the list",
-  "value": "Select an option from the list"
+  "value:en": "Select an option from the list",
+  "value:cy": "(cy) Select an option from the list"
 }

--- a/default_metadata/string/error.catch_all.json
+++ b/default_metadata/string/error.catch_all.json
@@ -2,5 +2,6 @@
   "_id": "error.catch_all",
   "_type": "string.error",
   "description": "A generic validation error not handled by a more concrete validator",
-  "value": "We could not save your answer, please try again"
+  "value:en": "We could not save your answer, please try again",
+  "value:cy": "(cy) We could not save your answer, please try again"
 }

--- a/default_metadata/string/error.date.json
+++ b/default_metadata/string/error.date.json
@@ -2,5 +2,6 @@
   "_id": "error.date",
   "_type": "string.error",
   "description": "Input (date) is not a valid date",
-  "value": "Enter a valid date for \"%{control}\""
+  "value:en": "Enter a valid date for \"%{control}\"",
+  "value:cy": "(cy) Enter a valid date for \"%{control}\""
 }

--- a/default_metadata/string/error.date_after.json
+++ b/default_metadata/string/error.date_after.json
@@ -2,5 +2,6 @@
   "_id": "error.date_after",
   "_type": "string.error",
   "description": "Input (date) is earlier than allowed",
-  "value": "Your answer for \"%{control}\" must be %{date_after} or later"
+  "value:en": "Your answer for \"%{control}\" must be %{date_after} or later",
+  "value:cy": "(cy) Your answer for \"%{control}\" must be %{date_after} or later"
 }

--- a/default_metadata/string/error.date_before.json
+++ b/default_metadata/string/error.date_before.json
@@ -2,5 +2,6 @@
   "_id": "error.date_before",
   "_type": "string.error",
   "description": "Input (date) is later than allowed",
-  "value": "Your answer for \"%{control}\" must be %{date_before} or earlier"
+  "value:en": "Your answer for \"%{control}\" must be %{date_before} or earlier",
+  "value:cy": "(cy) Your answer for \"%{control}\" must be %{date_before} or earlier"
 }

--- a/default_metadata/string/error.email.json
+++ b/default_metadata/string/error.email.json
@@ -2,5 +2,6 @@
   "_id": "error.email",
   "_type": "string.error",
   "description": "Input (email) is not a valid email",
-  "value": "Enter an email address in the correct format, like name@example.com"
+  "value:en": "Enter an email address in the correct format, like name@example.com",
+  "value:cy": "(cy) Enter an email address in the correct format, like name@example.com"
 }

--- a/default_metadata/string/error.max_files.json
+++ b/default_metadata/string/error.max_files.json
@@ -2,5 +2,6 @@
   "_id": "error.max_files",
   "_type": "string.error",
   "description": "Input (number) is larger than the maximum allowed",
-  "value": "Your answer for \"%{control}\" must be %{maximum} or lower"
+  "value:en": "Your answer for \"%{control}\" must be %{maximum} or lower",
+  "value:cy": "(cy) Your answer for \"%{control}\" must be %{maximum} or lower"
 }

--- a/default_metadata/string/error.max_length.json
+++ b/default_metadata/string/error.max_length.json
@@ -2,5 +2,6 @@
   "_id": "error.max_length",
   "_type": "string.error",
   "description": "Input (string) is too long",
-  "value": "Your answer for \"%{control}\" must be %{max_length} characters or fewer"
+  "value:en": "Your answer for \"%{control}\" must be %{max_length} characters or fewer",
+  "value:cy": "(cy) Your answer for \"%{control}\" must be %{max_length} characters or fewer"
 }

--- a/default_metadata/string/error.max_size.json
+++ b/default_metadata/string/error.max_size.json
@@ -2,5 +2,6 @@
   "_id": "error.max_size",
   "_type": "string.error",
   "description": "File is too large",
-  "value": "The selected file must be smaller than %{max_size}MB."
+  "value:en": "The selected file must be smaller than %{max_size}MB.",
+  "value:cy": "(cy) The selected file must be smaller than %{max_size}MB."
 }

--- a/default_metadata/string/error.max_word.json
+++ b/default_metadata/string/error.max_word.json
@@ -2,5 +2,6 @@
   "_id": "error.max_word",
   "_type": "string.error",
   "description": "Input (number) is higher than the maximum number of words allowed",
-  "value": "Your answer for \"%{control}\" must be %{max_word} words or fewer"
+  "value:en": "Your answer for \"%{control}\" must be %{max_word} words or fewer",
+  "value:cy": "(cy) Your answer for \"%{control}\" must be %{max_word} words or fewer"
 }

--- a/default_metadata/string/error.maximum.json
+++ b/default_metadata/string/error.maximum.json
@@ -2,5 +2,6 @@
   "_id": "error.maximum",
   "_type": "string.error",
   "description": "Input (number) is larger than the maximum allowed",
-  "value": "Your answer for \"%{control}\" must be %{maximum} or lower"
+  "value:en": "Your answer for \"%{control}\" must be %{maximum} or lower",
+  "value:cy": "(cy) Your answer for \"%{control}\" must be %{maximum} or lower"
 }

--- a/default_metadata/string/error.min_length.json
+++ b/default_metadata/string/error.min_length.json
@@ -2,5 +2,6 @@
   "_id": "error.min_length",
   "_type": "string.error",
   "description": "Input (string) is too short",
-  "value": "Your answer for \"%{control}\" must be %{min_length} characters or more"
+  "value:en": "Your answer for \"%{control}\" must be %{min_length} characters or more",
+  "value:cy": "(cy) Your answer for \"%{control}\" must be %{min_length} characters or more"
 }

--- a/default_metadata/string/error.min_word.json
+++ b/default_metadata/string/error.min_word.json
@@ -2,5 +2,6 @@
   "_id": "error.min_word",
   "_type": "string.error",
   "description": "Input (number) is lower than the minimum number of words allowed",
-  "value": "Your answer for \"%{control}\" must be %{min_word} words or more"
+  "value:en": "Your answer for \"%{control}\" must be %{min_word} words or more",
+  "value:cy": "(cy) Your answer for \"%{control}\" must be %{min_word} words or more"
 }

--- a/default_metadata/string/error.minimum.json
+++ b/default_metadata/string/error.minimum.json
@@ -2,5 +2,6 @@
   "_id": "error.minimum",
   "_type": "string.error",
   "description": "Input (number) is lower than the minimum allowed",
-  "value": "Your answer for \"%{control}\" must be %{minimum} or higher"
+  "value:en": "Your answer for \"%{control}\" must be %{minimum} or higher",
+  "value:cy": "(cy) Your answer for \"%{control}\" must be %{minimum} or higher"
 }

--- a/default_metadata/string/error.multiupload.json
+++ b/default_metadata/string/error.multiupload.json
@@ -2,5 +2,6 @@
   "_id": "error.multiupload",
   "_type": "string.error",
   "description": "Cannot upload files with duplicate filenames",
-  "value": "The selected file cannot have the same name as a file you have already selected. Please check you aren't uploading the same file again."
+  "value:en": "The selected file cannot have the same name as a file you have already selected. Please check you aren't uploading the same file again.",
+  "value:cy": "(cy) The selected file cannot have the same name as a file you have already selected. Please check you aren't uploading the same file again."
 }

--- a/default_metadata/string/error.number.json
+++ b/default_metadata/string/error.number.json
@@ -2,5 +2,6 @@
   "_id": "error.number",
   "_type": "string.error",
   "description": "Input (number) is not a number",
-  "value": "Enter a number for \"%{control}\""
+  "value:en": "Enter a number for \"%{control}\"",
+  "value:cy": "(cy) Enter a number for \"%{control}\""
 }

--- a/default_metadata/string/error.postcode.json
+++ b/default_metadata/string/error.postcode.json
@@ -2,5 +2,6 @@
   "_id": "error.postcode",
   "_type": "string.error",
   "description": "Postcode format is not valid",
-  "value": "Enter a valid UK postcode for \"%{control}\""
+  "value:en": "Enter a valid UK postcode for \"%{control}\"",
+  "value:cy": "(cy) Enter a valid UK postcode for \"%{control}\""
 }

--- a/default_metadata/string/error.required.json
+++ b/default_metadata/string/error.required.json
@@ -2,6 +2,6 @@
   "_id": "error.required",
   "_type": "string.error",
   "description": "Input is required",
-  "value": "Enter an answer for \"%{control}\"",
-  "value:cy": "Rhowch ateb i \"{control}\""
+  "value:en": "Enter an answer for \"%{control}\"",
+  "value:cy": "Rhowch ateb i \"%{control}\""
 }

--- a/default_metadata/string/error.virus_scan.json
+++ b/default_metadata/string/error.virus_scan.json
@@ -2,6 +2,6 @@
   "_id": "error.virus_scan",
   "_type": "string.error",
   "description": "File uploaded contains virus",
-  "value": "\"%{control}\" was not uploaded successfully because it contains a virus"
+  "value:en": "\"%{control}\" was not uploaded successfully because it contains a virus",
+  "value:cy": "(cy) \"%{control}\" was not uploaded successfully because it contains a virus"
 }
-

--- a/spec/validators/required_validator_spec.rb
+++ b/spec/validators/required_validator_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe MetadataPresenter::RequiredValidator do
   let(:page_answers) { MetadataPresenter::PageAnswers.new(page, answers) }
 
   describe '#valid?' do
+    let(:locale) { :en }
+
     before do
-      validator.valid?
+      I18n.with_locale(locale) { validator.valid? }
     end
 
     context 'when there is required validations on the metadata' do
@@ -60,6 +62,22 @@ RSpec.describe MetadataPresenter::RequiredValidator do
               ['Enter a parent name']
             )
           end
+        end
+      end
+
+      context 'when locale is welsh' do
+        let(:page) { service.find_page_by_url('/name') }
+        let(:answers) { {} }
+        let(:locale) { :cy }
+
+        it 'is invalid' do
+          expect(validator).to_not be_valid
+        end
+
+        it 'sets welsh error message on page' do
+          expect(page_answers.errors.full_messages).to eq(
+            ['Rhowch ateb i "Full name"']
+          )
         end
       end
 
@@ -116,6 +134,17 @@ RSpec.describe MetadataPresenter::RequiredValidator do
           it 'returns valid' do
             expect(validator).to be_valid
           end
+        end
+      end
+
+      context 'when component is an address' do
+        let(:page) { service.find_page_by_url('/postal-address') }
+        let(:answers) { { 'postal-address_address_1' => {} } }
+
+        # NOTE: required fields validation performed in separate `AddressValidator`
+        # For an address component this validator is always successful
+        it 'is valid' do
+          expect(validator).to be_valid
         end
       end
     end


### PR DESCRIPTION
https://trello.com/c/YohbrwI8

The error messages for each of the component validations are stored in json files.

This PR expands on a previous idea to have different `value` keys for each of the supported languages.

I've added a `value:cy` to all existing errors, that will need to be properly translated (there was only one existing translated error, in `error.required.json`).

Based on the current locale (coming from the metadata JSON and set on each request) the corresponding error message will be used on the runner.

![Screenshot 2024-01-30 at 11 18 32](https://github.com/ministryofjustice/fb-metadata-presenter/assets/687910/ab469c27-eeb0-4363-8dce-8070cc69f1e3)
