### PR TITLE
Accessible labelling page editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.33] - 2024-04-17
+### Changed
+ - Updated templates to improve accessible labelling when editing
+
 ## [3.3.32] - 2024-04-15
 ### Fixed
  - Fixed missing allowed mimetype for text/rtf in supported file list

--- a/app/views/metadata_presenter/attribute/_body.html.erb
+++ b/app/views/metadata_presenter/attribute/_body.html.erb
@@ -4,7 +4,9 @@
                           type="content"
                           default-content="<%= default_text('body') %>"
                           content="<%= page_body_content %>"
-                          data-fb-content-id="<%= "page[body]" %>">
+                          data-fb-content-id="<%= "page[body]" %>"
+                          data-editor-label-key="aria.optional_content_label"
+                          data-editor-description-key="aria.optional_content_description">
               <div class="html">
                 <%= to_html(page_body_content) %>
               </div>

--- a/app/views/metadata_presenter/component/_multiupload.html.erb
+++ b/app/views/metadata_presenter/component/_multiupload.html.erb
@@ -31,9 +31,9 @@
     'aria-disabled': editable?,
     label: -> do %>
       <% if answered?(component.id) && @page_answers.send(component.id)[component.id].compact.count.positive? && !editable? %>
-        <h3 class="govuk-heading-s govuk-!-margin-top-8"><%= t('presenter.questions.multiupload.add_another') %></h3>
+        <h2 class="govuk-heading-s govuk-!-margin-top-8"><%= t('presenter.questions.multiupload.add_another') %></h2>
       <% else %>
-        <h3 class="govuk-visually-hidden"><%= t('presenter.questions.multiupload.add_another') %></h3>
+        <h2 class="govuk-visually-hidden"><%= t('presenter.questions.multiupload.add_another') %></h2>
       <% end %>
     <% end %>
   </div>

--- a/app/views/metadata_presenter/page/checkanswers.html.erb
+++ b/app/views/metadata_presenter/page/checkanswers.html.erb
@@ -65,10 +65,12 @@
         </dl>
 
         <% if @page.send_heading.present? %>
-          <h2 class="fb-send-heading fb-editable govuk-heading-m"
+          <h2>
+            <span class="fb-send-heading fb-editable govuk-heading-m"
               data-fb-content-type="element"
               data-fb-content-id="page[send_heading]">
-            <%= @page.send_heading %>
+              <%= @page.send_heading %>
+            </span>
           </h2>
         <% end %>
 
@@ -102,9 +104,10 @@
         <%end%>
         <br><br>
         <div class="govuk-button-group">
-          <button <%= 'disabled' if editable? %> data-prevent-double-click="true" class="fb-block fb-block-actions govuk-button" data-module="govuk-button" data-block-id="actions" data-block-type="actions">
-            <%= t('presenter.actions.submit') -%></button>
-            <% if save_and_return_enabled? %>
+          <button <%= 'aria-disabled=true' if editable? %> data-prevent-double-click="true" class="fb-block fb-block-actions govuk-button" data-module="govuk-button" data-block-id="actions" data-block-type="actions">
+            <%= t('presenter.actions.submit') -%>
+          </button>
+          <% if save_and_return_enabled? %>
             <% if editor_preview? || editable? %>
               <%= button_to t('presenter.save_and_return.actions.save'), '/', params: { page_slug:request.env['PATH_INFO'] }, method: :post, class: "govuk-button govuk-button--secondary", name: 'save_for_later_check_answers', disabled: true %>
             <% else %>

--- a/app/views/metadata_presenter/page/confirmation.html.erb
+++ b/app/views/metadata_presenter/page/confirmation.html.erb
@@ -34,9 +34,7 @@
                data-fb-content-id="page[lede]"
                data-fb-content-type="element"
                data-fb-default-text="<%= default_text('lede') %>">
-              <div class="html">
                 <%= @page.lede %>
-              </div>
           </div>
         <%- end %>
       </div>

