### PR TITLE
Bunch of copy changes and tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Save and return error pages now include a "Start again" CTA button
 ### Changed
-- Required file upload error message changed from "Enter an answer for <question name>" to "Choose a file to upload"
+- Required file upload error message changed from "Enter an answer for 'question name'" to "Choose a file to upload"
 
 ## [3.3.35] - 2024-04-25
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.36] - 2024-04-30
+### Added
+- Save and return error pages now include a "Start again" CTA button
+### Changed
+- Required file upload error message changed from "Enter an answer for <question name>" to "Choose a file to upload"
+
 ## [3.3.35] - 2024-04-25
 ### Fixed
 - Fixed an issue with the back link in save and return pages and prevented an error when access email confirmation page when session cannot be loaded

--- a/app/validators/metadata_presenter/base_validator.rb
+++ b/app/validators/metadata_presenter/base_validator.rb
@@ -52,10 +52,16 @@ module MetadataPresenter
     # Assuming for example that the schema key is 'grogu' then the message
     # will lookup for 'errors.grogu.any'.
     #
-    # @return [String] message from the service metadata
+    # If there is a custom message defined in the locales, it will take
+    # precedence. Example: `presenter.components.upload.errors.required`
+    #
+    # @return [String] custom error message or `nil`
     #
     def custom_error_message
-      message = component.dig('errors', schema_key, 'any')
+      message = I18n.t(
+        "presenter.components.#{component.type}.errors.#{schema_key}",
+        default: component.dig('errors', schema_key, 'any')
+      )
 
       message % error_message_hash if message.present?
     end

--- a/app/views/metadata_presenter/resume/record_error.html.erb
+++ b/app/views/metadata_presenter/resume/record_error.html.erb
@@ -4,6 +4,7 @@
     <h1 id="page-heading" class="govuk-heading-xl"><%= t('presenter.save_and_return.resume.errors.generic_problem.heading') %></h1>
     <p><%= t('presenter.save_and_return.resume.errors.generic_problem.info_1') %></p>
     <p><%= t('presenter.save_and_return.resume.errors.generic_problem.info_2') %></p>
+    <%= render partial: 'metadata_presenter/shared/start_again_button' %>
     </div>
   </div>
 </div>

--- a/app/views/metadata_presenter/resume/record_failure.html.erb
+++ b/app/views/metadata_presenter/resume/record_failure.html.erb
@@ -4,6 +4,7 @@
     <h1 id="page-heading" class="govuk-heading-xl"><%= t('presenter.save_and_return.resume.errors.failure.heading') %></h1>
     <p><%= t('presenter.save_and_return.resume.errors.failure.info_1') %></p>
     <p><%= t('presenter.save_and_return.resume.errors.failure.info_2') %></p>
+    <%= render partial: 'metadata_presenter/shared/start_again_button' %>
     </div>
   </div>
 </div>

--- a/app/views/metadata_presenter/resume/record_link_expired.html.erb
+++ b/app/views/metadata_presenter/resume/record_link_expired.html.erb
@@ -4,6 +4,7 @@
     <h1 id="page-heading" class="govuk-heading-xl"><%= t('presenter.save_and_return.resume.errors.expired.heading') %></h1>
     <p><%= t('presenter.save_and_return.resume.errors.expired.info_1') %></p>
     <p><%= t('presenter.save_and_return.resume.errors.expired.info_2') %></p>
+    <%= render partial: 'metadata_presenter/shared/start_again_button' %>
     </div>
   </div>
 </div>

--- a/app/views/metadata_presenter/resume/record_link_used.html.erb
+++ b/app/views/metadata_presenter/resume/record_link_used.html.erb
@@ -4,6 +4,7 @@
     <h1 id="page-heading" class="govuk-heading-xl"><%= t('presenter.save_and_return.resume.errors.link_used.heading') %></h1>
     <p><%= t('presenter.save_and_return.resume.errors.link_used.info_1') %></p>
     <p><%= t('presenter.save_and_return.resume.errors.link_used.info_2') %></p>
