### PR TITLE
Semantic editable headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.30] - 2024-04-04
+### Changed
+ - Updated all editable headings to have a nested span for improved semantics when editing
+
 ## [3.3.29] - 2024-04-03
 ### Fixed
 - Make sure that the back link on a non existent page is referencing the previous page and not the precedent of the previous page

--- a/app/helpers/metadata_presenter/application_helper.rb
+++ b/app/helpers/metadata_presenter/application_helper.rb
@@ -6,7 +6,7 @@ module MetadataPresenter
 
     def main_title(component:, tag: :h1, classes: 'govuk-heading-xl')
       content_tag(tag, class: classes) do
-        component.humanised_title
+        content_tag(:span, component.humanised_title)
       end
     end
 

--- a/app/views/metadata_presenter/attribute/_heading.html.erb
+++ b/app/views/metadata_presenter/attribute/_heading.html.erb
@@ -1,7 +1,9 @@
-<h1 class="fb-editable govuk-heading-xl"
+<h1>
+  <span class="fb-editable govuk-heading-xl"
     data-fb-content-id="page[heading]"
     data-fb-content-type="element"
     data-fb-default-value="<%= default_page_title(@page.type) %>">
-  <%= @page.heading %>
+    <%= @page.heading %>
+  </span>
 </h1>
 

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -45,7 +45,7 @@
              component_id: "page[#{component.collection}[#{index}]]",
              input_title: main_title(
                component: component,
-               tag_name: :h2,
+               tag: :h2,
                classes: classes
              )
            }

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -45,7 +45,7 @@
              component_id: "page[#{component.collection}[#{index}]]",
              input_title: main_title(
                component: component,
-               tag: :h2,
+               tag_name: :h2,
                classes: classes
              )
            }

--- a/app/views/metadata_presenter/component/_multiupload.html.erb
+++ b/app/views/metadata_presenter/component/_multiupload.html.erb
@@ -28,7 +28,7 @@
       text: component.hint.present? ? component.hint : ''
     },
     accept: component.validation['accept'],
-    disabled: editable?,
+    'aria-disabled': editable?,
     label: -> do %>
       <% if answered?(component.id) && @page_answers.send(component.id)[component.id].compact.count.positive? && !editable? %>
         <h3 class="govuk-heading-s govuk-!-margin-top-8"><%= t('presenter.questions.multiupload.add_another') %></h3>

--- a/app/views/metadata_presenter/component/_multiupload.html.erb
+++ b/app/views/metadata_presenter/component/_multiupload.html.erb
@@ -1,4 +1,4 @@
-<legend class="govuk-heading-xl"><%= input_title %></legend>
+<label><%= input_title %></label>
 <%= render 'metadata_presenter/attribute/body' %>
 
 <% if answered?(component.id) && @page_answers.send(component.id)[component.id].compact.count.positive? %>

--- a/app/views/metadata_presenter/component/_upload.html.erb
+++ b/app/views/metadata_presenter/component/_upload.html.erb
@@ -1,5 +1,5 @@
 <% if answered?(component.id) %>
-  <h1 class="govuk-heading-xl"><%= input_title %></h1>
+  <%= input_title %>
   <span class="govuk-hint" id="answers-dog-picture-upload-1-hint" data-fb-default-text="<%= default_text('upload_hint') %>">
     <%= component.hint.present? ? component.hint : default_text('upload_hint') %>
   </span>

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -4,11 +4,13 @@
 
       <%= render partial:'metadata_presenter/component/conditional_component_banner'%>
 
-      <h1 class="fb-editable govuk-heading-xl"
+      <h1>
+        <span class="fb-editable govuk-heading-xl"
           data-fb-content-type="element"
           data-fb-content-id="page[heading]"
           data-fb-default-value="<%= default_page_title(@page.type) %>">
-        <%= @page.heading %>
+          <%= @page.heading %>
+        </span>
       </h1>
 
       <%= form_for @page, url: reserved_submissions_path, authenticity_token: false, html: { id: 'answers-form' } do |f| %>

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -8,15 +8,17 @@
     <% else %>
       <div class="govuk-panel govuk-panel--confirmation govuk-grid-column-two-thirds">
       <% end %>
-      <h1 class="fb-editable govuk-panel__title"
+      <h1>
+        <span class="fb-editable govuk-panel__title"
           data-fb-content-type="element"
           data-fb-content-id="page[heading]"
           data-fb-default-value="<%= default_page_title(@page.type) %>">
