### PR TITLE
Minimise localisation breaking changes

### DIFF
--- a/app/views/metadata_presenter/footer/footer.html.erb
+++ b/app/views/metadata_presenter/footer/footer.html.erb
@@ -9,13 +9,13 @@
           <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
         </svg>
         <span class="govuk-footer__licence-description">
-          <%= t('presenter.footer.license_html') %>
+          <%= t('presenter.meta.license_html') %>
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a class="govuk-footer__link govuk-footer__copyright-logo"
            href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
-          <%= t('presenter.footer.copyright') %>
+          <%= t('presenter.meta.copyright') %>
         </a>
       </div>
     </div>

--- a/app/views/metadata_presenter/save_and_return/resume_progress.html.erb
+++ b/app/views/metadata_presenter/save_and_return/resume_progress.html.erb
@@ -27,7 +27,7 @@
                     editable? ? '#' : page_answers_presenter.url,
                     class: 'govuk-link'
                   ) do %>
-                    Change<span class="govuk-visually-hidden"> Your answer for <%= page_answers_presenter.humanised_title %></span>
+                    <%= t('presenter.actions.change_html', question: page_answers_presenter.humanised_title) %>
                   <% end %>
                 </dd>
               </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -15,7 +15,7 @@ cy:
       continue: Parhau
       submit: (cy) Submit
       upload_options: (cy) Upload options
-      change_html: (cy) Change <span class="govuk-visually-hidden">your answer for %{question}</span>
+      change_html: (cy) Change <span class="govuk-visually-hidden">Your answer for %{question}</span>
     errors:
       summary_heading: Mae yna broblem
     notification_banners:
@@ -148,17 +148,16 @@ cy:
         heading: Polisi preifatrwydd
       accessibility:
         heading: Datganiad hygyrchedd
-      copyright: © Hawlfraint y Goron
-      license_html: |
-        Mae’r holl gynnwys ar gael dan 
-        <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license">Drwydded y Llywodraeth Agored v3.0</a>, 
-        ac eithrio lle nodir yn wahanol
-
     meta:
       config:
         meta--link: Cwcis
         meta--link--2: Preifatrwydd
         meta--link--3: Hygyrchedd
+      copyright: © Hawlfraint y Goron
+      license_html: |
+        Mae’r holl gynnwys ar gael dan 
+        <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license">Drwydded y Llywodraeth Agored v3.0</a>, 
+        ac eithrio lle nodir yn wahanol
 
   activemodel:
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@ en:
       continue: Continue
       submit: Submit
       upload_options: Upload options
-      change_html: Change <span class="govuk-visually-hidden">your answer for %{question}</span>
+      change_html: Change <span class="govuk-visually-hidden">Your answer for %{question}</span>
     errors:
       summary_heading: There is a problem
     notification_banners:
@@ -184,6 +184,11 @@ en:
           - "[date when you performed your basic accessibility check]"
           - "[insert team or organisation here]"
         url: 'accessibility'
+    meta:
+      config:
+        meta--link: Cookies
+        meta--link--2: Privacy
+        meta--link--3: Accessibility
       copyright: © Crown copyright
       license_html: |
         All content is available under the


### PR DESCRIPTION
Some of these changes although minor require changes to the runner or the editor.

As this i18n work is still WIP and other devs are working in other features branching out from this repo `main`, it is best to keep any breaking changes out of it for now.

This way even if we were to cut a new gem version of the metadata presenter and use it in the other services, everything should keep working as usual.