### PR TITLE
Resolve issue with if/and conditions for content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.22] - 2024-03-06
+### Fixed
+ - Fixed an issue where conditional content visibility would incorrectly return true if the first condition was `if` and was true.
+
 ## [3.3.21] - 2024-02-29
 ### Fixed
  - Fixed an issue where content wouldn't render on multiquestion pages with validation errors.

--- a/app/models/metadata_presenter/evaluate_content_conditionals.rb
+++ b/app/models/metadata_presenter/evaluate_content_conditionals.rb
@@ -22,12 +22,8 @@ module MetadataPresenter
 
     def uuid_to_include?(candidate_component)
       evaluation_conditions = []
-      if candidate_component.conditionals.count == 1
-        # if there are only and rules or the particular case where there is only one condition
-        evaluation_conditions << evaluate_condition(candidate_component.conditionals[0])
-        candidate_component.uuid if evaluation_conditions.flatten.all?
-      elsif candidate_component.conditionals.count > 1
-        # if there are or rule
+
+      if candidate_component.conditionals.count > 1
         if candidate_component.conditionals[0][:_type] == 'and'
           # if there are 'and' in conditions between the 'or' rule
           candidate_component.conditionals.map do |conditional|
@@ -42,6 +38,10 @@ module MetadataPresenter
           end
           candidate_component.uuid if evaluation_conditions.flatten.any?
         end
+      else
+        # if there are only and rules or the particular case where there is only one condition
+        evaluation_conditions << evaluate_condition(candidate_component.conditionals[0])
+        candidate_component.uuid if evaluation_conditions.flatten.all?
       end
     end
 

--- a/app/models/metadata_presenter/evaluate_content_conditionals.rb
+++ b/app/models/metadata_presenter/evaluate_content_conditionals.rb
@@ -24,22 +24,16 @@ module MetadataPresenter
       evaluation_conditions = []
 
       if candidate_component.conditionals.count > 1
-        if candidate_component.conditionals[0][:_type] == 'and'
-          # if there are 'and' in conditions between the 'or' rule
-          candidate_component.conditionals.map do |conditional|
+        candidate_component.conditionals.each do |conditional|
+          if conditional[:_type] == 'and'
             evaluation_conditions << evaluate_condition(conditional).flatten.all?
-          end
-          return candidate_component.uuid if evaluation_conditions.flatten.any?
-        end
-        if candidate_component.conditionals[0][:_type] == 'if'
-          # then this is an 'or' condition between conditionals
-          candidate_component.conditionals.map do |conditional|
+          else
             evaluation_conditions << evaluate_condition(conditional)
           end
-          candidate_component.uuid if evaluation_conditions.flatten.any?
         end
+
+        candidate_component.uuid if evaluation_conditions.flatten.any?
       else
-        # if there are only and rules or the particular case where there is only one condition
         evaluation_conditions << evaluate_condition(candidate_component.conditionals[0])
         candidate_component.uuid if evaluation_conditions.flatten.all?
       end

--- a/app/models/metadata_presenter/evaluate_content_conditionals.rb
+++ b/app/models/metadata_presenter/evaluate_content_conditionals.rb
@@ -25,11 +25,11 @@ module MetadataPresenter
 
       if candidate_component.conditionals.count > 1
         candidate_component.conditionals.each do |conditional|
-          if conditional[:_type] == 'and'
-            evaluation_conditions << evaluate_condition(conditional).flatten.all?
-          else
-            evaluation_conditions << evaluate_condition(conditional)
-          end
+          evaluation_conditions << if conditional[:_type] == 'and'
+                                     evaluate_condition(conditional).flatten.all?
+                                   else
+                                     evaluate_condition(conditional)
+                                   end
         end
 
         candidate_component.uuid if evaluation_conditions.flatten.any?

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.21'.freeze
+  VERSION = '3.3.22'.freeze
 end


### PR DESCRIPTION
This resolves a bug where if you have a condition that looks like `[if, and, and, and]` then it would hit the code branch for `[0] == if` and return `.any?` which meant that if was true, but none of the and conditions were, it would still be considered true and show the content.

New AT with a test for this in dev https://github.com/ministryofjustice/fb-acceptance-tests/pull/398
<img width="928" alt="image" src="https://github.com/ministryofjustice/fb-metadata-presenter/assets/7647632/ce00c142-2bd2-4b1f-aa95-e58fbe6dc497">