+    <%= render partial: 'metadata_presenter/shared/start_again_button' %>
     </div>
   </div>
 </div>

--- a/app/views/metadata_presenter/resume/resume_from_start.html.erb
+++ b/app/views/metadata_presenter/resume/resume_from_start.html.erb
@@ -2,10 +2,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
     <h1 id="page-heading" class="govuk-heading-xl"><%= t('presenter.save_and_return.resume.from_start.heading', service_name: service.service_name) %></h1>
-    <p class="govuk-hint"><%= t('presenter.save_and_return.resume.from_start.info_1') %></p>
+    <p class="govuk-body"><%= t('presenter.save_and_return.resume.from_start.info_1') %></p>
     <br/>
-    <p class="govuk-hint"><%= t('presenter.save_and_return.resume.from_start.info_2') %></p>
-    <%= link_to t('presenter.save_and_return.actions.continue'), root_path, class: "govuk-button" %>
+    <p class="govuk-body"><%= t('presenter.save_and_return.resume.from_start.info_2') %></p>
+
+    <%= render partial: 'metadata_presenter/shared/start_again_button',
+               locals: { button_text: t('presenter.save_and_return.actions.continue') } %>
     </div>
   </div>
 </div>

--- a/app/views/metadata_presenter/session/complete.html.erb
+++ b/app/views/metadata_presenter/session/complete.html.erb
@@ -3,7 +3,7 @@
     <h1 class="govuk-heading-l"><%= t('presenter.session_complete.title') %></h1>
     <div class="maintenance-content">
       <%= to_html t('presenter.session_complete.content') %>
-      <p><%= link_to t('presenter.session_complete.restart_link'), root_url %></p>
     </div>
+    <%= render partial: 'metadata_presenter/shared/start_again_button' %>
   </div>
 </div>

--- a/app/views/metadata_presenter/session/expired.html.erb
+++ b/app/views/metadata_presenter/session/expired.html.erb
@@ -3,7 +3,7 @@
     <h1 class="govuk-heading-l"><%= t('presenter.session_expired.title') %></h1>
     <div class="maintenance-content">
       <%= to_html t('presenter.session_expired.content') %>
-      <p><%= link_to t('presenter.session_expired.restart_link'), root_url %></p>
     </div>
+    <%= render partial: 'metadata_presenter/shared/start_again_button' %>
   </div>
 </div>

--- a/app/views/metadata_presenter/shared/_start_again_button.html.erb
+++ b/app/views/metadata_presenter/shared/_start_again_button.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-button-group govuk-!-margin-top-6">
+  <%= button_to(
+        defined?(button_text) ? button_text : t('presenter.actions.start_again'),
+        root_path, method: :get, class: 'govuk-button', data: { module: 'govuk-button' }
+      ) %>
+</div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -15,6 +15,7 @@ cy:
       continue: Parhau
       submit: Cyflwyno
       sign_in: Mewngofnodi
+      start_again: Dechrau eto
       upload_options: Llwytho opsiynau
       change_html: Newid <span class="govuk-visually-hidden">eich ateb ar gyfer %{question}</span>
     errors:
@@ -56,11 +57,9 @@ cy:
     session_expired:
       title: Mae eich ffurflen wedi’i hailosod
       content: "I ddiogelu eich gwybodaeth bersonol, rydym wedi ailosod y ffurflen ac wedi clirio’ch atebion.\r\n\r\nMae hyn oherwydd eich bod wedi bod yn segur am 30 munud."
-      restart_link: Dechrau eto
     session_complete:
       title: Wedi cyflwyno
       content: "Mae’r ffurflen hon eisoes wedi’i chyflwyno.\r\n\r\nI ddiogelu eich gwybodaeth bersonol, rydym wedi ailosod y ffurflen ac wedi clirio’ch atebion."
