### PR TITLE
Move components on a multiquestion page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.18] - 2024-02-23
+### Added
+ - Changes to templates to support moving components in the editor
+
 ## [3.3.17] - 2024-02-23
 ### Added
 - New method to serialise an address component.

--- a/app/models/metadata_presenter/component.rb
+++ b/app/models/metadata_presenter/component.rb
@@ -15,7 +15,7 @@ class MetadataPresenter::Component < MetadataPresenter::Metadata
 
   def <=>(other)
     return nil unless other.is_a?(MetadataPresenter::Component)
-    return 0 unless order
+    return 0 unless order && other.order
 
     order <=> other.order
   end

--- a/app/views/metadata_presenter/attribute/_body.html.erb
+++ b/app/views/metadata_presenter/attribute/_body.html.erb
@@ -5,6 +5,8 @@
                           default-content="<%= default_text('body') %>"
                           content="<%= page_body_content %>"
                           data-fb-content-id="<%= "page[body]" %>">
-    <%= to_html(page_body_content) %>
+              <div class="html">
+                <%= to_html(page_body_content) %>
+              </div>
   </editable-content>
 <%- end %>

--- a/app/views/metadata_presenter/attribute/_lede.html.erb
+++ b/app/views/metadata_presenter/attribute/_lede.html.erb
@@ -3,6 +3,8 @@
         data-fb-content-id="page[lede]"
         data-fb-content-type="element"
         data-fb-default-text="<%= default_text('lede') %>">
-    <%= @page.lede %>
+    <div class="html">
+      <%= @page.lede %>
+    </div>
   </div>
 <%- end %>

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -9,15 +9,14 @@
                           data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
                           data-config="<%= component.to_json %>"
                           data-conditional-api-path="<%= editable? ? URI.decode_www_form_component(api_service_edit_conditional_content_path(service.service_id, component.uuid)) : '' %>"
-                          data-controller="orderable-item movable-item component"
+                          data-controller="orderable-item component"
                           data-orderable-item-order-value="<%= component.order || index %>"
-                          data-movable-items-target="movableItem"
                           data-orderable-items-target="orderableItem"
-                          data-action="movable-item:move->orderable-items#reorder 
-                                       movable-item:move->component#focus
+                          data-action="orderable-item:move->orderable-items#reorder 
+                                       orderable-item:move->component#focus
                                        orderable-item:orderUpdated->component#update 
                                        questionRemove->component#destroy" 
-                          data-movable-item-moving-class="moving">
+                          data-orderable-item-moving-class="moving">
               <div class="html">
                 <%= to_html(component.content) %>
               </div>
@@ -30,15 +29,14 @@
          data-fb-content-data="<%= component.to_json %>"
          data-fb-default-value="<%= default_title(component.type) %>"
          data-fb-default-item-value="<%= default_item_title(component.type) %>"
-         data-controller="orderable-item movable-item component"
+         data-controller="orderable-item component"
          data-orderable-item-order-value="<%= component.order || index %>"
-         data-movable-items-target="movableItem"
          data-orderable-items-target="orderableItem"
-         data-action="movable-item:move->orderable-items#reorder 
-                      movable-item:move->component#focus
+         data-action="orderable-item:move->orderable-items#reorder 
+                      orderable-item:move->component#focus
                       orderable-item:orderUpdated->component#update 
                       questionRemove->component#destroy" 
