### PR TITLE
Support text/rtf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.32] - 2024-04-15
+### Fixed
+ - Fixed missing allowed mimetype for text/rtf in supported file list
+
 ## [3.3.31] - 2024-04-05
 ### Fixed
  - Fixed issue where going directly to a 404 page could cause a nil value exception

--- a/default_metadata/component/multiupload.json
+++ b/default_metadata/component/multiupload.json
@@ -14,6 +14,7 @@
     "accept": [
       "text/csv",
       "text/plain",
+      "text/rtf",
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "application/msword",
       "application/vnd.oasis.opendocument.spreadsheet",

--- a/default_metadata/component/upload.json
+++ b/default_metadata/component/upload.json
@@ -12,6 +12,7 @@
     "accept": [
       "text/csv",
       "text/plain",
+      "text/rtf",
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "application/msword",
       "application/vnd.oasis.opendocument.spreadsheet",

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.31'.freeze
+  VERSION = '3.3.32'.freeze
 end


### PR DESCRIPTION
Components will need to be recreated to pick up on the new default.

Corresponding PR https://github.com/ministryofjustice/fb-runner/pull/1357 to also add text/rtf to allowed mimetype list