### PR TITLE
Expose as_json method in address fieldset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.17] - 2024-02-23
+### Added
+- New method to serialise an address component.
+
 ## [3.3.16] - 2024-02-20
 ### Fixed
 - Fixed an issue where old default content in components created before recent changes was rendered

--- a/app/models/metadata_presenter/address_fieldset.rb
+++ b/app/models/metadata_presenter/address_fieldset.rb
@@ -27,7 +27,11 @@ module MetadataPresenter
     end
 
     def to_a
-      instance_values.values_at(*FIELDS).compact_blank
+      as_json.values.compact_blank
+    end
+
+    def as_json
+      super(only: FIELDS)
     end
 
     def conform(address_field)

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.16'.freeze
+  VERSION = '3.3.17'.freeze
 end

--- a/spec/models/address_fieldset_spec.rb
+++ b/spec/models/address_fieldset_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe MetadataPresenter::AddressFieldset do
   let(:metadata) do
     {
       'address_line_one' => '1 road',
+      'address_line_two' => '',
       'city' => 'ruby town',
+      'county' => '',
       'postcode' => '99 999',
       'country' => 'ruby land'
     }
@@ -42,6 +44,20 @@ RSpec.describe MetadataPresenter::AddressFieldset do
   describe '#to_a' do
     it 'returns a nice array to be shown in CYA page' do
       expect(subject.to_a).to eq(['1 road', 'ruby town', '99 999', 'ruby land'])
+    end
+  end
+
+  describe '#as_json' do
+    it 'returns a json representation of the address' do
+      expect(
+        subject.as_json
+      ).to eq(metadata)
+    end
+
+    it 'has the json keys ordered' do
+      expect(subject.as_json.keys).to eq(
+        %w[address_line_one address_line_two city county postcode country]
+      )
     end
   end
 end


### PR DESCRIPTION
This will be used in the runner as we will want to submit the address answer as JSON and not as a concatenated string as we were doing until now. Updated tests.

This change is backwards compatible as current runners are calling `#to_a` which we still keep as it is used in the check your answers page.