### PR TITLE
Protect from empty validation schema attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
-## [3.3.12] - 2024-01-29
+## [3.3.13] - 2024-02-07
+### Fixed
+- When inquiring metadata attributes in the editor, return the original value (even if is empty or nil) 
+  unless there is a default value for it set in `Rails.application.config.default_text`. This fixes an edge case 
+  where some old forms would have a `validation` attribute with empty hash value.
+
+## [3.3.12] - 2024-02-07
 ### Added
  - Added schema definitions for order property to component.json to allow for ordering of components on multiquestion pages.
 

--- a/app/helpers/metadata_presenter/default_text.rb
+++ b/app/helpers/metadata_presenter/default_text.rb
@@ -1,7 +1,13 @@
 module MetadataPresenter
   class DefaultText
-    def self.[](property)
-      Rails.application.config.default_text[property.to_s]
+    class << self
+      delegate :[], :key?, to: :defaults
+
+      private
+
+      def defaults
+        Rails.application.config.default_text
+      end
     end
   end
 end

--- a/app/helpers/metadata_presenter/default_text.rb
+++ b/app/helpers/metadata_presenter/default_text.rb
@@ -1,7 +1,7 @@
 module MetadataPresenter
   class DefaultText
     class << self
-      delegate :[], :key?, to: :defaults
+      delegate :[], :fetch, to: :defaults
 
       private
 

--- a/app/models/metadata_presenter/metadata.rb
+++ b/app/models/metadata_presenter/metadata.rb
@@ -31,7 +31,7 @@ class MetadataPresenter::Metadata
 
   def method_missing(method_name, *args, &block)
     value = metadata.send(method_name, *args, &block)
-    value.blank? && editor? && has_default?(method_name) ? MetadataPresenter::DefaultText[method_name] : value
+    value.blank? && editor? ? MetadataPresenter::DefaultText.fetch(method_name, value) : value
   end
 
   def ==(other)
@@ -40,9 +40,5 @@ class MetadataPresenter::Metadata
 
   def editor?
     @editor.present?
-  end
-
-  def has_default?(key)
-    MetadataPresenter::DefaultText.key?(key)
   end
 end

--- a/app/models/metadata_presenter/metadata.rb
+++ b/app/models/metadata_presenter/metadata.rb
@@ -31,7 +31,7 @@ class MetadataPresenter::Metadata
 
   def method_missing(method_name, *args, &block)
     value = metadata.send(method_name, *args, &block)
-    value.blank? && editor? ? MetadataPresenter::DefaultText[method_name] : value
+    value.blank? && editor? && has_default?(method_name) ? MetadataPresenter::DefaultText[method_name] : value
   end
 
   def ==(other)
@@ -40,5 +40,9 @@ class MetadataPresenter::Metadata
 
   def editor?
     @editor.present?
+  end
+
+  def has_default?(key)
+    MetadataPresenter::DefaultText.key?(key)
   end
 end

--- a/config/initializers/default_text.rb
+++ b/config/initializers/default_text.rb
@@ -2,4 +2,4 @@ Rails.application.config.default_text = JSON.parse(
   File.read(
     MetadataPresenter::Engine.root.join('default_text', 'content.json')
   )
-)
+).with_indifferent_access

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.12'.freeze
+  VERSION = '3.3.13'.freeze
 end

--- a/spec/models/metadata_spec.rb
+++ b/spec/models/metadata_spec.rb
@@ -21,10 +21,36 @@ RSpec.describe MetadataPresenter::Metadata do
     end
 
     context 'when there is no default text for an empty property' do
-      let(:meta) { { 'nope' => '' } }
+      context 'for an empty string' do
+        let(:meta) { { 'nope' => '' } }
 
-      it 'should be nil' do
-        expect(metadata.nope).to be_nil
+        it 'should present back the empty string' do
+          expect(metadata.nope).to eq('')
+        end
+      end
+
+      context 'for an empty hash' do
+        let(:meta) { { 'nope' => {} } }
+
+        it 'should present back the empty hash' do
+          expect(metadata.nope).to eq({})
+        end
+      end
+
+      context 'for an empty array' do
+        let(:meta) { { 'nope' => [] } }
+
+        it 'should present back the empty array' do
+          expect(metadata.nope).to eq([])
+        end
+      end
+
+      context 'for a nil value' do
+        let(:meta) { { 'nope' => nil } }
+
+        it 'should present back the nil value' do
+          expect(metadata.nope).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/q2iVyM9D

There is an edge case where in some forms the metadata JSON attribute `validation` is empty (empty hash).

The way the metadata is queried in the editor made this empty attribute provoke a lookup in the `MetadataPresenter::DefaultText` map which is intended for hint text, labels, etc. but not for "validation" (which is not present in the map)

This returned a nil, which made some things bad down the line in the editor.

Instead we are now returning the original value (in this case an empty hash) if there is no default text for it (as is the case for `validation` key).