--- a/app/views/metadata_presenter/page/content.html.erb
+++ b/app/views/metadata_presenter/page/content.html.erb
@@ -38,7 +38,7 @@
                    } %>
 
         <div class="govuk-button-group">
-          <%= f.govuk_submit(t('presenter.actions.continue'), disabled: editable?) %>
+          <%= f.govuk_submit(t('presenter.actions.continue'), 'aria-disabled': editable?) %>
           <% if save_and_return_enabled? %>
             <% if editor_preview? || editable? %>
               <%= button_to t('presenter.save_and_return.actions.save'), '/', params: { page_slug:request.env['PATH_INFO'] }, method: :post, class: "govuk-button govuk-button--secondary", name: 'save_for_later', disabled: true %>

--- a/app/views/metadata_presenter/page/standalone.html.erb
+++ b/app/views/metadata_presenter/page/standalone.html.erb
@@ -29,11 +29,12 @@
         <% end %>
        <%# ORIGINAL TEMPLATE: Uses content from form metadata %>
        <% if @page.heading %>
-         <h1 class="fb-editable govuk-heading-xl"
+         <h1> <span class="fb-editable govuk-heading-xl"
              data-fb-content-id="page[heading]"
              data-fb-content-type="element"
              data-fb-default-value="<%= t("presenter.footer.#{@page.id.gsub('page.','')}.heading") %>">
            <%= @page.heading %>
+           </span>
          </h1>
        <% end %>
        <%= render 'metadata_presenter/attribute/body' %>

--- a/app/views/metadata_presenter/page/start.html.erb
+++ b/app/views/metadata_presenter/page/start.html.erb
@@ -7,7 +7,7 @@
 
       <%= form_tag(root_path, method: :post, authenticity_token: false) do %>
         <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
-        <button <%= 'disabled' if editable? %> class='govuk-button govuk-button--start govuk-!-margin-top-2'>
+        <button <%= 'aria-disabled=true' if editable? %> class='govuk-button govuk-button--start govuk-!-margin-top-2'>
           <%= t('presenter.actions.start') -%>
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/default_metadata/page/start.json
+++ b/default_metadata/page/start.json
@@ -1,8 +1,8 @@
 {
-  "_id": "page.start",
-  "_type": "page.start",
-  "heading": "Service name goes here",
-  "body": "Use this service to apply for a service or contact us about a case.\r\n\r\n## Before you start\r\nYou will need:\r\n\r\n* your 8-digit reference number\r\n* a copy of your photo ID\r\n* something else\r\n\r\nThis form will take around 5 minutes to complete. We will reply within 10 working days.",
-  "before_you_start": "## Other ways to get in touch\r\nYou can also apply or contact us about your case by:\r\n\r\n* telephone: 01234 567889\r\n* email: <example.service@justice.gov.uk>\r\n\r\nThis form is also [available in Welsh (Cymraeg)](https://example-service.form.service.justice.gov.uk/).",
-  "url": "/"
+    "_id": "page.start",
+    "_type": "page.start",
+    "heading": "Service name goes here",
+    "body": "Use this service to apply for a service or contact us about a case.\r\n\r\n## Before you start\r\nYou will need:\r\n\r\n* your 8-digit reference number\r\n* a copy of your photo ID\r\n* something else\r\n\r\nThis form will take around 5 minutes to complete. We will reply within 10 working days.",
+    "before_you_start": "## Other ways to get in touch\r\nYou can also apply or contact us about your case by:\r\n\r\n* telephone: 01234 567889\r\n* email: <example.service@justice.gov.uk>\r\n\r\nThis form is also [available in Welsh (Cymraeg)](https://example-service.form.service.justice.gov.uk/).",
+    "url": "/"
 }

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.32'.freeze
+  VERSION = '3.3.33'.freeze
 end


### PR DESCRIPTION
This PR changes the presenter templates to enable better accessible labelling within the editor, and to address issues raised by the AXE audit tool.

* Fixes heading hierarchy issues
* Ensures editable headings use a child span as the editable element not the heading element itself.
* Ensures buttons are `aria-disabled` not `disabled` to enable them to be discoverable by AT users.

