### PR TITLE
Back link nil guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.31] - 2024-04-05
+### Fixed
+ - Fixed issue where going directly to a 404 page could cause a vil value exception
+
 ## [3.3.30] - 2024-04-04
 ### Changed
  - Updated all editable headings to have a nested span for improved semantics when editing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ## [3.3.31] - 2024-04-05
 ### Fixed
- - Fixed issue where going directly to a 404 page could cause a vil value exception
+ - Fixed issue where going directly to a 404 page could cause a nil value exception
 
 ## [3.3.30] - 2024-04-04
 ### Changed

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -55,10 +55,8 @@ module MetadataPresenter
     end
 
     def back_link
-      if response.status == 404
-        if @page
-          @back_link = File.join(request.script_name, @page.url)
-        end
+      if response.status == 404 && @page
+        @back_link = File.join(request.script_name, @page.url)
       end
 
       if use_external_start_page? && first_page?

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -56,6 +56,7 @@ module MetadataPresenter
 
     def back_link
       if response.status == 404
+        byebug
         @back_link = File.join(request.script_name, @page.url)
       end
 

--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -56,8 +56,9 @@ module MetadataPresenter
 
     def back_link
       if response.status == 404
-        byebug
-        @back_link = File.join(request.script_name, @page.url)
+        if @page
+          @back_link = File.join(request.script_name, @page.url)
+        end
       end
 
       if use_external_start_page? && first_page?

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.30'.freeze
+  VERSION = '3.3.31'.freeze
 end


### PR DESCRIPTION
Going direct to a bad url (perhaps an old bookmark) would throw instead of returning a 404

Added a guard to prevent this