### PR TITLE
CDPTKAN-239: Retire webpacker: Update assets path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 ### Fixed
 
+## [3.4.21] - 2026-08-07
+### Fixed
+-  Change assets path (replacing `media/images/*` with `static/*`) to be used by `shakapacker`
+
 ## [3.4.20] - 2026-07-30
 ### Fixed
 -  Revert changes made in version 3.4.18

--- a/app/views/layouts/metadata_presenter/application.html.erb
+++ b/app/views/layouts/metadata_presenter/application.html.erb
@@ -8,12 +8,12 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="robots" content="noindex">
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_pack_url('media/images/favicon.ico') %>" type="image/x-icon" />
-    <link rel="mask-icon" href="<%= asset_pack_url('media/images/govuk-mask-icon.svg') %>" color="blue">
-    <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-180x180.png') %>">
-    <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-167x167.png') %>">
-    <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-152x152.png') %>">
-    <link rel="apple-touch-icon" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon.png') %>">
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_pack_url('static/favicon.ico') %>" type="image/x-icon" />
+    <link rel="mask-icon" href="<%= asset_pack_url('static/govuk-mask-icon.svg') %>" color="blue">
+    <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_pack_url('static/govuk-apple-touch-icon-180x180.png') %>">
+    <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_pack_url('static/govuk-apple-touch-icon-167x167.png') %>">
+    <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_pack_url('static/govuk-apple-touch-icon-152x152.png') %>">
+    <link rel="apple-touch-icon" href="<%= asset_pack_url('static/govuk-apple-touch-icon.png') %>">
 
     <%= javascript_pack_tag 'runner_application', 'govuk', defer: true %>
     <%= stylesheet_pack_tag 'govuk', 'runner_application', media: 'all' %>

--- a/lib/metadata_presenter/version.rb
+++ b/lib/metadata_presenter/version.rb
@@ -1,3 +1,3 @@
 module MetadataPresenter
-  VERSION = '3.4.20'.freeze
+  VERSION = '3.4.21'.freeze
 end


### PR DESCRIPTION
### Change assets path (replacing `media/images/*` with `static/*`) to support `shakapacker`


Webpacker's manifest plugin categorizes emitted assets by type:
- Images → media/images/...
- Fonts → media/fonts/...

So an image imported through webpack is typically referenced as:
`asset_pack_path("media/images/logo.png")`

whereas shakapacker categorizes emitted assets as
- Images → static/...
- Fonts → static/...

