### PR TITLE
Backlink for a non-existent page fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.29] - 2024-04-03
+### Fixed
+- Make sure that the back link on a non existent page is referencing the previous page and not the precedent of the previous page
+
 ## [3.3.28] - 2024-03-25
 ### Fixed
 - Fix issue with validating autocomplete options containing ampersands

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -72,6 +72,10 @@ module MetadataPresenter
           previous_page.url
         )
       end
+
+      if response.status == 404
+        @back_link = File.join(request.script_name, @page.url)
+      end
     end
     helper_method :back_link
 

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -55,6 +55,10 @@ module MetadataPresenter
     end
 
     def back_link
+      if response.status == 404
+        @back_link = File.join(request.script_name, @page.url)
+      end
+
       if use_external_start_page? && first_page?
         return external_start_page_url
       end
@@ -71,10 +75,6 @@ module MetadataPresenter
           request.script_name,
           previous_page.url
         )
-      end
-
-      if response.status == 404
-        @back_link = File.join(request.script_name, @page.url)
       end
     end
     helper_method :back_link

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.28'.freeze
+  VERSION = '3.3.29'.freeze
 end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
         let(:referrer) { '/' }
         let(:status) { 200 }
 
-
         it 'returns the previous page' do
           expect(controller.back_link).to eq('/')
         end

--- a/spec/controllers/engine_controller_spec.rb
+++ b/spec/controllers/engine_controller_spec.rb
@@ -3,6 +3,13 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
     before do
       allow(controller.request).to receive(:script_name).and_return(script_name)
       allow(controller.request).to receive(:referrer).and_return(referrer)
+      RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+      allow(controller.response).to receive(:status).and_return(status)
+      controller.instance_variable_set(:@page, page)
+    end
+
+    after do
+      RSpec::Mocks.configuration.allow_message_expectations_on_nil = false
     end
 
     context 'when in preview' do
@@ -10,11 +17,8 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
         '/services/1/preview'
       end
 
-      before do
-        controller.instance_variable_set(:@page, page)
-      end
-
       context 'when there is a page' do
+        let(:status) { 200 }
         let(:page) { MetadataPresenter::Page.new(service.pages.second) }
         let(:referrer) { 'http://localhost:3000/services/1/preview' }
 
@@ -26,6 +30,7 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
       context 'when there is no page' do
         let(:page) { MetadataPresenter::Page.new(service.pages.first) }
         let(:referrer) { nil }
+        let(:status) { 404 }
 
         it 'returns nil' do
           expect(controller.back_link).to be_nil
@@ -39,10 +44,8 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
       context 'when there is a page' do
         let(:page) { MetadataPresenter::Page.new(service.pages.second) }
         let(:referrer) { '/' }
+        let(:status) { 200 }
 
-        before do
-          controller.instance_variable_set(:@page, page)
-        end
 
         it 'returns the previous page' do
           expect(controller.back_link).to eq('/')
@@ -51,6 +54,8 @@ RSpec.describe MetadataPresenter::EngineController, type: :controller do
 
       context 'when there is no page' do
         let(:referrer) { nil }
+        let(:status) { 404 }
+        let(:page) { MetadataPresenter::Page.new(service.pages.second) }
 
         it 'returns nil' do
           expect(controller.back_link).to be_nil

--- a/spec/validators/pattern_validator_spec.rb
+++ b/spec/validators/pattern_validator_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe MetadataPresenter::PatternValidator do
     context 'when answer does not match pattern' do
       let(:answers) { { 'name_text_1' => '123' } }
 
-      it 'returns valid' do
+      it 'returns invalid' do
         expect(validator).to_not be_valid
       end
     end


### PR DESCRIPTION
[Trello](https://trello.com/c/fxjAcvOd/3995-back-link-on-page-missing-page-is-incorrect-prioritisation-score-9)

Back link on a non-existent page was linking to 2 pages back because page didn't exist so the previous page was still page and backlink reference the previous to this page. This fix check if the page exist, i.e. if the response is not a 404.
