### PR TITLE
CDPTKAN-772: Fix AppSec issues

### DIFF
--- a/app/controllers/metadata_presenter/engine_controller.rb
+++ b/app/controllers/metadata_presenter/engine_controller.rb
@@ -148,7 +148,10 @@ module MetadataPresenter
 
     def authorised_session!
       cookies.signed[:_fb_authorised] = {
-        value: 1, same_site: :strict, httponly: true
+        value: 1,
+        same_site: :strict,
+        secure: !(Rails.env.test? || Rails.env.development?),
+        httponly: !(Rails.env.test? || Rails.env.development?)
       }
     end
 

--- a/spec/models/saved_form_spec.rb
+++ b/spec/models/saved_form_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe MetadataPresenter::SavedForm, type: :model do
   describe 'populating necessary attributes' do
     let(:params) { { 'email' => 'email@email.com', 'saved_form' => { 'page_slug' => 'slug', 'secret_question' => 'some text' }, 'secret_answer' => 'answer' } }
-    let(:session) { { user_id: 'idval', user_token: 'token', user_data: { 'field1' => 'answer' } } }
+    let(:user_id) { 'idval' }
+    let(:user_token) { 'token' }
+    let(:session) { { user_id: user_id, user_token: user_token, user_data: { 'field1' => 'answer' } } }
     let(:service) { OpenStruct.new(version_id: '123') }
 
     it 'should populate from params' do

--- a/spec/requests/save_and_return_controller_spec.rb
+++ b/spec/requests/save_and_return_controller_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe MetadataPresenter::SaveAndReturnController, type: :request do
 
   describe '#create' do
     context 'valid request' do
+      let(:user_id) { '1324' }
+      let(:user_token) { 'token' }
       it 'posts the save progress form' do
-        session = { user_id: '1324', user_token: 'token', user_data_payload: { 'question_1' => 'answer' } }
+        session = { user_id: user_id, user_token: user_token, user_data_payload: { 'question_1' => 'answer' } }
         allow_any_instance_of(MetadataPresenter::SaveAndReturnController).to receive(:session).and_return(session)
 
         params = { email: 'valid@example.com', secret_answer: 'secret stuff', saved_form: { page_slug: '/a-page', secret_question: 1 } }


### PR DESCRIPTION
- Cookie httponly is not set explicitly and defaults to false. Set it to true to protect the cookie from malicious client-side JavaScript code.
- Cookie secure is not set explicitly and defaults to false. Set it to true to ensure the cookie is only sent via HTTPS and help protect from man-in-the-middle attacks.


JIRA: https://dsdmoj.atlassian.net/browse/CDPTKAN-772
SNYK: https://app.snyk.io/org/central-digital/project/497d8b63-f6c1-4fec-b409-8d3fabb36661