### PR TITLE
Basic auth replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.25] - 2024-03-14
+### Added
+- Support for custom form authentication in the runner, replacing http basic auth.
+
 ## [3.3.24] - 2024-03-11
 ### Fixed
 - Fixed position of error summary in multi-question pages.

--- a/app/controllers/metadata_presenter/auth_controller.rb
+++ b/app/controllers/metadata_presenter/auth_controller.rb
@@ -10,13 +10,11 @@ module MetadataPresenter
     def create
       @auth_form = AuthForm.new(auth_params)
 
-      if @auth_form.invalid?
-        render :show
-      elsif @auth_form.authorised?
+      if @auth_form.valid?
         authorised_session!
         redirect_to root_path
       else
-        redirect_to auth_path, flash: { error: :unauthorised }
+        render :show
       end
     end
 

--- a/app/controllers/metadata_presenter/auth_controller.rb
+++ b/app/controllers/metadata_presenter/auth_controller.rb
@@ -12,7 +12,7 @@ module MetadataPresenter
       if @auth_form.invalid?
         render :show
       elsif @auth_form.authorised?
-        set_authorised_cookie!
+        authorised_session!
         redirect_to root_path
       else
         redirect_to auth_path, flash: { error: :unauthorised }
@@ -31,12 +31,6 @@ module MetadataPresenter
 
     def check_session_is_authorised
       redirect_to root_path if session_authorised?
-    end
-
-    def set_authorised_cookie!
-      cookies.signed[:_fb_authorised] = {
-        value: 1, same_site: :strict, httponly: true
-      }
     end
 
     def auth_params

--- a/app/controllers/metadata_presenter/auth_controller.rb
+++ b/app/controllers/metadata_presenter/auth_controller.rb
@@ -1,5 +1,6 @@
 module MetadataPresenter
   class AuthController < EngineController
+    skip_before_action :require_basic_auth
     before_action :check_session_is_authorised
 
     def show

--- a/app/controllers/metadata_presenter/auth_controller.rb
+++ b/app/controllers/metadata_presenter/auth_controller.rb
@@ -12,7 +12,7 @@ module MetadataPresenter
       if @auth_form.invalid?
         render :show
       elsif @auth_form.authorised?
-        session[:authorised] = 1
+        set_authorised_cookie!
         redirect_to root_path
       else
         redirect_to auth_path, flash: { error: :unauthorised }
@@ -31,6 +31,12 @@ module MetadataPresenter
 
     def check_session_is_authorised
       redirect_to root_path if session_authorised?
+    end
+
+    def set_authorised_cookie!
+      cookies.signed[:_fb_authorised] = {
+        value: 1, same_site: :strict, httponly: true
+      }
     end
 
     def auth_params

--- a/app/controllers/metadata_presenter/auth_controller.rb
+++ b/app/controllers/metadata_presenter/auth_controller.rb
@@ -1,0 +1,42 @@
+module MetadataPresenter
+  class AuthController < EngineController
+    before_action :check_session_is_authorised
+
+    def show
+      @auth_form = AuthForm.new
+    end
+
+    def create
+      @auth_form = AuthForm.new(auth_params)
+
+      if @auth_form.invalid?
+        render :show
+      elsif @auth_form.authorised?
+        session[:authorised] = 1
+        redirect_to root_path
+      else
+        redirect_to auth_path, flash: { error: :unauthorised }
+      end
+    end
+
+    private
+
+    def allow_analytics?
+      false
+    end
+
+    def show_cookie_request?
+      false
+    end
+
+    def check_session_is_authorised
+      redirect_to root_path if session_authorised?
+    end
+
+    def auth_params
+      params.require(:auth_form).permit(
+        :username, :password
+      )
+    end
+  end
+end

--- a/app/controllers/metadata_presenter/auth_controller.rb
+++ b/app/controllers/metadata_presenter/auth_controller.rb
@@ -1,6 +1,6 @@
 module MetadataPresenter
   class AuthController < EngineController
-    PRODUCTION_ENVS = %w[live-dev live-production].freeze
+    PRODUCTION_ENVS = %w[test-production live-production].freeze
 
     skip_before_action :require_basic_auth
     before_action :check_session_is_authorised

--- a/app/controllers/metadata_presenter/auth_controller.rb
+++ b/app/controllers/metadata_presenter/auth_controller.rb
@@ -1,5 +1,7 @@
 module MetadataPresenter
   class AuthController < EngineController
+    PRODUCTION_ENV = 'live-production'.freeze
+
     skip_before_action :require_basic_auth
     before_action :check_session_is_authorised
 
@@ -31,6 +33,11 @@ module MetadataPresenter
     def check_session_is_authorised
       redirect_to root_path if session_authorised?
     end