-      restart_link: Dechrau eto
     confirmation:
       reference_number: 'Eich cyfeirnod yw:'
       payment_enabled: Rydych dal angen talu

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -23,10 +23,10 @@ cy:
     components:
       upload:
         errors:
-          required: (cy) Choose a file to upload
+          required: Dewiswch ffeil i’w llwytho
       multiupload:
         errors:
-          required: (cy) Choose a file to upload
+          required: Dewiswch ffeil i’w llwytho
     notification_banners:
       important: Pwysig
       warning: Rhybudd

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -20,6 +20,13 @@ cy:
       change_html: Newid <span class="govuk-visually-hidden">eich ateb ar gyfer %{question}</span>
     errors:
       summary_heading: Mae yna broblem
+    components:
+      upload:
+        errors:
+          required: (cy) Choose a file to upload
+      multiupload:
+        errors:
+          required: (cy) Choose a file to upload
     notification_banners:
       important: Pwysig
       warning: Rhybudd

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,13 @@ en:
       change_html: Change <span class="govuk-visually-hidden">Your answer for %{question}</span>
     errors:
       summary_heading: There is a problem
+    components:
+      upload:
+        errors:
+          required: Choose a file to upload
+      multiupload:
+        errors:
+          required: Choose a file to upload
     notification_banners:
       important: Important
       warning: Warning

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
       continue: Continue
       submit: Submit
       sign_in: Sign in
+      start_again: Start again
       upload_options: Upload options
       change_html: Change <span class="govuk-visually-hidden">Your answer for %{question}</span>
     errors:
@@ -47,11 +48,9 @@ en:
     session_expired:
       title: Your form has been reset
       content: "To protect your personal information, we have reset the form and cleared your answers.\r\n\r\nThis is because you were inactive for 30 minutes."
-      restart_link: Start again
     session_complete:
       title: Submission complete
       content: "This form has already been submitted.\r\n\r\nTo protect your personal information, we have reset the form and cleared your answers."
-      restart_link: Start again
     confirmation:
       reference_number: 'Your reference number is:'
       payment_enabled: You still need to pay

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.35'.freeze
+  VERSION = '3.3.36'.freeze
 end

--- a/spec/validators/required_validator_spec.rb
+++ b/spec/validators/required_validator_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe MetadataPresenter::RequiredValidator do
 
           it 'gets the error message from the locales' do
             expect(page_answers.errors.full_messages).to eq(
-              ['(cy) Choose a file to upload']
+              ['Dewiswch ffeil i’w llwytho']
             )
           end
         end

--- a/spec/validators/required_validator_spec.rb
+++ b/spec/validators/required_validator_spec.rb
@@ -48,7 +48,34 @@ RSpec.describe MetadataPresenter::RequiredValidator do
         end
       end
 
-      context 'when there is custom error message' do
+      context 'when there is custom error message defined on the locales' do
+        let(:page) { service.find_page_by_url('/dog-picture-2') }
+        let(:answers) { { 'dog-picture_upload_2' => {} } }
+
+        it 'is invalid' do
+          expect(validator).to_not be_valid
+        end
+
+        context 'for english locale' do
+          it 'gets the error message from the locales' do
+            expect(page_answers.errors.full_messages).to eq(
+              ['Choose a file to upload']
+            )
+          end
+        end
+
+        context 'for welsh locale' do
+          let(:locale) { :cy }
+
+          it 'gets the error message from the locales' do
+            expect(page_answers.errors.full_messages).to eq(
+              ['(cy) Choose a file to upload']
+            )
+          end
+        end
+      end
+
+      context 'when there is custom error message defined on the metadata' do
         context 'when there is "any"' do
           let(:page) { service.find_page_by_url('/parent-name') }
           let(:answers) { { 'parent-name_text_1' => '' } }


### PR DESCRIPTION
The changes corresponds to the following tickets:

https://trello.com/c/uNCSxLY4
Adds a start again CTA button to all save and return resume error pages.

https://trello.com/c/r3wfBU4f
Changes the required file upload error message as the generic one we use for all other components does not make sense for file uploads.