-        <% if payment_link_enabled? && @page.heading == I18n.t('presenter.confirmation.application_complete') %>
-          <p><%= I18n.t('presenter.confirmation.payment_enabled') %></p>
-        <% else %>
-          <%= @page.heading %>
-        <% end %>
+          <% if payment_link_enabled? && @page.heading == I18n.t('presenter.confirmation.application_complete') %>
+            <%= I18n.t('presenter.confirmation.payment_enabled') %>
+          <% else %>
+            <%= @page.heading %>
+          <% end %>
+        </span>
       </h1>
 
       <div class="govuk-panel__body">

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -9,11 +9,13 @@
 
       <%= render 'metadata_presenter/attribute/section_heading' %>
 
-      <h1 class="fb-editable govuk-heading-xl"
+      <h1>
+        <span class="fb-editable govuk-heading-xl"
           data-fb-content-id="page[heading]"
           data-fb-content-type="element"
           data-fb-default-value="<%= default_page_title(@page.type) %>">
-        <%= @page.heading %>
+          <%= @page.heading %>
+        </span>
       </h1>
 
       <%= render 'metadata_presenter/attribute/lede' %>

--- a/app/views/metadata_presenter/page/exit.html.erb
+++ b/app/views/metadata_presenter/page/exit.html.erb
@@ -6,11 +6,13 @@
 
       <%= render 'metadata_presenter/attribute/section_heading' %>
 
-      <h1 class="fb-editable govuk-heading-xl"
+      <h1>
+        <span class="fb-editable govuk-heading-xl"
           data-fb-content-id="page[heading]"
           data-fb-content-type="element"
           data-fb-default-value="<%= default_page_title(@page.type) %>">
-        <%= @page.heading %>
+          <%= @page.heading %>
+        </span>
       </h1>
 
       <%= render 'metadata_presenter/attribute/lede' %>

--- a/app/views/metadata_presenter/page/multiplequestions.html.erb
+++ b/app/views/metadata_presenter/page/multiplequestions.html.erb
@@ -25,8 +25,7 @@
           %>
 
         <div class="govuk-button-group">
-          <%= f.govuk_submit(t('presenter.actions.continue'), disabled: editable?) %>
-
+          <%= f.govuk_submit(t('presenter.actions.continue'),'aria-disabled': editable?) %>
           <% if save_and_return_enabled? && show_save_and_return %>
             <% if editor_preview? || editable? %>
               <%= button_to t('presenter.save_and_return.actions.save'), '/', params: { page_slug:request.env['PATH_INFO'] }, method: :post, class: "govuk-button govuk-button--secondary", name: 'save_for_later', disabled: true %>

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -27,8 +27,7 @@
         <% end %>
 
         <div class="govuk-button-group">
-          <%= f.govuk_submit(t('presenter.actions.continue'), disabled: editable?) %>
-
+          <%= f.govuk_submit(t('presenter.actions.continue'), 'aria-disabled': editable?) %>
           <% if save_and_return_enabled? && show_save_and_return %>
             <% if editor_preview? || editable? %>
               <%= button_to t('presenter.save_and_return.actions.save'), '/', params: { page_slug:request.env['PATH_INFO'] }, method: :post, class: "govuk-button govuk-button--secondary", name: 'save_for_later', disabled: true %>

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -10,7 +10,7 @@
 
       <%= form_for @page_answers, as: :answers, url: @page.url, method: :post, authenticity_token: false do |f| %>
         <%= f.govuk_error_summary(t('presenter.errors.summary_heading')) %>
-<%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
+        <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
         <% @page.components.each_with_index do |component, index| %>
           <div class="fb-editable"
                data-fb-content-type="<%= component._type %>"

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.29'.freeze
+  VERSION = '3.3.30'.freeze
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
 
       it 'returns h1 wrapped in a legend by default' do
         expect(helper.main_title(component:)).to eq(
-          %(<h1 class="govuk-heading-xl">Luke Skywalker</h1>)
+          %(<h1 class="govuk-heading-xl"><span>Luke Skywalker</span></h1>)
         )
       end
     end
@@ -19,7 +19,7 @@ RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
 
       it 'returns h1 default' do
         expect(helper.main_title(component:)).to eq(
-          %(<h1 class="govuk-heading-xl">Luke Skywalker</h1>)
+          %(<h1 class="govuk-heading-xl"><span>Luke Skywalker</span></h1>)
         )
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe MetadataPresenter::ApplicationHelper, type: :helper do
         expect(
           helper.main_title(component:, tag: :h2, classes: 'govuk-heading-m govuk-margin-top-5')
         ).to eq(
-          %(<h2 class="govuk-heading-m govuk-margin-top-5">Mace Windu</h2>)
+          %(<h2 class="govuk-heading-m govuk-margin-top-5"><span>Mace Windu</span></h2>)
         )
       end
     end


### PR DESCRIPTION
This PR adds a child span within editable H1 headings.

This allows the editor to use the span for the `contentEditable` functionality which then means that the heading semantics remain and are communicated to the user.