### PR TITLE
Additional copy extracted to locales

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -141,6 +141,7 @@ cy:
           content_2: '(cy) Here are the answers you have provided so far.'
       confirmation_email:
         subject: "(cy) Your saved form - '%{service_name}'"
+        body: "(cy) You have saved your progress with the form '%{service_name}'.<br /><br /><a href=%{magic_link}>Continue with your form</a><br /><br />This link will only work once. If you want to save your progress again after resuming the form, you will need to repeat the save process and generate another link.<br /><br />The link is valid for 28 days. After that time, your saved information will be deleted."
     header:
       skip: Neidio i’r prif gynnwys
       govuk_url: 'https://www.gov.uk/cymraeg'

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -60,6 +60,8 @@ cy:
       application_complete: '(cy) Application complete'
       email_disclaimer_email_question: '(cy) We will use this address to send you a confirmation email with a copy of your answers.'
       email_basic_disclaimer_html: '(cy) We will send a confirmation email with a copy of these answers to %{email_provided}'
+    confirmation_email:
+      table_heading: (cy) Your answers
     questions:
       upload:
         remove_file: (cy) Remove file

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -139,6 +139,8 @@ cy:
           heading: '(cy) %{service_name}'
           content_1: '(cy) You have successfully retrieved your saved information.'
           content_2: '(cy) Here are the answers you have provided so far.'
+      confirmation_email:
+        subject: "(cy) Your saved form - '%{service_name}'"
     header:
       skip: Neidio i’r prif gynnwys
       govuk_url: 'https://www.gov.uk/cymraeg'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,8 @@ en:
           heading: '%{service_name}'
           content_1: 'You have successfully retrieved your saved information.'
           content_2: 'Here are the answers you have provided so far.'
+      confirmation_email:
+        subject: "Your saved form - '%{service_name}'"
     header:
       skip: Skip to main content
       govuk_url: 'https://www.gov.uk'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,8 @@ en:
       application_complete: 'Application complete'
       email_disclaimer_email_question: 'We will use this address to send you a confirmation email with a copy of your answers.'
       email_basic_disclaimer_html: 'We will send a confirmation email with a copy of these answers to %{email_provided}'
+    confirmation_email:
+      table_heading: Your answers
     questions:
       upload:
         remove_file: Remove file

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,7 @@ en:
           content_2: 'Here are the answers you have provided so far.'
       confirmation_email:
         subject: "Your saved form - '%{service_name}'"
+        body: "You have saved your progress with the form '%{service_name}'.<br /><br /><a href=%{magic_link}>Continue with your form</a><br /><br />This link will only work once. If you want to save your progress again after resuming the form, you will need to repeat the save process and generate another link.<br /><br />The link is valid for 28 days. After that time, your saved information will be deleted."
     header:
       skip: Skip to main content
       govuk_url: 'https://www.gov.uk'


### PR DESCRIPTION
The "Your answers" heading, in the submission confirmation email, was hardcoded. Extracted to locales so we are able to translate it to welsh.

Also, the save&return confirmation email body and subject was hardcoded. The body was also set as an ENV variable in the editor, which does not play nice with localisation.
Decided to move this to the runner/presenter as this copy is not user-editable and extracted to locales.