### PR TITLE
[CDPTKAN-460] Use original icon set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ## [3.4.18] - 2026-07-29
 ### Fixed
--  Enable functionality for the password show button. Includes new JS classnames from https://frontend.design-system.service.gov.uk/import-javascript/#before-you-start and icons.
+-  Enable functionality for the password show button. Includes new JS classnames from https://frontend.design-system.service.gov.uk/import-javascript/#before-you-start.
 
 ## [3.4.17] - 2026-07-23
 ### Fixed

--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -8,10 +8,12 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="robots" content="noindex">
-    <link rel="icon" sizes="48x48" href="<%= asset_pack_url('media/images/favicon.ico') %>">
-    <link rel="icon" sizes="any" href="<%= asset_pack_url('media/images/favicon.svg') %>" type="image/svg+xml">
-    <link rel="mask-icon" href="<%= asset_pack_url('media/images/govuk-icon-mask.svg') %>" color="blue">
-    <link rel="apple-touch-icon" href="<%= asset_pack_url('media/images/govuk-icon-180.png') %>">
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_pack_url('media/images/favicon.ico') %>" type="image/x-icon" />
+    <link rel="mask-icon" href="<%= asset_pack_url('media/images/govuk-mask-icon.svg') %>" color="blue">
+    <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-180x180.png') %>">
+    <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-167x167.png') %>">
+    <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-152x152.png') %>">
+    <link rel="apple-touch-icon" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon.png') %>">
 
     <%= javascript_pack_tag 'runner_application', 'govuk', defer: true %>
     <%= stylesheet_pack_tag 'govuk', 'runner_application', media: 'all' %>


### PR DESCRIPTION
Revert icon changes from https://github.com/ministryofjustice/fb-metadata-presenter/pull/429. As this is likely the cause for failing CI build https://app.circleci.com/pipelines/github/ministryofjustice/fb-runner/7641/workflows/c1541e71-e992-4d16-9e77-e7334b3cb6f9/jobs/27919