-         data-movable-item-moving-class="moving">
+         data-orderable-item-moving-class="moving">
 
          <%= render partial: component, locals: {
            f: f,

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -2,7 +2,11 @@
 
   <% if component.type == 'content' %>
     <% next unless (editable? || @page.show_conditional_component?(component.uuid) || single_page_preview?) %>
-
+<div data-controller="orderable-item movable-item component"
+         data-orderable-item-order-value="<%= index %>"
+         data-movable-items-target="movableItem"
+         data-orderable-items-target="orderableItem"
+         data-action="movable-item:move->orderable-items#reorder orderable-item:orderUpdated->component#update">
     <editable-content id="<%= component.id %>"
                       class="fb-editable govuk-!-margin-top-8"
                       type="<%= component.type %>"
@@ -10,12 +14,19 @@
                       content="<%= component.content %>"
                       data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
                       data-config="<%= component.to_json %>"
-                      data-conditional-api-path="<%= editable? ? URI.decode_www_form_component(api_service_edit_conditional_content_path(service.service_id, component.uuid)) : '' %>">
-        <%= to_html(component.content) %>
+                      data-conditional-api-path="<%= editable? ? URI.decode_www_form_component(api_service_edit_conditional_content_path(service.service_id, component.uuid)) : '' %>"
+                      data-component-target="content">
+         <%= to_html(component.content) %>
     </editable-content>
+</div>
   <% end %>
 
   <% unless component.type == 'content' %>
+    <div data-controller="orderable-item movable-item component"
+         data-orderable-item-order-value="<%= index %>"
+         data-movable-items-target="movableItem"
+         data-orderable-items-target="orderableItem"
+         data-action="movable-item:move->orderable-items#reorder orderable-item:orderUpdated->component#update">
     <div class="fb-editable govuk-!-margin-top-8"
          id="<%= component.id %>"
          data-fb-content-type="<%= component.type %>"
@@ -23,10 +34,7 @@
          data-fb-content-data="<%= component.to_json %>"
          data-fb-default-value="<%= default_title(component.type) %>"
          data-fb-default-item-value="<%= default_item_title(component.type) %>"
-         data-questions-target="question"
-         data-controller="question"
-         data-question-index-value="<%= index %>"
-         data-question-content-value="<%= component.to_json %>">
+         data-component-target="question">
 
          <%= render partial: component, locals: {
            f: f,
@@ -39,6 +47,7 @@
            )
          }
        %>
+    </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -22,7 +22,11 @@
          data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
          data-fb-content-data="<%= component.to_json %>"
          data-fb-default-value="<%= default_title(component.type) %>"
-         data-fb-default-item-value="<%= default_item_title(component.type) %>">
+         data-fb-default-item-value="<%= default_item_title(component.type) %>"
+         data-questions-target="question"
+         data-controller="question"
+         data-question-index-value="<%= index %>"
+         data-question-content-value="<%= component.to_json %>">
 
          <%= render partial: component, locals: {
            f: f,

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -10,7 +10,7 @@
                           data-config="<%= component.to_json %>"
                           data-conditional-api-path="<%= editable? ? URI.decode_www_form_component(api_service_edit_conditional_content_path(service.service_id, component.uuid)) : '' %>"
                           data-controller="orderable-item movable-item component"
-                          data-orderable-item-order-value="<%= component.order %>"
+                          data-orderable-item-order-value="<%= component.order || index %>"
                           data-movable-items-target="movableItem"
                           data-orderable-items-target="orderableItem"
                           data-action="movable-item:move->orderable-items#reorder 
@@ -31,7 +31,7 @@
          data-fb-default-value="<%= default_title(component.type) %>"
          data-fb-default-item-value="<%= default_item_title(component.type) %>"
          data-controller="orderable-item movable-item component"
-         data-orderable-item-order-value="<%= component.order %>"
+         data-orderable-item-order-value="<%= component.order || index %>"
          data-movable-items-target="movableItem"
          data-orderable-items-target="orderableItem"
          data-action="movable-item:move->orderable-items#reorder 

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -3,10 +3,12 @@
   <% if component.type == 'content' %>
     <% next unless (editable? || @page.show_conditional_component?(component.uuid) || single_page_preview?) %>
 <div data-controller="orderable-item movable-item component"
-         data-orderable-item-order-value="<%= index %>"
+         data-orderable-item-order-value="<%= component.order %>"
          data-movable-items-target="movableItem"
          data-orderable-items-target="orderableItem"
-         data-action="movable-item:move->orderable-items#reorder orderable-item:orderUpdated->component#update">
+         data-action="movable-item:move->orderable-items#reorder orderable-item:orderUpdated->component#update"
+         data-movable-item-moving-class="moving">
+ 
     <editable-content id="<%= component.id %>"
                       class="fb-editable govuk-!-margin-top-8"
                       type="<%= component.type %>"
@@ -22,11 +24,7 @@
   <% end %>
 
   <% unless component.type == 'content' %>
-    <div data-controller="orderable-item movable-item component"
-         data-orderable-item-order-value="<%= index %>"
-         data-movable-items-target="movableItem"
-         data-orderable-items-target="orderableItem"
-         data-action="movable-item:move->orderable-items#reorder orderable-item:orderUpdated->component#update">
+
     <div class="fb-editable govuk-!-margin-top-8"
          id="<%= component.id %>"
          data-fb-content-type="<%= component.type %>"
@@ -34,7 +32,15 @@
          data-fb-content-data="<%= component.to_json %>"
          data-fb-default-value="<%= default_title(component.type) %>"
          data-fb-default-item-value="<%= default_item_title(component.type) %>"
-         data-component-target="question">
+         data-controller="orderable-item movable-item component"
+         data-orderable-item-order-value="<%= component.order %>"
+         data-movable-items-target="movableItem"
+         data-orderable-items-target="orderableItem"
+         data-action="movable-item:move->orderable-items#reorder 
+                      movable-item:move->component#focus
+                      orderable-item:orderUpdated->component#update 
+                      questionRemove->component#destroy" 
+         data-movable-item-moving-class="moving">
 
          <%= render partial: component, locals: {
            f: f,
@@ -47,7 +53,6 @@
            )
          }
        %>