+
+    def production_env?
+      "#{ENV['PLATFORM_ENV']}-#{ENV['DEPLOYMENT_ENV']}".eql?(PRODUCTION_ENV)
+    end
+    helper_method :production_env?
 
     def auth_params
       params.require(:auth_form).permit(

--- a/app/controllers/metadata_presenter/auth_controller.rb
+++ b/app/controllers/metadata_presenter/auth_controller.rb
@@ -1,6 +1,6 @@
 module MetadataPresenter
   class AuthController < EngineController
-    PRODUCTION_ENV = 'live-production'.freeze
+    PRODUCTION_ENVS = %w[live-dev live-production].freeze
 
     skip_before_action :require_basic_auth
     before_action :check_session_is_authorised
@@ -35,7 +35,7 @@ module MetadataPresenter
     end
 
     def production_env?
-      "#{ENV['PLATFORM_ENV']}-#{ENV['DEPLOYMENT_ENV']}".eql?(PRODUCTION_ENV)
+      PRODUCTION_ENVS.include?("#{ENV['PLATFORM_ENV']}-#{ENV['DEPLOYMENT_ENV']}")
     end
     helper_method :production_env?
 

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -124,6 +124,12 @@ module MetadataPresenter
       ENV['MAINTENANCE_MODE'].present? && ENV['MAINTENANCE_MODE'] == '1'
     end
 
+    def session_authorised?
+      return true if ENV['BASIC_AUTH_USER'].blank? || ENV['BASIC_AUTH_PASS'].blank?
+
+      !!session[:authorised]
+    end
+
     def external_or_relative_link(link)
       uri = URI.parse(link)
       return link if uri.scheme.present? && uri.host.present?

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -6,7 +6,11 @@ module MetadataPresenter
     default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
     around_action :switch_locale
-    before_action :show_maintenance_page
+    before_action :show_maintenance_page, :require_basic_auth
+
+    def require_basic_auth
+      redirect_to auth_path unless session_authorised?
+    end
 
     def reload_user_data
       # :nocov:

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -127,7 +127,7 @@ module MetadataPresenter
     def session_authorised?
       return true if ENV['BASIC_AUTH_USER'].blank? || ENV['BASIC_AUTH_PASS'].blank?
 
-      !!session[:authorised]
+      !!cookies.signed[:_fb_authorised]
     end
 
     def external_or_relative_link(link)

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -130,6 +130,12 @@ module MetadataPresenter
       !!cookies.signed[:_fb_authorised]
     end
 
+    def authorised_session!
+      cookies.signed[:_fb_authorised] = {
+        value: 1, same_site: :strict, httponly: true
+      }
+    end
+
     def external_or_relative_link(link)
       uri = URI.parse(link)
       return link if uri.scheme.present? && uri.host.present?

--- a/app/controllers/metadata_presenter/resume_controller.rb
+++ b/app/controllers/metadata_presenter/resume_controller.rb
@@ -4,6 +4,8 @@ module MetadataPresenter
 
     helper_method :get_service_name, :get_uuid, :pages_presenters
 
+    skip_before_action :require_basic_auth
+
     def return
       response = get_saved_progress(get_uuid)
 

--- a/app/controllers/metadata_presenter/resume_controller.rb
+++ b/app/controllers/metadata_presenter/resume_controller.rb
@@ -49,6 +49,9 @@ module MetadataPresenter
 
         invalidate_record(@saved_form.id)
 
+        # authorise user as to not ask them again for credentials, if set
+        authorised_session! unless session_authorised?
+
         if @saved_form.service_version == service.version_id
           redirect_to '/resume_progress' and return
         else

--- a/app/controllers/metadata_presenter/session_controller.rb
+++ b/app/controllers/metadata_presenter/session_controller.rb
@@ -1,5 +1,7 @@
 module MetadataPresenter
   class SessionController < EngineController
+    skip_before_action :require_basic_auth
+
     def expired; end
 
     def complete; end

--- a/app/models/metadata_presenter/auth_form.rb
+++ b/app/models/metadata_presenter/auth_form.rb
@@ -1,0 +1,27 @@
+module MetadataPresenter
+  class AuthForm
+    include ActiveModel::Model
+
+    attr_accessor :username, :password
+
+    validates :username, :password,
+              presence: true, allow_blank: false
+
+    def authorised?
+      # This comparison uses & so that it doesn't short circuit and
+      # uses `secure_compare` so that length information isn't leaked.
+      ActiveSupport::SecurityUtils.secure_compare(env_username, username) &
+        ActiveSupport::SecurityUtils.secure_compare(env_password, password)
+    end
+
+    private
+
+    def env_username
+      ENV['BASIC_AUTH_USER'].to_s
+    end
+
+    def env_password
+      ENV['BASIC_AUTH_PASS'].to_s
+    end
+  end
+end

--- a/app/models/metadata_presenter/auth_form.rb
+++ b/app/models/metadata_presenter/auth_form.rb
@@ -7,14 +7,20 @@ module MetadataPresenter
     validates :username, :password,
               presence: true, allow_blank: false
 
+    validate :valid_credentials
+
+    private
+
+    def valid_credentials
+      errors.add(:base, :unauthorised) unless errors.any? || authorised?
+    end
+
     def authorised?
       # This comparison uses & so that it doesn't short circuit and
       # uses `secure_compare` so that length information isn't leaked.
       ActiveSupport::SecurityUtils.secure_compare(env_username, username) &
         ActiveSupport::SecurityUtils.secure_compare(env_password, password)
     end
-
-    private
 
     def env_username
       ENV['BASIC_AUTH_USER'].to_s

--- a/app/views/metadata_presenter/auth/show.html.erb
+++ b/app/views/metadata_presenter/auth/show.html.erb
@@ -8,6 +8,20 @@
           <%= t('presenter.authorisation.heading') %>
         </h1>
 
+        <p class="govuk-body">
+          <%= t('presenter.authorisation.lede') %>
+        </p>
+
+        <% unless production_env? %>
+          <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden"><%= t('presenter.notification_banners.warning') %></span>
+              <%= t('presenter.authorisation.warning') %>
+            </strong>
+          </div>
+        <% end %>
+
         <%= f.govuk_text_field :username, width: 'one-third', autocorrect: 'off',
                                label: { text: t('presenter.authorisation.labels.username') } %>
 
@@ -15,7 +29,7 @@
                                    label: { text: t('presenter.authorisation.labels.password') } %>
 
         <div class="govuk-button-group">
-          <%= f.govuk_submit t('presenter.actions.continue') %>
+          <%= f.govuk_submit t('presenter.actions.sign_in') %>
         </div>
       <% end %>
     </div>

--- a/app/views/metadata_presenter/auth/show.html.erb
+++ b/app/views/metadata_presenter/auth/show.html.erb
@@ -1,23 +1,8 @@
 <div class="fb-main-grid-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <% if flash[:error] %>
-        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-          <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-              <%= t('presenter.notification_banners.error') %>
-            </h2>
-          </div>
-          <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">
-              <%= t(flash[:error], scope: 'presenter.authorisation.notifications') %>
-            </p>
-          </div>
-        </div>
-      <% end %>
-
       <%= form_for @auth_form, url: { action: :create } do |f| %>
-        <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
+        <%= f.govuk_error_summary(t('presenter.errors.summary_heading'), link_base_errors_to: :username) %>
 
         <h1 id="page-heading" class="govuk-heading-xl">
           <%= t('presenter.authorisation.heading') %>

--- a/app/views/metadata_presenter/auth/show.html.erb
+++ b/app/views/metadata_presenter/auth/show.html.erb
@@ -1,0 +1,40 @@
+<div class="fb-main-grid-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if flash[:error] %>
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+          <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+              <%= t('presenter.notification_banners.error') %>
+            </h2>
+          </div>
+          <div class="govuk-notification-banner__content">
+            <p class="govuk-notification-banner__heading">
+              <%= t(flash[:error], scope: 'presenter.authorisation.notifications') %>
+            </p>
+          </div>
+        </div>
+      <% end %>
+
+      <h1 id="page-heading" class="govuk-heading-xl">
+        <%= t('presenter.authorisation.heading') %>
+      </h1>
+
+      <%= form_for @auth_form, url: { action: :create } do |f| %>
+        <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
+
+        <%= f.govuk_text_field :username, width: 'one-third',
+                               label: { text: t('presenter.authorisation.labels.username') },
+                               autocorrect: 'off', autocomplete: 'off' %>
+
+        <%= f.govuk_text_field :password, width: 'one-third',
+                               label: { text: t('presenter.authorisation.labels.password') },
+                               autocorrect: 'off', autocomplete: 'off' %>
+
+        <div class="govuk-button-group">
+          <%= f.govuk_submit t('presenter.actions.continue') %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/metadata_presenter/auth/show.html.erb
+++ b/app/views/metadata_presenter/auth/show.html.erb
@@ -23,13 +23,11 @@
       <%= form_for @auth_form, url: { action: :create } do |f| %>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
 
-        <%= f.govuk_text_field :username, width: 'one-third',
-                               label: { text: t('presenter.authorisation.labels.username') },
-                               autocorrect: 'off', autocomplete: 'off' %>
+        <%= f.govuk_text_field :username, width: 'one-third', autocorrect: 'off',
+                               label: { text: t('presenter.authorisation.labels.username') } %>
 
-        <%= f.govuk_text_field :password, width: 'one-third',
-                               label: { text: t('presenter.authorisation.labels.password') },
-                               autocorrect: 'off', autocomplete: 'off' %>
+        <%= f.govuk_password_field :password, width: 'one-third', autocorrect: 'off',
+                                   label: { text: t('presenter.authorisation.labels.password') } %>
 
         <div class="govuk-button-group">
           <%= f.govuk_submit t('presenter.actions.continue') %>

--- a/app/views/metadata_presenter/auth/show.html.erb
+++ b/app/views/metadata_presenter/auth/show.html.erb
@@ -16,12 +16,12 @@
         </div>
       <% end %>
 
-      <h1 id="page-heading" class="govuk-heading-xl">
-        <%= t('presenter.authorisation.heading') %>
-      </h1>
-
       <%= form_for @auth_form, url: { action: :create } do |f| %>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
+
+        <h1 id="page-heading" class="govuk-heading-xl">
+          <%= t('presenter.authorisation.heading') %>
+        </h1>
 
         <%= f.govuk_text_field :username, width: 'one-third', autocorrect: 'off',
                                label: { text: t('presenter.authorisation.labels.username') } %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -14,6 +14,7 @@ cy:
       start: Dechrau nawr
       continue: Parhau
       submit: Cyflwyno
+      sign_in: (cy) Sign in
       upload_options: Llwytho opsiynau
       change_html: Newid <span class="govuk-visually-hidden">eich ateb ar gyfer %{question}</span>
     errors:
@@ -40,6 +41,8 @@ cy:
       maintenance_page_content: "Os oeddech chi yng nghanol llenwi’r ffurflen, nid yw eich data wedi’i chadw.\r\n\r\nBydd y ffurflen ar gael eto o 9am ar ddydd Llun 19 Tachwedd.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nCysylltwch â ni os yw eich cais yn frys \r\n\r\nEmail:  \r\nTelephone:  \r\nDydd Llun i ddydd Gwener, 9am i 5pm  \r\n[Gwybodaeth am gost galwadau](https://www.gov.uk/costau-galwadau)"
     authorisation:
       heading: (cy) Sign in
+      lede: (cy) This form has its own username and password. Contact the form owner if you are unsure what these are.
+      warning: (cy) This is a Test version of the form and should not be shared without the form owner’s permission.
       labels:
         username: (cy) Username
         password: (cy) Password

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -21,6 +21,7 @@ cy:
     notification_banners:
       important: Pwysig
       warning: Rhybudd
+      error: (cy) Error
     analytics:
       heading: Cwcis ar %{service_name}
       body_1: Rydym ni’n defnyddio rhai cwcis hanfodol i wneud i’r gwasanaeth hwn weithio.
@@ -38,6 +39,13 @@ cy:
     maintenance:
       maintenance_page_heading: Mae’n ddrwg gennym, nid yw’r ffurflen hon ar gael
       maintenance_page_content: "Os oeddech chi yng nghanol llenwi’r ffurflen, nid yw eich data wedi’i chadw.\r\n\r\nBydd y ffurflen ar gael eto o 9am ar ddydd Llun 19 Tachwedd.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nCysylltwch â ni os yw eich cais yn frys \r\n\r\nEmail:  \r\nTelephone:  \r\nDydd Llun i ddydd Gwener, 9am i 5pm  \r\n[Gwybodaeth am gost galwadau](https://www.gov.uk/costau-galwadau)"
+    authorisation:
+      heading: (cy) Enter form credentials
+      labels:
+        username: (cy) Username
+        password: (cy) Password
+      notifications:
+        unauthorised: (cy) Invalid username or password
     session_timeout_warning:
       heading: Ydych chi eisiau mwy o amser?
       timer: Byddwn yn ailosod eich ffurflen ac yn dileu eich gwybodaeth os na fyddwch yn parhau mewn
@@ -169,6 +177,13 @@ cy:
     errors:
       messages:
         blank: 'Rhowch ateb i "%{attribute}"'
+      models:
+        metadata_presenter/auth_form:
+          attributes:
+            username:
+              blank: (cy) Enter the username
+            password:
+              blank: (cy) Enter the password
     attributes:
       metadata_presenter/saved_form:
         secret_question: Cwestiwn cudd

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -21,7 +21,6 @@ cy:
     notification_banners:
       important: Pwysig
       warning: Rhybudd
-      error: (cy) Error
     analytics:
       heading: Cwcis ar %{service_name}
       body_1: Rydym ni’n defnyddio rhai cwcis hanfodol i wneud i’r gwasanaeth hwn weithio.
@@ -40,12 +39,10 @@ cy:
       maintenance_page_heading: Mae’n ddrwg gennym, nid yw’r ffurflen hon ar gael
       maintenance_page_content: "Os oeddech chi yng nghanol llenwi’r ffurflen, nid yw eich data wedi’i chadw.\r\n\r\nBydd y ffurflen ar gael eto o 9am ar ddydd Llun 19 Tachwedd.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nCysylltwch â ni os yw eich cais yn frys \r\n\r\nEmail:  \r\nTelephone:  \r\nDydd Llun i ddydd Gwener, 9am i 5pm  \r\n[Gwybodaeth am gost galwadau](https://www.gov.uk/costau-galwadau)"
     authorisation:
-      heading: (cy) Enter form credentials
+      heading: (cy) Sign in
       labels:
         username: (cy) Username
         password: (cy) Password
-      notifications:
-        unauthorised: (cy) Invalid username or password
     session_timeout_warning:
       heading: Ydych chi eisiau mwy o amser?
       timer: Byddwn yn ailosod eich ffurflen ac yn dileu eich gwybodaeth os na fyddwch yn parhau mewn
@@ -180,10 +177,12 @@ cy:
       models:
         metadata_presenter/auth_form:
           attributes:
+            base:
+              unauthorised: (cy) The username and password do not match. Try again
             username:
-              blank: (cy) Enter the username
+              blank: (cy) Enter a username
             password:
-              blank: (cy) Enter the password
+              blank: (cy) Enter a password
     attributes:
       metadata_presenter/saved_form:
         secret_question: Cwestiwn cudd

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -14,7 +14,7 @@ cy:
       start: Dechrau nawr
       continue: Parhau
       submit: Cyflwyno
-      sign_in: (cy) Sign in
+      sign_in: Sign in
       upload_options: Llwytho opsiynau
       change_html: Newid <span class="govuk-visually-hidden">eich ateb ar gyfer %{question}</span>
     errors:
@@ -40,12 +40,12 @@ cy:
       maintenance_page_heading: Mae’n ddrwg gennym, nid yw’r ffurflen hon ar gael
       maintenance_page_content: "Os oeddech chi yng nghanol llenwi’r ffurflen, nid yw eich data wedi’i chadw.\r\n\r\nBydd y ffurflen ar gael eto o 9am ar ddydd Llun 19 Tachwedd.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nCysylltwch â ni os yw eich cais yn frys \r\n\r\nEmail:  \r\nTelephone:  \r\nDydd Llun i ddydd Gwener, 9am i 5pm  \r\n[Gwybodaeth am gost galwadau](https://www.gov.uk/costau-galwadau)"
     authorisation:
-      heading: (cy) Sign in
-      lede: (cy) This form has its own username and password. Contact the form owner if you are unsure what these are.
-      warning: (cy) This is a Test version of the form and should not be shared without the form owner’s permission.
+      heading: Sign in
+      lede: This form has its own username and password. Contact the form owner if you are unsure what these are.
+      warning: This is a Test version of the form and should not be shared without the form owner’s permission.
       labels:
-        username: (cy) Username
-        password: (cy) Password
+        username: Username
+        password: Password
     session_timeout_warning:
       heading: Ydych chi eisiau mwy o amser?
       timer: Byddwn yn ailosod eich ffurflen ac yn dileu eich gwybodaeth os na fyddwch yn parhau mewn
@@ -181,11 +181,11 @@ cy:
         metadata_presenter/auth_form:
           attributes:
             base:
-              unauthorised: (cy) The username and password do not match. Try again
+              unauthorised: The username and password do not match. Try again
             username:
-              blank: (cy) Enter a username
+              blank: Enter a username
             password:
-              blank: (cy) Enter a password
+              blank: Enter a password
     attributes:
       metadata_presenter/saved_form:
         secret_question: Cwestiwn cudd

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,6 @@ en:
     notification_banners:
       important: Important
       warning: Warning
-      error: Error
     analytics:
       heading: Cookies on %{service_name}
       body_1: We use some essential cookies to make this service work.
@@ -31,12 +30,10 @@ en:
       maintenance_page_heading: 'Sorry, this form is unavailable'
       maintenance_page_content: "If you were in the middle of completing the form, your data has not been saved.\r\n\r\nThe form will be available again from 9am on Monday 19 November 2018.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nContact us if your application is urgent \r\n\r\nEmail:  \r\nTelephone:  \r\nMonday to Friday, 9am to 5pm  \r\n[Find out about call charges](https://www.gov.uk/call-charges)"
     authorisation:
-      heading: Enter form credentials
+      heading: Sign in
       labels:
         username: Username
         password: Password
-      notifications:
-        unauthorised: Invalid username or password
     session_timeout_warning:
       heading: Do you need more time?
       timer: We will reset your form and delete your information if you do not continue in
@@ -216,10 +213,12 @@ en:
       models:
         metadata_presenter/auth_form:
           attributes:
+            base:
+              unauthorised: The username and password do not match. Try again
             username:
-              blank: Enter the username
+              blank: Enter a username
             password:
-              blank: Enter the password
+              blank: Enter a password
     attributes:
       metadata_presenter/saved_form:
         secret_question: Secret question

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
       start: Start now
       continue: Continue
       submit: Submit
+      sign_in: Sign in
       upload_options: Upload options
       change_html: Change <span class="govuk-visually-hidden">Your answer for %{question}</span>
     errors:
@@ -31,6 +32,8 @@ en:
       maintenance_page_content: "If you were in the middle of completing the form, your data has not been saved.\r\n\r\nThe form will be available again from 9am on Monday 19 November 2018.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nContact us if your application is urgent \r\n\r\nEmail:  \r\nTelephone:  \r\nMonday to Friday, 9am to 5pm  \r\n[Find out about call charges](https://www.gov.uk/call-charges)"
     authorisation:
       heading: Sign in
+      lede: This form has its own username and password. Contact the form owner if you are unsure what these are.
+      warning: This is a Test version of the form and should not be shared without the form owner’s permission.
       labels:
         username: Username
         password: Password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
     notification_banners:
       important: Important
       warning: Warning
+      error: Error
     analytics:
       heading: Cookies on %{service_name}
       body_1: We use some essential cookies to make this service work.
@@ -29,6 +30,13 @@ en:
     maintenance:
       maintenance_page_heading: 'Sorry, this form is unavailable'
       maintenance_page_content: "If you were in the middle of completing the form, your data has not been saved.\r\n\r\nThe form will be available again from 9am on Monday 19 November 2018.\r\n\r\n\r\n\r\n### Other ways to apply\r\n\r\nContact us if your application is urgent \r\n\r\nEmail:  \r\nTelephone:  \r\nMonday to Friday, 9am to 5pm  \r\n[Find out about call charges](https://www.gov.uk/call-charges)"
+    authorisation:
+      heading: Enter form credentials
+      labels:
+        username: Username
+        password: Password
+      notifications:
+        unauthorised: Invalid username or password
     session_timeout_warning:
       heading: Do you need more time?
       timer: We will reset your form and delete your information if you do not continue in
@@ -205,6 +213,13 @@ en:
     errors:
       messages:
         blank: 'Enter an answer for "%{attribute}"'
+      models:
+        metadata_presenter/auth_form:
+          attributes:
+            username:
+              blank: Enter the username
+            password:
+              blank: Enter the password
     attributes:
       metadata_presenter/saved_form:
         secret_question: Secret question

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 MetadataPresenter::Engine.routes.draw do
   root to: 'service#start'
 
+  get  '/auth', to: 'auth#show'
+  post '/auth', to: 'auth#create'
+
   post '/reserved/submissions', to: 'submissions#create', as: :reserved_submissions
   get '/reserved/change-answer', to: 'change_answer#create', as: :change_answer
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.24'.freeze
+  VERSION = '3.3.25'.freeze
 end

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -59,4 +59,43 @@ RSpec.describe MetadataPresenter::AuthController, type: :controller do
       end
     end
   end
+
+  describe 'helpers' do
+    subject { controller.helpers.production_env? }
+
+    before do
+      allow(ENV).to receive(:[]).with('PLATFORM_ENV').and_return(platform_env)
+      allow(ENV).to receive(:[]).with('DEPLOYMENT_ENV').and_return(deployment_env)
+    end
+
+    describe '#production_env?' do
+      context 'for test-dev' do
+        let(:platform_env) { 'test' }
+        let(:deployment_env) { 'dev' }
+
+        it { is_expected.to be(false) }
+      end
+
+      context 'for test-production' do
+        let(:platform_env) { 'test' }
+        let(:deployment_env) { 'production' }
+
+        it { is_expected.to be(false) }
+      end
+
+      context 'for live-dev' do
+        let(:platform_env) { 'live' }
+        let(:deployment_env) { 'dev' }
+
+        it { is_expected.to be(false) }
+      end
+
+      context 'for live-production' do
+        let(:platform_env) { 'live' }
+        let(:deployment_env) { 'production' }
+
+        it { is_expected.to be(true) }
+      end
+    end
+  end
 end

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe MetadataPresenter::AuthController, type: :controller do
+  routes { MetadataPresenter::Engine.routes }
+
+  before do
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with('BASIC_AUTH_USER').and_return(username)
+    allow(ENV).to receive(:[]).with('BASIC_AUTH_PASS').and_return(password)
+  end
+
+  let(:username) { 'username' }
+  let(:password) { 'password' }
+
+  describe '#show' do
+    context 'when there are no basic auth credentials set' do
+      let(:username) { nil }
+      let(:password) { nil }
+
+      it 'redirects to the homepage' do
+        get :show
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'when there are basic auth credentials set' do
+      context 'when session is already authorised' do
+        it 'redirects to the homepage' do
+          cookies.signed['_fb_authorised'] = 1
+
+          get :show
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context 'when session is not authorised yet' do
+        it 'shows the sign in page' do
+          get :show
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'for invalid credentials' do
+      it 'does not authorise the user and renders the sign in page' do
+        post :create, params: { auth_form: { username: 'foo', password: 'bar' } }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.cookies['_fb_authorised']).to be_nil
+      end
+    end
+
+    context 'for valid credentials' do
+      it 'authorises the user and redirects to the homepage' do
+        post :create, params: { auth_form: { username:, password: } }
+
+        expect(response).to redirect_to(root_path)
+        expect(response.cookies['_fb_authorised']).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -80,14 +80,14 @@ RSpec.describe MetadataPresenter::AuthController, type: :controller do
         let(:platform_env) { 'test' }
         let(:deployment_env) { 'production' }
 
