### PR TITLE
CDPTKAN-1150-rails-8-upgrade: Fix html elements indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.4.16] - 2026-07-01
+### Fixed
+-  Fix frontend or templates using the old naming convention 'page[components[0]]' instead of the correct Rails convention 'page[components][0]'
+
 ## [3.4.15] - 2026-06-09
 ### Changed
 - Updated rails from 7.2.3.1 to 8.1.3

--- a/app/views/metadata_presenter/component/_components.html.erb
+++ b/app/views/metadata_presenter/component/_components.html.erb
@@ -7,7 +7,7 @@
                             type="<%= component.type %>"
                             default-content="<%= default_text('content') %>"
                             content="<%= component.content %>"
-                            data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
+                            data-fb-content-id="<%= "page[#{component.collection}][#{index}]" %>"
                             data-config="<%= component.to_json %>"
                             data-conditional-api-path="<%= editable? ? URI.decode_www_form_component(api_service_edit_conditional_content_path(service.service_id, component.uuid)) : '' %>"
                             data-controller="orderable-item component"
@@ -26,7 +26,7 @@
       <div class="fb-editable govuk-!-margin-top-8"
            id="<%= component.id %>"
            data-fb-content-type="<%= component.type %>"
-           data-fb-content-id="<%= "page[#{component.collection}[#{index}]]" %>"
+           data-fb-content-id="<%= "page[#{component.collection}][#{index}]" %>"
            data-fb-content-data="<%= component.to_json %>"
            data-fb-default-value="<%= default_title(component.type) %>"
            data-fb-default-item-value="<%= default_item_title(component.type) %>"
@@ -42,7 +42,7 @@
            <%= render partial: component, locals: {
              f: f,
              component: component,
-             component_id: "page[#{component.collection}[#{index}]]",
+             component_id: "page[#{component.collection}][#{index}]",
              input_title: main_title(
                component: component,
                tag: :h2,

--- a/app/views/metadata_presenter/page/singlequestion.html.erb
+++ b/app/views/metadata_presenter/page/singlequestion.html.erb
@@ -14,7 +14,7 @@
         <% @page.components.each_with_index do |component, index| %>
           <div class="fb-editable"
                data-fb-content-type="<%= component._type %>"
-               data-fb-content-id="<%= "page[components[#{index}]]" %>"
+               data-fb-content-id="<%= "page[components][#{index}]" %>"
                data-fb-content-data="<%= component.to_json %>"
                data-fb-default-value="<%= default_title(component.type) %>"
                data-fb-default-item-value="<%= default_item_title(component.type) %>">

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.4.15'.freeze
+  VERSION = '3.4.16'.freeze
 end


### PR DESCRIPTION
### Issue:

```ruby
Fix "components[0" in Started PATCH "/services/34eb38ed-a24e-452a-8b77-a23fa33a5c30/pages/5fa74b62-953d-4976-96b5-d27ed8c323cf" for 192.168.65.1 at 2026-06-29 16:08:06 +0000
Processing by PagesController#update as HTML
  Parameters: {"page"=>{"components[0"=>{"]"=>"{\"_id\":\"asdasdasdasd_number_1\",\"hint\":\"asdasdas\",\"name\":\"asdasdasdasd_number_1\",\"_type\":\"number\",\"_uuid\":\"404d6537-e180-4ded-be64-01e62a7ca858\",\"label\":\"Quesasdadasdtion\",\"errors\":{},\"validation\":{\"number\":true,\"required\":true},\"width_class_input\":\"10\",\"collection\":\"components\"}"}, "url"=>"asdasdasdasd", "body"=>"", "lede"=>"", "heading"=>"", "components"=>{"0"=>"{\"_id\":\"asdasdasdasd_number_1\",\"hint\":\"\",\"name\":\"asdasdasdasd_number_1\",\"_type\":\"number\",\"_uuid\":\"404d6537-e180-4ded-be64-01e62a7ca858\",\"label\":\"Question\",\"errors\":{},\"validation\":{\"number\":true,\"required\":true},\"width_class_input\":\"10\"}"}, "section_heading"=>"asdad"}, "authenticity_token"=>"[FILTERED]", "id"=>"34eb38ed-a24e-452a-8b77-a23fa33a5c30", "page_uuid"=>"5fa74b62-953d-4976-96b5-d27ed8c323cf"}

```

### Solution

The issue is caused by the frontend or templates using the old naming convention `page[components[0]]` instead of the correct Rails convention `page[components][0]`, leading to incorrect parameter parsing. Need to update the templates in `fb-metadata-presenter` and other places to use the correct naming convention and verify if changes are needed in the JavaScript.

  ```html
  [OLD]
  <input autocomplete="off" name="page[components[0]]" value="{SOME DATA}" id="components_0" type="hidden">
  [NEW]
  <input autocomplete="off" name="page[components][0]" value="{SOME DATA}" id="components_0" type="hidden">
  ```

### Summary
- Fixed malformed component parameters (e.g., `components[0"`) by standardizing on the correct Rails nested parameter naming convention `page[components][index]` across both backend templates and frontend metadata.