-    </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -1,30 +1,28 @@
 <% components.each_with_index do |component, index| %>
-
   <% if component.type == 'content' %>
     <% next unless (editable? || @page.show_conditional_component?(component.uuid) || single_page_preview?) %>
-<div data-controller="orderable-item movable-item component"
-         data-orderable-item-order-value="<%= component.order %>"
-         data-movable-items-target="movableItem"
-         data-orderable-items-target="orderableItem"
-         data-action="movable-item:move->orderable-items#reorder orderable-item:orderUpdated->component#update"
-         data-movable-item-moving-class="moving">
- 
-    <editable-content id="<%= component.id %>"
-                      class="fb-editable govuk-!-margin-top-8"
-                      type="<%= component.type %>"
-                      default-content="<%= default_text('content') %>"
-                      content="<%= component.content %>"
-                      data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
-                      data-config="<%= component.to_json %>"
-                      data-conditional-api-path="<%= editable? ? URI.decode_www_form_component(api_service_edit_conditional_content_path(service.service_id, component.uuid)) : '' %>"
-                      data-component-target="content">
-         <%= to_html(component.content) %>
-    </editable-content>
-</div>
-  <% end %>
-
-  <% unless component.type == 'content' %>
-
+        <editable-content id="<%= component.id %>"
+                          class="fb-editable govuk-!-margin-top-8"
+                          type="<%= component.type %>"
+                          default-content="<%= default_text('content') %>"
+                          content="<%= component.content %>"
+                          data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
+                          data-config="<%= component.to_json %>"
+                          data-conditional-api-path="<%= editable? ? URI.decode_www_form_component(api_service_edit_conditional_content_path(service.service_id, component.uuid)) : '' %>"
+                          data-controller="orderable-item movable-item component"
+                          data-orderable-item-order-value="<%= component.order %>"
+                          data-movable-items-target="movableItem"
+                          data-orderable-items-target="orderableItem"
+                          data-action="movable-item:move->orderable-items#reorder 
+                                       movable-item:move->component#focus
+                                       orderable-item:orderUpdated->component#update 
+                                       questionRemove->component#destroy" 
+                          data-movable-item-moving-class="moving">
+              <div class="html">
+                <%= to_html(component.content) %>
+              </div>
+        </editable-content>
+  <% else %>
     <div class="fb-editable govuk-!-margin-top-8"
          id="<%= component.id %>"
          data-fb-content-type="<%= component.type %>"

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -77,7 +77,9 @@
                             default-content="<%= default_text('body') %>"
                             content="<%= @page.send_body %>"
                             data-fb-content-id="<%= "page[send_body]" %>">