-        it { is_expected.to be(false) }
+        it { is_expected.to be(true) }
       end
 
       context 'for live-dev' do
         let(:platform_env) { 'live' }
         let(:deployment_env) { 'dev' }
 
-        it { is_expected.to be(true) }
+        it { is_expected.to be(false) }
       end
 
       context 'for live-production' do

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe MetadataPresenter::AuthController, type: :controller do
         let(:platform_env) { 'live' }
         let(:deployment_env) { 'dev' }
 
-        it { is_expected.to be(false) }
+        it { is_expected.to be(true) }
       end
 
       context 'for live-production' do

--- a/spec/models/auth_form_spec.rb
+++ b/spec/models/auth_form_spec.rb
@@ -1,0 +1,113 @@
+RSpec.describe MetadataPresenter::AuthForm do
+  subject { described_class.new(attrs) }
+
+  let(:attrs) do
+    { username:, password: }
+  end
+
+  describe 'validations' do
+    context '`username` and `password` are blank' do
+      let(:username) { nil }
+      let(:password) { nil }
+
+      it { is_expected.not_to be_valid }
+
+      context 'error types' do
+        before { subject.valid? }
+
+        it 'has an error in the `username` field' do
+          expect(subject.errors.added?(:username, :blank)).to be(true)
+        end
+
+        it 'has an error in the `password` field' do
+          expect(subject.errors.added?(:password, :blank)).to be(true)
+        end
+
+        it 'does not have errors in the base' do
+          expect(subject.errors.added?(:base)).to be(false)
+        end
+      end
+    end
+
+    context '`username` is blank' do
+      let(:username) { nil }
+      let(:password) { 'password' }
+
+      it { is_expected.not_to be_valid }
+
+      context 'error types' do
+        before { subject.valid? }
+
+        it 'has an error in the `username` field' do
+          expect(subject.errors.added?(:username, :blank)).to be(true)
+        end
+
+        it 'does not have an error in the `password` field' do
+          expect(subject.errors.added?(:password)).to be(false)
+        end
+
+        it 'does not have errors in the base' do
+          expect(subject.errors.added?(:base)).to be(false)
+        end
+      end
+    end
+
+    context '`password` is blank' do
+      let(:username) { 'username' }
+      let(:password) { nil }
+
+      it { is_expected.not_to be_valid }
+
+      context 'error types' do
+        before { subject.valid? }
+
+        it 'has an error in the `password` field' do
+          expect(subject.errors.added?(:password, :blank)).to be(true)
+        end
+
+        it 'does not have an error in the `username` field' do
+          expect(subject.errors.added?(:username)).to be(false)
+        end
+
+        it 'does not have errors in the base' do
+          expect(subject.errors.added?(:base)).to be(false)
+        end
+      end
+    end
+
+    context '`username` and `password` are entered but wrong' do
+      let(:username) { 'username' }
+      let(:password) { 'password' }
+
+      it { is_expected.not_to be_valid }
+
+      context 'error types' do
+        before { subject.valid? }
+
+        it 'does not have errors in the `username` field' do
+          expect(subject.errors.added?(:username)).to be(false)
+        end
+
+        it 'does not have errors in the `password` field' do
+          expect(subject.errors.added?(:password)).to be(false)
+        end
+
+        it 'has errors in the base' do
+          expect(subject.errors.added?(:base, :unauthorised)).to be(true)
+        end
+      end
+    end
+
+    context '`username` and `password` are entered and correct' do
+      let(:username) { 'username' }
+      let(:password) { 'password' }
+
+      before do
+        allow(ENV).to receive(:[]).with('BASIC_AUTH_USER').and_return(username)
+        allow(ENV).to receive(:[]).with('BASIC_AUTH_PASS').and_return(password)
+      end
+
+      it { is_expected.to be_valid }
+    end
+  end
+end

