### PR TITLE
Sort components by order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.14] - 2024-02-08
+### Added
+ - Added `Comparable` module to `Component` class to enable sorting of components based on the `order` property.
+
 ## [3.3.13] - 2024-02-07
 ### Fixed
 - When inquiring metadata attributes in the editor, return the original value (even if is empty or nil) 

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -1,4 +1,6 @@
 class MetadataPresenter::Component < MetadataPresenter::Metadata
+  include Comparable
+
   VALIDATION_BUNDLES = {
     'date' => 'date',
     'number' => 'number',
@@ -10,6 +12,13 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
   # Used for max_length and max_word validations.
   # Threshold percentage at which the remaining count is shown
   VALIDATION_STRING_LENGTH_THRESHOLD = 75
+
+  def <=>(other)
+    return nil unless other.is_a?(MetadataPresenter::Component)
+    return 0 unless order
+
+    order <=> other.order
+  end
 
   # Overriding here because autocomplete component's items property is non interactable
   # in the Editor therefore it does not need to exist in the data-fb-content-data

--- a/app/models/metadata_presenter/page.rb
+++ b/app/models/metadata_presenter/page.rb
@@ -181,12 +181,12 @@ module MetadataPresenter
     end
 
     def to_components(node_components, collection:)
-      Array(node_components).map do |component|
+      Array(node_components).map { |component|
         MetadataPresenter::Component.new(
           component.merge(collection:),
           editor: editor?
         )
-      end
+      }.sort
     end
 
     def supported_components(page_type)

--- a/fixtures/version.json
+++ b/fixtures/version.json
@@ -425,7 +425,8 @@
           "collection": "components",
           "validation": {
             "required": true
-          }
+          },
+          "order": 2
         },
         {
           "_id": "star-wars-knowledge_content_1",
@@ -433,7 +434,8 @@
           "_type": "content",
           "_uuid": "82444d3d-dab6-44c4-a147-e2650326c9eb",
           "content": "Stay on target",
-          "collection": "components"
+          "collection": "components",
+          "order": 1
         },
         {
           "_id": "star-wars-knowledge_radios_1",
@@ -493,7 +495,8 @@
           "collection": "components",
           "validation": {
             "required": true
-          }
+          },
+          "order": 0
         }
       ],
       "add_component": "radios",
@@ -528,7 +531,7 @@
       "heading": "Question",
       "components": [
         {
-          "_id":  "dog-picture_upload_1",
+          "_id": "dog-picture_upload_1",
           "name": "dog-picture_upload_1",
           "_type": "upload",
           "_uuid": "f056a76e-ec3f-47ae-b625-1bba92220ad1",
@@ -594,7 +597,7 @@
       "heading": "Multiupload",
       "components": [
         {
-          "_id":  "dog-picture_upload_2",
+          "_id": "dog-picture_upload_2",
           "name": "dog-picture_upload_2",
           "_type": "multiupload",
           "_uuid": "f056a76e-ec3f-47ae-b625-1bba92220ad2",
@@ -668,10 +671,8 @@
           "name": "countries_autocomplete_1",
           "_type": "autocomplete",
           "_uuid": "4dc23b9c-9757-4526-813d-b43efbe07dad",
-          "items": [
-          ],
-          "errors": {
-          },
+          "items": [],
+          "errors": {},
           "legend": "Countries",
           "validation": {
             "required": true,

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.13'.freeze
+  VERSION = '3.3.14'.freeze
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe MetadataPresenter::Page do
 
   describe '#input_components' do
     let(:page) { service.find_page_by_url('star-wars-knowledge') }
-    let(:expected_component_ids) { %w[star-wars-knowledge_text_1 star-wars-knowledge_radios_1] }
+    let(:expected_component_ids) { %w[star-wars-knowledge_radios_1 star-wars-knowledge_text_1] }
 
     it 'returns an array of only components that take user input' do
       component_ids = page.input_components.map(&:id)


### PR DESCRIPTION
This PR adds the `Comparable` module to the `Component` class.  This allows us to define the `<=>` method to allow comparaison and sorting of component instances.

This makes ensuring the components are ordered correctly simple, as we can just call `sort` on an array of components.

If there is no order property for the component we return `0` meaning the order will remain unchanged.
