### PR TITLE
Release v3.3.24 (bug fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.24] - 2024-03-11
+### Fixed
+- Fixed position of error summary in multi-question pages.
+- Fixed an edge case with uploaded files with uncommon `image/jpeg` uppercase file extensions.
+
 ## [3.3.23] - 2024-03-07
 ### Changed
  - Updated templates to allow components to be moved on any page type not just

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -172,8 +172,8 @@ module MetadataPresenter
     def jfif_or_jpg_extension?(answer)
       return false if answer.nil?
 
-      file_extension = File.extname(answer)
-      %w[.jfif .jpg].include?(file_extension)
+      file_extension = File.extname(answer).downcase
+      %w[.jpg .jpe .jif .jfif].include?(file_extension)
     end
 
     # NOTE: Address component is different to other components in the sense it can

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -168,10 +168,11 @@ module MetadataPresenter
     def normalise_file_extension(answer)
       return if answer.nil?
 
-      file_extension = File.extname(answer).downcase
+      file_extension = File.extname(answer)
       file_basename  = answer.delete_suffix(file_extension)
 
       # Handle less common `image/jpeg` MIME type extensions
+      file_extension.downcase!
       file_extension = '.jpeg' if %w[.jpg .jpe .jif .jfif].include?(file_extension)
 
       [file_basename, file_extension].join

--- a/app/models/metadata_presenter/page_answers.rb
+++ b/app/models/metadata_presenter/page_answers.rb
@@ -146,7 +146,7 @@ module MetadataPresenter
     end
 
     def sanitize_filename(answer)
-      sanitize(filename(update_filename(answer)))
+      sanitize(filename(normalise_file_extension(answer)))
     end
 
     def filename(path)
@@ -165,15 +165,16 @@ module MetadataPresenter
       filename
     end
 
-    def update_filename(answer)
-      jfif_or_jpg_extension?(answer) ? "#{File.basename(answer, '.*')}.jpeg" : answer
-    end
-
-    def jfif_or_jpg_extension?(answer)
-      return false if answer.nil?
+    def normalise_file_extension(answer)
+      return if answer.nil?
 
       file_extension = File.extname(answer).downcase
-      %w[.jpg .jpe .jif .jfif].include?(file_extension)
+      file_basename  = answer.delete_suffix(file_extension)
+
+      # Handle less common `image/jpeg` MIME type extensions
+      file_extension = '.jpeg' if %w[.jpg .jpe .jif .jfif].include?(file_extension)
+
+      [file_basename, file_extension].join
     end
 
     # NOTE: Address component is different to other components in the sense it can

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -8,11 +8,11 @@
       <%= render partial:'metadata_presenter/component/conditional_component_banner'%>
 
       <%= render 'metadata_presenter/attribute/section_heading' %>
-      <%= render 'metadata_presenter/attribute/heading' %>
 
       <%= form_for @page_answers, as: :answers, url: @page.url, method: :post, authenticity_token: false do |f| %>
         <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
+        <%= render 'metadata_presenter/attribute/heading' %>
 
           <%= render partial: 'metadata_presenter/component/components', locals: {
               f: f,

--- a/app/views/metadata_presenter/save_and_return/email_confirmation.html.erb
+++ b/app/views/metadata_presenter/save_and_return/email_confirmation.html.erb
@@ -7,7 +7,7 @@
         <div class="govuk-form-group">
           <%=
           f.govuk_email_field :email_confirmation,
-            label: { size: 'l', text: t('presenter.save_and_return.confirm_email.heading') },
+            label: { tag: 'h1', size: 'l', text: t('presenter.save_and_return.confirm_email.heading') },
             name: "email_confirmation",
             spellcheck: "false",
             autocomplete: "email"

--- a/app/views/metadata_presenter/save_and_return/show.html.erb
+++ b/app/views/metadata_presenter/save_and_return/show.html.erb
@@ -1,11 +1,12 @@
 <div class="fb-main-grid-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-    <h1 id="page-heading" class="govuk-heading-xl"><%= t('presenter.save_and_return.show.heading') %></h1>
-    <p class="mojf-settings-screen__description"><%= t('presenter.save_and_return.show.description') %></p>
-
       <%= form_for @saved_form do |f| %>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
+
+        <h1 id="page-heading" class="govuk-heading-xl"><%= t('presenter.save_and_return.show.heading') %></h1>
+        <p class="mojf-settings-screen__description"><%= t('presenter.save_and_return.show.description') %></p>
+
         <div class="govuk-form-group">
         <%= f.hidden_field(:page_slug, value: page_slug) %>
           <%=

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.23'.freeze
+  VERSION = '3.3.24'.freeze
 end

--- a/spec/models/page_answers_spec.rb
+++ b/spec/models/page_answers_spec.rb
@@ -418,6 +418,18 @@ RSpec.describe MetadataPresenter::PageAnswers do
                 ).to eq('hello.png')
               end
             end
+
+            context 'when file extension is uncommon jpeg mime type' do
+              let(:upload_file) do
+                { 'original_filename' => 'test.JFIF' }
+              end
+
+              it 'replaces the extension and makes it lowercase' do
+                expect(
+                  page_answers.send('dog-picture_upload_1')['original_filename']
+                ).to eq('test.jpeg')
+              end
+            end
           end
 
           context 'when file details is an ActionController::Parameters object' do


### PR DESCRIPTION
- Fixed position of error summary in multi-question pages.
- Fixed an edge case with uploaded files with uncommon `image/jpeg` uppercase file extensions.

Uploaded files now will always have their file extension lowercase to be consistent with the submitter that will apply the mime type extension and will be also lowercase.
This makes it consistent across check your answers, PDF, CSV and email attachments.