### PR TITLE
Add order to components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.12] - 2024-01-29
+### Added
+ - Added schema definitions for order property to component.json to allow for ordering of components on multiquestion pages.
+
 ## [3.3.11] - 2024-02-06
 ### Added
 - Initial support for locales other than english in preparation for Welsh translation. A future gem version will update the `cy.yml` with the actual translations.

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.11'.freeze
+  VERSION = '3.3.12'.freeze
 end

--- a/schemas/definition/component.json
+++ b/schemas/definition/component.json
@@ -2,6 +2,13 @@
   "$id": "http://gov.uk/schema/v1.0.0/definition/component",
   "_name": "definition.component",
   "title": "Component definition",
+  "properties": {
+    "order": {
+      "title": "Order",
+      "description": "Used to order components within a page",
+      "type": "integer"
+    }
+  },
   "allOf": [
     {
       "$ref": "definition.block"


### PR DESCRIPTION
This PR is incredibly tiny for the time taken to create it!

Adds an optional `order` property to the component json, in preparation for moving components on multiquestion pages.

This is a default property with no default set, as it needs to be backwards compatible with forms that do not have the property.

When the feature UI is aded in the editor, as soon as a multiquestion page with unordered components is saved, all components will gain the `order` property.

This leaves us with 2 eventual states:
 - No components on a page have an `order` property
 - All components on a page have an `order` property

