### PR TITLE
Movable components everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.23] - 2024-03-07
+### Changed
+ - Updated templates to allow components to be moved on any page type not just
+ multiplequestion
+
 ## [3.3.22] - 2024-03-06
 ### Fixed
  - Fixed an issue where conditional content visibility would incorrectly return true if the first condition was `if` and was true.

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -1,54 +1,56 @@
-<% components.each_with_index do |component, index| %>
-  <% if component.type == 'content' %>
-    <% next unless (editable? || @page.show_conditional_component?(component.uuid) || single_page_preview?) %>
-        <editable-content id="<%= component.id %>"
-                          class="fb-editable govuk-!-margin-top-8"
-                          type="<%= component.type %>"
-                          default-content="<%= default_text('content') %>"
-                          content="<%= component.content %>"
-                          data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
-                          data-config="<%= component.to_json %>"
-                          data-conditional-api-path="<%= editable? ? URI.decode_www_form_component(api_service_edit_conditional_content_path(service.service_id, component.uuid)) : '' %>"
-                          data-controller="orderable-item component"
-                          data-orderable-item-order-value="<%= component.order || index %>"
-                          data-orderable-items-target="orderableItem"
-                          data-action="orderable-item:move->orderable-items#reorder 
-                                       orderable-item:move->component#focus
-                                       orderable-item:orderUpdated->component#update 
-                                       questionRemove->component#destroy" 
-                          data-orderable-item-moving-class="moving">
-              <div class="html">
-                <%= to_html(component.content) %>
-              </div>
-        </editable-content>
-  <% else %>
-    <div class="fb-editable govuk-!-margin-top-8"
-         id="<%= component.id %>"
-         data-fb-content-type="<%= component.type %>"
-         data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
-         data-fb-content-data="<%= component.to_json %>"
-         data-fb-default-value="<%= default_title(component.type) %>"
-         data-fb-default-item-value="<%= default_item_title(component.type) %>"
-         data-controller="orderable-item component"
-         data-orderable-item-order-value="<%= component.order || index %>"
-         data-orderable-items-target="orderableItem"
-         data-action="orderable-item:move->orderable-items#reorder 
-                      orderable-item:move->component#focus
-                      orderable-item:orderUpdated->component#update 
-                      questionRemove->component#destroy" 
-         data-orderable-item-moving-class="moving">
+<div class="components" data-controller="orderable-items">
+  <% components.each_with_index do |component, index| %>
+    <% if component.type == 'content' %>
+      <% next unless (editable? || @page.show_conditional_component?(component.uuid) || single_page_preview?) %>
+          <editable-content id="<%= component.id %>"
+                            class="fb-editable govuk-!-margin-top-8"
+                            type="<%= component.type %>"
+                            default-content="<%= default_text('content') %>"
+                            content="<%= component.content %>"
+                            data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
+                            data-config="<%= component.to_json %>"
+                            data-conditional-api-path="<%= editable? ? URI.decode_www_form_component(api_service_edit_conditional_content_path(service.service_id, component.uuid)) : '' %>"
+                            data-controller="orderable-item component"
+                            data-orderable-item-order-value="<%= component.order || index %>"
+                            data-orderable-items-target="orderableItem"
+                            data-action="orderable-item:move->orderable-items#reorder 
+                                         orderable-item:move->component#focus
+                                         orderable-item:orderUpdated->component#update 
+                                         questionRemove->component#destroy" 
+                            data-orderable-item-moving-class="moving">
+                <div class="html">
+                  <%= to_html(component.content) %>
+                </div>
+          </editable-content>
+    <% else %>
+      <div class="fb-editable govuk-!-margin-top-8"
+           id="<%= component.id %>"
+           data-fb-content-type="<%= component.type %>"
+           data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
+           data-fb-content-data="<%= component.to_json %>"
+           data-fb-default-value="<%= default_title(component.type) %>"
+           data-fb-default-item-value="<%= default_item_title(component.type) %>"
+           data-controller="orderable-item component"
+           data-orderable-item-order-value="<%= component.order || index %>"
+           data-orderable-items-target="orderableItem"
+           data-action="orderable-item:move->orderable-items#reorder 
+                        orderable-item:move->component#focus
+                        orderable-item:orderUpdated->component#update 
+                        questionRemove->component#destroy" 
+           data-orderable-item-moving-class="moving">
 
-         <%= render partial: component, locals: {
-           f: f,
-           component: component,
-           component_id: "page[#{component.collection}[#{index}]]",
-           input_title: main_title(
+           <%= render partial: component, locals: {
+             f: f,
              component: component,
-             tag: :h2,
-             classes: classes
-           )
-         }
-       %>
-    </div>
+             component_id: "page[#{component.collection}[#{index}]]",
+             input_title: main_title(
+               component: component,
+               tag: :h2,
+               classes: classes
+             )
+           }
+         %>
+      </div>
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -14,7 +14,6 @@
         <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
 
-        <div class="components" data-controller="orderable-items">
           <%= render partial: 'metadata_presenter/component/components', locals: {
               f: f,
               components: @page.components,
@@ -24,7 +23,7 @@
               content_components: @page.supported_content_components
             }
           %>
-        </div>
+
         <div class="govuk-button-group">
           <%= f.govuk_submit(t('presenter.actions.continue'), disabled: editable?) %>
 

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.22'.freeze
+  VERSION = '3.3.23'.freeze
 end


### PR DESCRIPTION
This PR updates the templates by moving the `.components` wrapper `<div>` into the `_components.html.erb` partial.  This allows any template that includes the components partial to gain the ordering/moving ability.