### PR TITLE
Update copy on hide cookie banner button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.3.38] - 2024-05-03
+### Changed
+ - Updated copy on hide cookie message button for better screenreader accessibility
+
 ## [3.3.37] - 2024-05-02
 ### Fixed
 - Missing multi question headings when resuming saved forms

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@ en:
       confirmation:
         accepted: You've accepted analytics cookies.
         rejected: You've rejected analytics cookies.
-      hide: Hide this message
+      hide: Hide cookie message
     external_start_page_info:
       content: "Your form has a %{href}. Links to your form's 'home' page, such as your form's name in the header, will not work until the GOV.UK page has been published."
       link_text: 'GOV.UK start page'

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.3.37'.freeze
+  VERSION = '3.3.38'.freeze
 end


### PR DESCRIPTION
This PR fixes an issues raised in the DAC accessibility audit.

The "hide this message" copy on the cookie banner button was not clear to screenreader users browsing out of context. Updated to "Hide cookie message"