--- a/spec/requests/resume_controller_spec.rb
+++ b/spec/requests/resume_controller_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe MetadataPresenter::ResumeController, type: :request do
         post '/resume_forms', params: { resume_form: { uuid:, secret_answer: } }
 
         expect(response).to redirect_to('/resume_progress')
+        expect(response.cookies['_fb_authorised']).to be_nil
       end
 
       it 'redirects to resume from start if versions do not match' do
@@ -67,6 +68,26 @@ RSpec.describe MetadataPresenter::ResumeController, type: :request do
         post '/resume_forms', params: { resume_form: { uuid:, secret_answer: } }
 
         expect(response).to redirect_to('/resume_from_start')
+        expect(response.cookies['_fb_authorised']).to be_nil
+      end
+
+      context 'when basic auth is enabled' do
+        before do
+          allow(ENV).to receive(:[])
+          allow(ENV).to receive(:[]).with('BASIC_AUTH_USER').and_return('username')
+          allow(ENV).to receive(:[]).with('BASIC_AUTH_PASS').and_return('password')
+        end
+
+        it 'authorises the session' do
+          expect_any_instance_of(MetadataPresenter::ResumeController).to receive(:get_saved_progress).with(uuid).and_return(saved_form)
+          expect_any_instance_of(MetadataPresenter::ResumeController).to receive(:service).at_least(1).and_return(OpenStruct.new(version_id:))
+          expect_any_instance_of(MetadataPresenter::ResumeController).to receive(:invalidate_record).with(uuid)
+
+          post '/resume_forms', params: { resume_form: { uuid:, secret_answer: } }
+
+          expect(response).to redirect_to('/resume_progress')
+          expect(response.cookies['_fb_authorised']).not_to be_nil
+        end
       end
     end
 