-              <%= to_html(@page.send_body) %>
+              <div class="html">
+                <%= to_html(@page.send_body) %>
+              </div>
           </editable-content>
         <% end %>
 

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -32,7 +32,9 @@
                data-fb-content-id="page[lede]"
                data-fb-content-type="element"
                data-fb-default-text="<%= default_text('lede') %>">
-            <%= @page.lede %>
+              <div class="html">
+                <%= @page.lede %>
+              </div>
           </div>
         <%- end %>
       </div>

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -14,7 +14,7 @@
         <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
 
-        <div data-controller="questions">
+        <div data-controller="orderable-items movable-items components">
         <%= render partial: 'metadata_presenter/component/components', locals: {
             f: f,
             components: @page.components,

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -15,6 +15,7 @@
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
 
         <div data-controller="orderable-items movable-items components">
+
         <%= render partial: 'metadata_presenter/component/components', locals: {
             f: f,
             components: @page.components,

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -14,6 +14,7 @@
         <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
 
+        <div data-controller="questions">
         <%= render partial: 'metadata_presenter/component/components', locals: {
             f: f,
             components: @page.components,
@@ -23,6 +24,7 @@
             content_components: @page.supported_content_components
           }
         %>
+        </div>
         <div class="govuk-button-group">
           <%= f.govuk_submit(t('presenter.actions.continue'), disabled: editable?) %>
 

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -14,7 +14,7 @@
         <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
 
-        <div data-controller="orderable-items movable-items">
+        <div data-controller="orderable-items">
           <%= render partial: 'metadata_presenter/component/components', locals: {
               f: f,
               components: @page.components,

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -14,7 +14,7 @@
         <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
 
-        <div data-controller="orderable-items">
+        <div class="components" data-controller="orderable-items">
           <%= render partial: 'metadata_presenter/component/components', locals: {
               f: f,
               components: @page.components,

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -14,17 +14,16 @@
         <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
 
-        <div data-controller="orderable-items movable-items components">
-
-        <%= render partial: 'metadata_presenter/component/components', locals: {
-            f: f,
-            components: @page.components,
-            tag: :h2,
-            classes: 'govuk-heading-m',
-            input_components: @page.supported_input_components,
-            content_components: @page.supported_content_components
-          }
-        %>
+        <div data-controller="orderable-items movable-items">
+          <%= render partial: 'metadata_presenter/component/components', locals: {
+              f: f,
+              components: @page.components,
+              tag: :h2,
+              classes: 'govuk-heading-m',
+              input_components: @page.supported_input_components,
+              content_components: @page.supported_content_components
+            }
+          %>
         </div>
         <div class="govuk-button-group">
           <%= f.govuk_submit(t('presenter.actions.continue'), disabled: editable?) %>

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -22,7 +22,9 @@
                           default-content="<%= default_text('before_you_start') %>"
                           content="<%= @page.before_you_start %>"
                           data-fb-content-id="<%= "page[before_you_start]" %>">
-          <%= to_html(@page.before_you_start) %>
+              <div class="html">
+                <%= to_html(@page.before_you_start) %>
+              </div>
         </editable-content>
       <%- end %>
     </div>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.17'.freeze
+  VERSION = '3.3.18'.freeze
 end


### PR DESCRIPTION
This PR updates the temp[lates to accomodate moving components on a multiquestion page

Changes include:
* Adding data attributes for stimulus controllers used in the editor
* Adding a wrapper div around editable content in order for it to work with move