### PR TITLE
Release new version with initial welsh support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.11] - 2024-02-06
+### Added
+- Initial support for locales other than english in preparation for Welsh translation. A future gem version will update the `cy.yml` with the actual translations.
+
 ## [3.3.10] - 2024-01-26
 ### Added
 - External start page release. If a form is configured to use an external start page, the static start page will by pypassed using a redirect to the first question. The header link and back links will also be updated to use that external start page URL.

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.10'.freeze
+  VERSION = '3.3.11'.freeze
 end


### PR DESCRIPTION
Cutting a new gem version containing everything up until today that was merged to `main` in preparation to support welsh localisation.

A follow-up version will be needed to replace the `cy.yml` with the actual translations.

No current forms are using `locale=cy` so there will be no impact even if we release runner/editor using this new gem version.