### PR TITLE
CDPT-2975: Update rails version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             bundle install
       - run:
           name: Security
-          command: bundle exec brakeman -q --no-pager -i brakeman.ignore -x EOLRails
+          command: bundle exec brakeman -q --no-pager -i brakeman.ignore
       - run:
           name: Lint
           command: bundle exec rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.4.9] - 2025-08-20
+### Changed
+- Bumped rails dependency to 7.2
 
 ## [3.4.8] - 2025-08-05
 ### Changed

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.4.8'.freeze
+  VERSION = '3.4.9'.freeze
 end

--- a/metadata_presenter.gemspec
+++ b/metadata_presenter.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json-schema', '~> 4.1.1'
   spec.add_dependency 'kramdown', '~> 2.4.0'
   spec.add_dependency 'govspeak', '~> 7.1'
-  spec.add_dependency 'rails', '~> 7.1.0'
+  spec.add_dependency 'rails', '~> 7.2.0'
   spec.add_dependency 'sassc-rails', '2.1.2'
   spec.add_dependency 'sprockets-rails'
   spec.add_dependency 'sprockets'


### PR DESCRIPTION
- Bumped rails dependency to 7.2
- Enable brakeman security warning (disabled in [#416](https://github.com/ministryofjustice/fb-metadata-presenter/pull/416))

<img width="748" height="709" alt="Screenshot 2025-08-06 at 12 10 15" src="https://github.com/user-attachments/assets/6f046f67-1663-4b76-8191-942eda90ce38" />
