### PR TITLE
Refactor resume answers page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.37] - 2024-05-02
+### Fixed
+- Missing multi question headings when resuming saved forms
+
 ## [3.3.36] - 2024-04-30
 ### Added
 - Save and return error pages now include a "Start again" CTA button

--- a/app/presenters/metadata_presenter/summary/answers_presenter.rb
+++ b/app/presenters/metadata_presenter/summary/answers_presenter.rb
@@ -1,0 +1,27 @@
+module MetadataPresenter
+  module Summary
+    class AnswersPresenter
+      attr_reader :page_answers
+
+      def initialize(page_answers)
+        @page_answers = page_answers
+      end
+
+      def page
+        @page ||= answers.first.page
+      end
+
+      def answers
+        @answers ||= page_answers.select { |pa| pa.answer.present? }
+      end
+
+      def multi_questions_page?
+        page.type.eql?('page.multiplequestions')
+      end
+
+      def to_partial_path
+        'metadata_presenter/resume/answers_presenter'.freeze
+      end
+    end
+  end
+end

--- a/app/views/metadata_presenter/resume/_answers_presenter.html.erb
+++ b/app/views/metadata_presenter/resume/_answers_presenter.html.erb
@@ -1,0 +1,27 @@
+<% if answers_presenter.answers.any? %>
+  <% if answers_presenter.multi_questions_page? %>
+    <h2 class="govuk-heading-m">
+      <%= answers_presenter.page.heading %>
+    </h2>
+  <% end %>
+
+  <dl class="fb-block fb-block-answers govuk-summary-list">
+    <% answers_presenter.answers.each do |answer| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= answer.humanised_title %>
+        </dt>
+
+        <dd class="govuk-summary-list__value">
+          <%= answer.answer %>
+        </dd>
+
+        <dd class="govuk-summary-list__actions">
+          <%= link_to(answer.url, class: 'govuk-link') do
+            t('presenter.actions.change_html', question: answer.humanised_title)
+          end %>
+        </dd>
+      </div>
+    <% end %>
+  </dl>
+<% end %>

--- a/app/views/metadata_presenter/resume/resume_progress.html.erb
+++ b/app/views/metadata_presenter/resume/resume_progress.html.erb
@@ -7,44 +7,14 @@
     <div class="govuk-grid-column-two-thirds">
       <p><%= t('presenter.save_and_return.resume.progress.content_1') %></p>
       <p><%= t('presenter.save_and_return.resume.progress.content_2') %></p>
-      <%= form_for @page, url: reserved_submissions_path, html: { id: 'answers-form' } do |f| %>
-        <dl class="fb-block fb-block-answers govuk-summary-list">
-          <% pages_presenters.each do |page_answers_presenters| %>
-            <% page_answers_presenters.each_with_index do |page_answers_presenter, index| %>
 
-              <% if !page_answers_presenter.answer.empty? %>
-
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  <%= page_answers_presenter.humanised_title %>
-                </dt>
-
-                <dd class="govuk-summary-list__value">
-                  <%= page_answers_presenter.answer %>
-                </dd>
-                <dd class="govuk-summary-list__actions">
-                  <%= link_to(
-                    editable? ? '#' : page_answers_presenter.url,
-                    class: 'govuk-link'
-                  ) do %>
-                    <%= t('presenter.actions.change_html', question: page_answers_presenter.humanised_title) %>
-                  <% end %>
-                </dd>
-              </div>
-
-              <% if page_answers_presenter.last_multiple_question?(index, page_answers_presenters.size) %>
-              <% end %>
-        </dl>
-        <dl class="fb-block fb-block-answers govuk-summary-list">
-              <% end %>
-            <% end %>
-          <% end %>
-        </dl>
-
-        <div class="govuk-button-group">
-          <%= link_to t('presenter.save_and_return.actions.continue'), page_slug, class: "govuk-button" %> <a href="<%= save_path(:page_slug=>page_slug) %>" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-component="save-button"><%= t('presenter.save_and_return.actions.save') %></a>
-        </div>
+      <% pages_presenters.each do |page_answers_presenters| %>
+        <%= render MetadataPresenter::Summary::AnswersPresenter.new(page_answers_presenters) %>
       <% end %>
+
+      <div class="govuk-button-group">
+        <%= link_to t('presenter.save_and_return.actions.continue'), page_slug, class: "govuk-button" %> <a href="<%= save_path(:page_slug=>page_slug) %>" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-component="save-button"><%= t('presenter.save_and_return.actions.save') %></a>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.36'.freeze
+  VERSION = '3.3.37'.freeze
 end

--- a/spec/presenters/metadata_presenter/summary/answers_presenter_spec.rb
+++ b/spec/presenters/metadata_presenter/summary/answers_presenter_spec.rb
@@ -1,0 +1,41 @@
+describe MetadataPresenter::Summary::AnswersPresenter do
+  subject { described_class.new(page_answers) }
+
+  let(:page_answers) { [answer_1, answer_2] }
+
+  let(:page) { double(type: page_type) }
+  let(:page_type) { 'page.multiplequestions' }
+
+  let(:answer_1) { double(page:, answer: 'foobar') }
+  let(:answer_2) { double(page:, answer: '') }
+
+  describe '#to_partial_path' do
+    it 'returns the correct partial path' do
+      expect(subject.to_partial_path).to eq('metadata_presenter/resume/answers_presenter')
+    end
+  end
+
+  describe '#page' do
+    it 'uses the first answer to retrieve the page' do
+      expect(subject.page).to eq(page)
+    end
+  end
+
+  describe '#answers' do
+    it 'returns a collection of answered (non-blank) answers' do
+      expect(subject.answers).to eq([answer_1])
+    end
+  end
+
+  describe '#multi_questions_page?' do
+    context 'for a single page type' do
+      let(:page_type) { 'page.singlequestion' }
+
+      it { expect(subject.multi_questions_page?).to eq(false) }
+    end
+
+    context 'for a multiquestions page type' do
+      it { expect(subject.multi_questions_page?).to eq(true) }
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/vlN23B93

Fixed an issue where if a form includes multi-question pages, these titles were not shown on the summary page when returning to a saved form.