@@ -74,6 +95,10 @@ RSpec.describe MetadataPresenter::ResumeController, type: :request do
       let(:secret_answer) { 'some other answer' }
       let(:saved_form) { OpenStruct.new(status: 200, body: JSON.parse("{\"id\":\"#{uuid}\",\"email\":\"email@email.com\",\"secret_question\":\"What was your mother's maiden name?\",\"secret_answer\":\"not a match\",\"page_slug\":\"email-address\",\"service_slug\":\"some-slug\",\"service_version\":\"#{version_id}\",\"user_id\":\"8acfb3db90002a5fc5b43e71638fc709\",\"user_token\":\"b9cca34d4331399c5f461c0ba1c406aa\",\"user_data_payload\":\"{\\\"name_text_1\\\"=\\u003e\\\"Name\\\"}\",\"attempts\":\"0.0\",\"active\":true,\"created_at\":\"2023-04-12T10:28:48.370Z\",\"updated_at\":\"2023-04-12T10:28:48.370Z\"}")) }
       let(:attempted_saved_form) { OpenStruct.new(status: 200, body: JSON.parse("{\"id\":\"#{uuid}\",\"email\":\"email@email.com\",\"secret_question\":\"What was your mother's maiden name?\",\"secret_answer\":\"not a match\",\"page_slug\":\"email-address\",\"service_slug\":\"some-slug\",\"service_version\":\"#{version_id}\",\"user_id\":\"8acfb3db90002a5fc5b43e71638fc709\",\"user_token\":\"b9cca34d4331399c5f461c0ba1c406aa\",\"user_data_payload\":\"{\\\"name_text_1\\\"=\\u003e\\\"Name\\\"}\",\"attempts\":\"3\",\"active\":true,\"created_at\":\"2023-04-12T10:28:48.370Z\",\"updated_at\":\"2023-04-12T10:28:48.370Z\"}")) }
+
+      after do
+        expect(response.cookies['_fb_authorised']).to be_nil
+      end
 
       it 're-renders with validation error' do
         expect_any_instance_of(MetadataPresenter::ResumeController).to receive(:get_saved_progress).with(uuid).and_return(saved_form)


### PR DESCRIPTION
https://trello.com/c/kgK7tVzy

This will "hook" into the current `require_basic_auth` runner before filter so it is as "drop-in" as possible.

It replaces the native browser basic auth with a hosted view / controller and form object to perform the authentication using the same user/password coming from ENV variables as before.

It sets a session cookie upon successful sign in and checks this cookie on each request to know if the user is allowed in.

A warning message is shown unless form is running in `live-production` or `test-production`.

Pending welsh translation of the new strings used in this feature. For the time being English strings will be shown.

![Screenshot 2024-03-13 at 12 30 33](https://github.com/ministryofjustice/fb-metadata-presenter/assets/687910/38272f32-f842-4603-9a95-cdb89230b6d4)
